### PR TITLE
Source code for decorated functions

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -191,7 +191,7 @@ import sys
 from mako.lookup import TemplateLookup
 from mako.exceptions import TopLevelLookupException
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 """
 The current version of pdoc. This value is read from `setup.py`.
 """


### PR DESCRIPTION
These changes fix bug #5, that decorated functions use the decorator code or no code at all. All this does is check for source code of `obj.__wrapped__` before bailing out with the empty list (and updated docstrings). Also did mini-version bump to 0.2.1.
