### PR TITLE
Added viewport <meta> tag for small screens

### DIFF
--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -405,7 +405,8 @@
 
 <!doctype html>
 <head>
-  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 
   % if module_list:
 	  <title>Python module list</title>


### PR DESCRIPTION
Sorry, I left out the crucial viewport <meta> tag for small screen support in the earlier pull request.
