### PR TITLE
support for markdown output

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -353,11 +353,9 @@ def import_module(module_name):
         # contained in `pdoc.import_path`.
         imp.find_module(module_name.split('.')[0], import_path)
 
-    if module_name in sys.modules:
-        return sys.modules[module_name]
-    else:
+    if module_name not in sys.modules:
         __import__(module_name)
-        return sys.modules[module_name]
+    return sys.modules[module_name]
 
 
 def _source(obj):

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -208,6 +208,18 @@ html_package_name = 'index.html'
 The file name to use for a package's `__init__.py` module.
 """
 
+markdown_module_suffix = '.m.md'
+"""
+The suffix to use for module markdown files. By default, this is set to
+`.m.md`, where the extra `.m` is used to differentiate a package's
+`index.md` from a submodule called `index`.
+"""
+
+markdown_package_name = 'index.md'
+"""
+The file name to use for a package's `__init__.py` module.
+"""
+
 import_path = sys.path[:]
 """
 A list of paths to restrict imports to. Any module that cannot be
@@ -289,6 +301,27 @@ def text(module_name, docfilter=None, allsubmodules=False):
                  docfilter=docfilter,
                  allsubmodules=allsubmodules)
     return mod.text()
+
+
+def markdown(module_name, docfilter=None, allsubmodules=False):
+    """
+    Returns the documentation for the module `module_name` in
+    markdown format. The module must be importable.
+
+    `docfilter` is an optional predicate that controls which
+    documentation objects are shown in the output. It is a single
+    argument function that takes a documentation object and returns
+    True of False. If False, that object will not be included in the
+    output.
+
+    If `allsubmodules` is `True`, then every submodule of this module
+    that can be found will be included in the documentation, regardless
+    of whether `__all__` contains it.
+    """
+    mod = Module(import_module(module_name),
+                 docfilter=docfilter,
+                 allsubmodules=allsubmodules)
+    return mod.markdown()
 
 
 def import_module(module_name):
@@ -646,6 +679,14 @@ class Module (Doc):
         Returns the documentation for this module as plain text.
         """
         t = _get_tpl('/text.mako')
+        text, _ = re.subn('\n\n\n+', '\n\n', t.render(module=self).strip())
+        return text
+
+    def markdown(self):
+        """
+        Returns the documentation for this module as plain markdown.
+        """
+        t = _get_tpl('/md.mako')
         text, _ = re.subn('\n\n\n+', '\n\n', t.render(module=self).strip())
         return text
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -208,7 +208,7 @@ html_package_name = 'index.html'
 The file name to use for a package's `__init__.py` module.
 """
 
-markdown_module_suffix = '.m.md'
+markdown_module_suffix = '.md'
 """
 The suffix to use for module markdown files. By default, this is set to
 `.m.md`, where the extra `.m` is used to differentiate a package's

--- a/pdoc/templates/md.mako
+++ b/pdoc/templates/md.mako
@@ -2,6 +2,8 @@
 
 <%!
   import re
+  from os.path import join
+  from pdoc import markdown_module_suffix, markdown_package_name
 
   def docstring(d):
       if len(d.docstring) == 0 and hasattr(d, 'inherits'):
@@ -71,6 +73,20 @@
           strings.append('```')
           codeblock = False
       return '\n'.join(strings)
+
+  def submodule_link(submodule, module):
+      path = submodule.name
+      path = path.replace(module.name, '', 1)
+      path = path.lstrip('.')
+      path = path.split('.')
+      if submodule.is_package():
+          path.append(markdown_package_name)
+      else:
+          e = path[-1]
+          del path[-1]
+          path.append(e + markdown_module_suffix)
+      path = join(*path)
+      return path
 %>
 
 <%def name="function(func)" filter="trim">
@@ -201,7 +217,7 @@ ${class_(c)}
 Sub-modules
 -----------
 % for m in submodules:
-- ${m.name}
+- [${m.name}](${submodule_link(m, module)})
 
 % endfor
 % endif

--- a/pdoc/templates/md.mako
+++ b/pdoc/templates/md.mako
@@ -1,0 +1,178 @@
+## Define mini-templates for each portion of the doco.
+
+<%!
+  import re
+
+  def docstring(d):
+      if len(d.docstring) == 0 and hasattr(d, 'inherits'):
+          return d.inherits.docstring
+      else:
+          return d.docstring
+
+  def nl2br(str):
+      str = str.replace("\r\n\r\n", "\r\n\r\n    ")
+      str.replace("\r\n", "  \r\n")
+      str = str.replace("\n\n", "\n\n    ")
+      str.replace("\n", "  \n")
+      str = str.replace("\r\r", "\r\r    ")
+      str.replace("\r", "  \r")
+      return str
+
+  def h1(str):
+      str = "# " + str
+      return str
+
+  def h2(str):
+      str = "## " + str
+      return str
+
+  def h3(str):
+      str = "### " + str
+      return str
+
+  def h4(str):
+      str = "#### " + str
+      return str
+
+  def h6(str):
+      str = "##### " + str
+      return str
+
+  def h6(str):
+      str = "###### " + str
+      return str
+
+%>
+
+<%def name="function(func)" filter="trim">
+**${func.name}** (${func.spec()})
+
+    ${docstring(func) | nl2br}  
+
+</%def>
+
+<%def name="variable(var)" filter="trim">
+**${var.name}**
+
+    ${docstring(var) | nl2br}  
+
+</%def>
+
+<%def name="class_(cls)" filter="trim">
+${cls.name | h4} \
+% if len(cls.docstring) > 0:
+
+${cls.docstring}  
+
+% endif
+<%
+  class_vars = cls.class_variables()
+  static_methods = cls.functions()
+  inst_vars = cls.instance_variables()
+  methods = cls.methods()
+  mro = cls.module.mro(cls)
+  descendents = cls.module.descendents(cls)
+%>
+% if len(mro) > 0:
+${"Ancestors (in MRO)" | h6}
+% for c in mro:
+- ${c.refname}
+
+% endfor
+% endif
+
+% if len(descendents) > 0:
+${"Descendents" | h6}
+% for c in descendents:
+- ${c.refname}
+
+% endfor
+% endif
+
+% if len(class_vars) > 0:
+${"Class variables" | h6}
+% for v in class_vars:
+- ${capture(variable, v)}
+
+% endfor
+% endif
+
+% if len(static_methods) > 0:
+${"Static methods" | h6}
+% for f in static_methods:
+- ${capture(function, f)}
+
+% endfor
+% endif
+
+% if len(inst_vars) > 0:
+${"Instance variables" | h6}
+% for v in inst_vars:
+- ${capture(variable, v)}
+
+% endfor
+% endif
+
+% if len(methods) > 0:
+${"Methods" | h6}
+% for m in methods:
+- ${capture(function, m)}
+
+% endfor
+% endif
+</%def>
+
+## Start the output logic for an entire module.
+
+<%
+  variables = module.variables()
+  classes = module.classes()
+  functions = module.functions()
+  submodules = module.submodules()
+%>
+
+Module ${module.name}
+-------${'-' * len(module.name)}
+% if not module._filtering:
+${module.docstring}
+% endif
+
+
+% if len(variables) > 0:
+Variables
+---------
+% for v in variables:
+- ${variable(v)}
+
+% endfor
+% endif
+
+
+% if len(functions) > 0:
+Functions
+---------
+% for f in functions:
+- ${function(f)}
+
+% endfor
+% endif
+
+
+% if len(classes) > 0:
+Classes
+-------
+% for c in classes:
+${class_(c)}
+
+% endfor
+% endif
+
+
+% if len(submodules) > 0:
+Sub-modules
+-----------
+% for m in submodules:
+- ${m.name}
+
+% endfor
+% endif

--- a/pdoc/templates/md.mako
+++ b/pdoc/templates/md.mako
@@ -13,11 +13,15 @@
 
   def nl2br(string):
       string = string.replace("\r\n\r\n", "\r\n\r\n    ")
-      string.replace("\r\n", "  \r\n")
+      string = string.replace("\r\n  \r\n", "\r\n  \r\n    ")
+      #string.replace("\r\n", "  \r\n")
       string = string.replace("\n\n", "\n\n    ")
-      string.replace("\n", "  \n")
+      string = string.replace("\n  \n", "\n  \n    ")
+      #string.replace("\n", "  \n")
       string = string.replace("\r\r", "\r\r    ")
-      string.replace("\r", "  \r")
+      string = string.replace("\r  \r", "\r  \r    ")
+      #string.replace("\r", "  \r")
+      string = string.replace("    ```", "```")
       return string
 
   def h1(string):
@@ -36,7 +40,7 @@
       string = "#### " + string
       return string
 
-  def h6(string):
+  def h5(string):
       string = "##### " + string
       return string
 
@@ -46,18 +50,21 @@
 
   def makeup(string):
       strings = string.splitlines()
+      p = re.compile(r':\s*$')
       dd = re.compile(r':')
       li = re.compile(r'^([0-9]+[\.)]|\*|\-\+)')
       snc = re.compile(r'^[A-Z]\w?')
       code = re.compile(r'^(#!|\.{1,3}|>{1,3})')
-      qu = re.compile(r'^`{1,3}')
+      qu = re.compile(r'^`{3}')
       codeblock = False
       for i, s in enumerate(strings):
           s = s.lstrip()
           if snc.search(s) and i != 0:
               strings[i-1] += '  '
-          if dd.search(s):
+          if p.search(s):
               s += '  '
+          elif  dd.search(s):
+              s = '\n* ' + s
           if li.search(s):
               s = '\n' + s
           if qu.search(s):
@@ -119,7 +126,7 @@ ${cls.docstring | makeup}
   descendents = cls.module.descendents(cls)
 %>
 % if len(mro) > 0:
-${"Ancestors (in MRO)" | h6}
+${"Ancestors (in MRO)" | h5}
 % for c in mro:
 - ${c.refname}
 
@@ -127,7 +134,7 @@ ${"Ancestors (in MRO)" | h6}
 % endif
 
 % if len(descendents) > 0:
-${"Descendents" | h6}
+${"Descendents" | h5}
 % for c in descendents:
 - ${c.refname}
 
@@ -135,7 +142,7 @@ ${"Descendents" | h6}
 % endif
 
 % if len(class_vars) > 0:
-${"Class variables" | h6}
+${"Class variables" | h5}
 % for v in class_vars:
 - ${capture(variable, v)}
 
@@ -143,7 +150,7 @@ ${"Class variables" | h6}
 % endif
 
 % if len(static_methods) > 0:
-${"Static methods" | h6}
+${"Static methods" | h5}
 % for f in static_methods:
 - ${capture(function, f)}
 
@@ -151,7 +158,7 @@ ${"Static methods" | h6}
 % endif
 
 % if len(inst_vars) > 0:
-${"Instance variables" | h6}
+${"Instance variables" | h5}
 % for v in inst_vars:
 - ${capture(variable, v)}
 
@@ -159,7 +166,7 @@ ${"Instance variables" | h6}
 % endif
 
 % if len(methods) > 0:
-${"Methods" | h6}
+${"Methods" | h5}
 % for m in methods:
 - ${capture(function, m)}
 
@@ -221,3 +228,4 @@ Sub-modules
 
 % endfor
 % endif
+

--- a/pdoc/templates/md.mako
+++ b/pdoc/templates/md.mako
@@ -9,52 +9,81 @@
       else:
           return d.docstring
 
-  def nl2br(str):
-      str = str.replace("\r\n\r\n", "\r\n\r\n    ")
-      str.replace("\r\n", "  \r\n")
-      str = str.replace("\n\n", "\n\n    ")
-      str.replace("\n", "  \n")
-      str = str.replace("\r\r", "\r\r    ")
-      str.replace("\r", "  \r")
-      return str
+  def nl2br(string):
+      string = string.replace("\r\n\r\n", "\r\n\r\n    ")
+      string.replace("\r\n", "  \r\n")
+      string = string.replace("\n\n", "\n\n    ")
+      string.replace("\n", "  \n")
+      string = string.replace("\r\r", "\r\r    ")
+      string.replace("\r", "  \r")
+      return string
 
-  def h1(str):
-      str = "# " + str
-      return str
+  def h1(string):
+      string = "# " + string
+      return string
 
-  def h2(str):
-      str = "## " + str
-      return str
+  def h2(string):
+      string = "## " + string
+      return string
 
-  def h3(str):
-      str = "### " + str
-      return str
+  def h3(string):
+      string = "### " + string
+      return string
 
-  def h4(str):
-      str = "#### " + str
-      return str
+  def h4(string):
+      string = "#### " + string
+      return string
 
-  def h6(str):
-      str = "##### " + str
-      return str
+  def h6(string):
+      string = "##### " + string
+      return string
 
-  def h6(str):
-      str = "###### " + str
-      return str
+  def h6(string):
+      string = "###### " + string
+      return string
 
+  def makeup(string):
+      strings = string.splitlines()
+      dd = re.compile(r':')
+      li = re.compile(r'^([0-9]+[\.)]|\*|\-\+)')
+      snc = re.compile(r'^[A-Z]\w?')
+      code = re.compile(r'^(#!|\.{1,3}|>{1,3})')
+      qu = re.compile(r'^`{1,3}')
+      codeblock = False
+      for i, s in enumerate(strings):
+          s = s.lstrip()
+          if snc.search(s) and i != 0:
+              strings[i-1] += '  '
+          if dd.search(s):
+              s += '  '
+          if li.search(s):
+              s = '\n' + s
+          if qu.search(s):
+              codeblock = not codeblock
+          if code.search(s) and not codeblock:
+              s = '```\n' + s
+              codeblock = True
+          if s == '' and codeblock:
+              s = '```'
+              codeblock = False
+          strings[i] = s
+      if codeblock:
+          strings.append('```')
+          codeblock = False
+      return '\n'.join(strings)
 %>
 
 <%def name="function(func)" filter="trim">
 **${func.name}** (${func.spec()})
 
-    ${docstring(func) | nl2br}  
+    ${docstring(func) | makeup,nl2br}
 
 </%def>
 
 <%def name="variable(var)" filter="trim">
 **${var.name}**
 
-    ${docstring(var) | nl2br}  
+    ${docstring(var) | makeup,nl2br}
 
 </%def>
 
@@ -62,7 +91,7 @@
 ${cls.name | h4} \
 % if len(cls.docstring) > 0:
 
-${cls.docstring}  
+${cls.docstring | makeup}
 
 % endif
 <%
@@ -133,9 +162,9 @@ ${"Methods" | h6}
 
 Module ${module.name}
 -------${'-' * len(module.name)}
-% if not module._filtering:
-${module.docstring}
-% endif
+
+${module.docstring | makeup}
+
 
 
 % if len(variables) > 0:

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -40,8 +40,8 @@ aa('--markdown', action='store_true',
    help='When set, the output will be markdown formatted.')
 aa('--html', action='store_true',
    help='When set, the output will be HTML formatted.')
-aa('--html-dir', type=str, default='.',
-   help='The directory to output HTML files to. This option is ignored when '
+aa('--output-dir', type=str, default='.',
+   help='The directory to output HTML or markdown files to. This option is ignored when '
         'outputting documentation as plain text.')
 aa('--html-no-source', action='store_true',
    help='When set, source code will not be viewable in the generated HTML. '
@@ -202,14 +202,14 @@ class WebDoc (BaseHTTPRequestHandler):
 
     def resolve_ext(self, import_path):
         def exists(p):
-            p = path.join(args.html_dir, p)
+            p = path.join(args.output_dir, p)
             pkg = path.join(p, pdoc.html_package_name)
             mod = p + pdoc.html_module_suffix
 
             if path.isfile(pkg):
-                return pkg[len(args.html_dir):]
+                return pkg[len(args.output_dir):]
             elif path.isfile(mod):
-                return mod[len(args.html_dir):]
+                return mod[len(args.output_dir):]
             return None
 
         parts = import_path.split('.')
@@ -222,7 +222,7 @@ class WebDoc (BaseHTTPRequestHandler):
 
     @property
     def file_path(self):
-        fp = path.join(args.html_dir, *self.import_path.split('.'))
+        fp = path.join(args.output_dir, *self.import_path.split('.'))
         pkgp = path.join(fp, pdoc.html_package_name)
         if path.isdir(fp) and path.isfile(pkgp):
             fp = pkgp
@@ -296,7 +296,7 @@ def last_modified(fp):
 
 
 def module_file_html(m):
-    mbase = path.join(args.html_dir, *m.name.split('.'))
+    mbase = path.join(args.output_dir, *m.name.split('.'))
     if m.is_package():
         return path.join(mbase, pdoc.html_package_name)
     else:
@@ -304,7 +304,7 @@ def module_file_html(m):
 
 
 def module_file_md(m):
-    mbase = path.join(args.html_dir, *m.name.split('.'))
+    mbase = path.join(args.output_dir, *m.name.split('.'))
     if m.is_package():
         return path.join(mbase, pdoc.markdown_package_name)
     else:
@@ -379,7 +379,7 @@ def process_html_out(impath):
     cmd = [sys.executable,
            path.realpath(__file__),
            '--html',
-           '--html-dir', args.html_dir,
+           '--output-dir', args.output_dir,
            '--http-html',
            '--overwrite',
            '--link-prefix', args.link_prefix]
@@ -426,7 +426,7 @@ if __name__ == '__main__':
     if args.http:
         args.html = True
         args.external_links = True
-        args.html_dir = args.http_dir
+        args.output_dir = args.http_dir
         args.overwrite = True
         args.link_prefix = '/'
 
@@ -516,7 +516,7 @@ if __name__ == '__main__':
 
     # HTML output depends on whether the module being documented is a package
     # or not. If not, then output is written to {MODULE_NAME}.html in
-    # `html-dir`. If it is a package, then a directory called {MODULE_NAME}
+    # `output-dir`. If it is a package, then a directory called {MODULE_NAME}
     # is created, and output is written to {MODULE_NAME}/index.html.
     # Submodules are written to {MODULE_NAME}/{MODULE_NAME}.m.html and
     # subpackages are written to {MODULE_NAME}/{MODULE_NAME}/index.html. And

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -26,7 +26,7 @@ parser = argparse.ArgumentParser(
     description='Automatically generate API docs for Python modules.',
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 aa = parser.add_argument
-aa('module_name', type=str, nargs='?',
+aa('module_names', type=str, nargs='*', default=[],
    help='The Python module name. This may be an import path resolvable in '
         'the current environment, or a file path to a Python module or '
         'package.')
@@ -77,6 +77,12 @@ aa('--http-port', type=int, default=8080,
    help='The port on which to run the HTTP server.')
 aa('--http-html', action='store_true',
    help='Internal use only. Do not set.')
+aa('--walk-path', action='store_true',
+   help='Generate the docs for modules in a directory tree by walking the'
+        'tree either top-down or bottom-up')
+aa('--walk-path-followlinks', action='store_true',
+   help='Set followlinks to True to visit directories pointed to by symlinks,'
+        'on systems that support them.')
 args = parser.parse_args()
 
 
@@ -318,9 +324,6 @@ def quit_if_exists(m):
             _eprint('%s already exists. Delete it or run with --overwrite' % f)
             sys.exit(1)
 
-    if args.overwrite:
-        return
-
     for f in (module_file_html(m), module_file_md(m)):
         check_file(f)
 
@@ -406,6 +409,25 @@ def process_html_out(impath):
         print(out)
 
 
+def walk_modules(path, followlinks=False):
+    names = []
+    for p in path:
+        if os.path.isfile(p):
+            names.append(os.path.basename(p))
+            continue
+        for root, dirs, files in os.walk(p, followlinks):
+            for f in files:
+                if f == '__init__.py':
+                    names.append(root)
+                elif len(f) > 3 and f[-3:] == '.py':
+                    names.append(os.path.join(root, f))
+                else:
+                    with open(os.path.join(root, f)) as fi:
+                        if 'python' in fi.readline():
+                            names.append(os.path.join(root, f))
+    return names
+
+
 if __name__ == '__main__':
     if args.version:
         print(pdoc.__version__)
@@ -418,17 +440,12 @@ if __name__ == '__main__':
     except:
         pass
 
-    if not args.http and args.module_name is None:
+    if not args.http and not args.module_names:
         _eprint('No module name specified.')
         sys.exit(1)
+
     if args.template_dir is not None:
         pdoc.tpl_lookup.directories.insert(0, args.template_dir)
-    if args.http:
-        args.html = True
-        args.external_links = True
-        args.output_dir = args.http_dir
-        args.overwrite = True
-        args.link_prefix = '/'
 
     # If PYTHONPATH is set, let it override everything if we want it to.
     pypath = os.getenv('PYTHONPATH')
@@ -436,7 +453,13 @@ if __name__ == '__main__':
         pdoc.import_path = pypath.split(path.pathsep)
 
     if args.http:
-        if args.module_name is not None:
+        args.html = True
+        args.external_links = True
+        args.output_dir = args.http_dir
+        args.overwrite = True
+        args.link_prefix = '/'
+
+        if args.module_names:
             _eprint('Module names cannot be given with --http set.')
             sys.exit(1)
 
@@ -465,64 +488,71 @@ if __name__ == '__main__':
     # import paths over files. If a file is really necessary, then
     # specify the absolute path, which is guaranteed not to be a
     # Python import path.
-    try:
-        module = pdoc.import_module(args.module_name)
-    except Exception as e:
-        module = None
-
-    # Get the module that we're documenting. Accommodate for import paths,
-    # files and directories.
-    if module is None:
-        isdir = path.isdir(args.module_name)
-        isfile = path.isfile(args.module_name)
-        if isdir or isfile:
-            fp = path.realpath(args.module_name)
-            module_name = path.basename(fp)
-            if isdir:
-                fp = path.join(fp, '__init__.py')
-            else:
-                module_name, _ = path.splitext(module_name)
-
-            # Use a special module name to avoid import conflicts.
-            # It is hidden from view via the `Module` class.
-            with open(fp) as f:
-                module = imp.load_source('__pdoc_file_module__', fp, f)
-                if isdir:
-                    module.__path__ = [path.realpath(args.module_name)]
-                module.__pdoc_module_name = module_name
-        else:
-            module = pdoc.import_module(args.module_name)
-    module = pdoc.Module(module, docfilter=docfilter,
-                         allsubmodules=args.all_submodules)
-
-    # Plain text?
-    if not args.html and not args.markdown:
-        output = module.text()
+    modules = []
+    if args.walk_path:
+        args.module_names = walk_modules(args.module_names,
+                                         args.walk_path_followlinks)
+    for module_name in args.module_names:
         try:
-            print(output)
-        except IOError as e:
-            # This seems to happen for long documentation.
-            # This is obviously a hack. What's the real cause? Dunno.
-            if e.errno == 32:
-                pass
+            module = pdoc.import_module(module_name)
+        except Exception as e:
+            # Get the module that we're documenting. Accommodate for import paths,
+            # files and directories.
+            isdir = path.isdir(module_name)
+            isfile = path.isfile(module_name)
+            if isdir or isfile:
+                fp = path.realpath(module_name)
+                module_name = path.basename(fp)
+                if isdir:
+                    fp = path.join(fp, '__init__.py')
+                else:
+                    module_name, _ = path.splitext(module_name)
+
+                # Use a special module name to avoid import conflicts.
+                # It is hidden from view via the `Module` class.
+                with open(fp) as f:
+                    module = imp.load_source('__pdoc_file_module__', fp, f)
+                    if isdir:
+                        module.__path__ = [path.realpath(module_name)]
+                    module.__pdoc_module_name = module_name
             else:
-                raise e
-        sys.exit(0)
+                module = pdoc.import_module(module_name)
+        modules.append(
+            pdoc.Module(
+                module, docfilter=docfilter,
+                allsubmodules=args.all_submodules
+                )
+            )
 
-    if args.markdown:
-        quit_if_exists(module)
-        markdown_out(module)
-        sys.exit(0)
 
-    # HTML output depends on whether the module being documented is a package
-    # or not. If not, then output is written to {MODULE_NAME}.html in
-    # `output-dir`. If it is a package, then a directory called {MODULE_NAME}
-    # is created, and output is written to {MODULE_NAME}/index.html.
-    # Submodules are written to {MODULE_NAME}/{MODULE_NAME}.m.html and
-    # subpackages are written to {MODULE_NAME}/{MODULE_NAME}/index.html. And
-    # so on... The same rules apply for `http_dir` when `pdoc` is run as an
-    # HTTP server.
-    if not args.http:
-        quit_if_exists(module)
-        html_out(module)
-        sys.exit(0)
+    for module in modules:
+        # Plain text?
+        if not args.html and not args.markdown:
+            output = module.text()
+            try:
+                print(output)
+            except IOError as e:
+                # This seems to happen for long documentation.
+                # This is obviously a hack. What's the real cause? Dunno.
+                if e.errno == 32:
+                    pass
+                else:
+                    raise e
+
+        elif args.markdown:
+            if not args.overwrite:
+                quit_if_exists(module)
+            markdown_out(module)
+
+        # HTML output depends on whether the module being documented is a package
+        # or not. If not, then output is written to {MODULE_NAME}.html in
+        # `output-dir`. If it is a package, then a directory called {MODULE_NAME}
+        # is created, and output is written to {MODULE_NAME}/index.html.
+        # Submodules are written to {MODULE_NAME}/{MODULE_NAME}.m.html and
+        # subpackages are written to {MODULE_NAME}/{MODULE_NAME}/index.html. And
+        # so on... The same rules apply for `http_dir` when `pdoc` is run as an
+        # HTTP server.
+        else:
+            if not args.overwrite:
+                quit_if_exists(module)
+            html_out(module)

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -519,7 +519,11 @@ if __name__ == '__main__':
                 # Use a special module name to avoid import conflicts.
                 # It is hidden from view via the `Module` class.
                 with open(fp) as f:
-                    module = imp.load_source('__pdoc_file_module__', fp, f)
+                    try:
+                        module = imp.load_source('__pdoc_file_module__', fp, f)
+                    except ImportError as e:
+                        print("Can not import module %s" % module_name)
+                        print(e)
                     if isdir:
                         module.__path__ = [path.realpath(module_name)]
                     module.__pdoc_module_name = module_name

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -461,12 +461,17 @@ def create_mkdocs_yaml(docs_dir):
         config = {'site_name': 'My Docs', 'docs_dir': '', 'pages': []}
 
     filenames = []
+    pname = pdoc.markdown_package_name
+    mname = pdoc.markdown_module_suffix
     for root, dirs, files in os.walk(docs_dir):
         for f in files:
-            path = os.path.join(root, f)
-            path = path.replace(docs_dir, '', 1)
-            path = path.lstrip(os.sep)
-            filenames.append(path)
+            for s in [pname, mname, '.md', '.markdown']:
+                if f[-len(s):] == s:
+                    path = os.path.join(root, f)
+                    path = path.replace(docs_dir, '', 1)
+                    path = path.lstrip(os.sep)
+                    filenames.append(path)
+                    break
 
     config['docs_dir'] = docs_dir
 
@@ -485,11 +490,11 @@ def create_mkdocs_yaml(docs_dir):
             f = f.replace(c, ' ')
         if f == 'index.md':
             path = ['Home']
-        elif os.path.basename(f) == pdoc.markdown_package_name:
+        elif os.path.basename(f) == pname:
             path = f.split(os.sep)
             del path[-1]
         else:
-            f = f.replace(pdoc.markdown_module_suffix, '')
+            f = f.replace(mname, '')
             path = f.split(os.sep)
         if len(path) > 2:
             f, l = path[0], path[-1]

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -502,12 +502,21 @@ if __name__ == '__main__':
                                          args.walk_path_followlinks)
     for module_name in args.module_names:
         try:
-            module = pdoc.import_module(module_name)
+            isdir = path.isdir(module_name)
+            isfile = path.isfile(module_name)
+            if isdir:
+                sys.path.insert(1, os.path.join(module_name, os.pardir))
+                name = os.path.basename(module_name.rstrip('/\\'))
+            elif isfile and os.path.basename(module_name) == '__init__.py':
+                name = os.path.dirname(module_name)
+                sys.path.insert(1, os.path.join(name, os.pardir))
+                name = os.path.basename(name)
+            else:
+                name = module_name
+            module = pdoc.import_module(name)
         except Exception as e:
             # Get the module that we're documenting.
             # Accommodate for import paths, files and directories.
-            isdir = path.isdir(module_name)
-            isfile = path.isfile(module_name)
             if isdir or isfile:
                 fp = path.realpath(module_name)
                 module_name = path.basename(fp)

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -36,6 +36,8 @@ aa('ident_name', type=str, nargs='?',
         'Has no effect when --http is set.')
 aa('--version', action='store_true',
    help='Print the version of pdoc and exit.')
+aa('--markdown', action='store_true',
+   help='When set, the output will be markdown formatted.')
 aa('--html', action='store_true',
    help='When set, the output will be HTML formatted.')
 aa('--html-dir', type=str, default='.',
@@ -293,12 +295,21 @@ def last_modified(fp):
         return datetime.datetime.min
 
 
-def module_file(m):
+def module_file_html(m):
     mbase = path.join(args.html_dir, *m.name.split('.'))
     if m.is_package():
         return path.join(mbase, pdoc.html_package_name)
     else:
         return '%s%s' % (mbase, pdoc.html_module_suffix)
+
+
+def module_file_md(m):
+    mbase = path.join(args.html_dir, *m.name.split('.'))
+    if m.is_package():
+        return path.join(mbase, pdoc.markdown_package_name)
+    else:
+        return '%s%s' % (mbase, pdoc.markdown_module_suffix)
+
 
 
 def quit_if_exists(m):
@@ -309,17 +320,18 @@ def quit_if_exists(m):
 
     if args.overwrite:
         return
-    f = module_file(m)
-    check_file(f)
 
-    # If this is a package, make sure the package directory doesn't exist
-    # either.
-    if m.is_package():
-        check_file(path.dirname(f))
+    for f in (module_file_html(m), module_file_md(m)):
+        check_file(f)
+
+        # If this is a package, make sure the package directory doesn't exist
+        # either.
+        if m.is_package():
+            check_file(path.dirname(f))
 
 
 def html_out(m):
-    f = module_file(m)
+    f = module_file_html(m)
     dirpath = path.dirname(f)
     if not os.access(dirpath, os.R_OK):
         os.makedirs(dirpath)
@@ -338,6 +350,25 @@ def html_out(m):
         raise e
     for submodule in m.submodules():
         html_out(submodule)
+
+
+def markdown_out(m):
+    f = module_file_md(m)
+    dirpath = path.dirname(f)
+    if not os.access(dirpath, os.R_OK):
+        os.makedirs(dirpath)
+    try:
+        with codecs.open(f, 'w+', 'utf-8') as w:
+            out = m.markdown()
+            print(out, file=w)
+    except Exception as e:
+        try:
+            os.unlink(f)
+        except:
+            pass
+        raise e
+    for submodule in m.submodules():
+        markdown_out(submodule)
 
 
 def process_html_out(impath):
@@ -465,7 +496,7 @@ if __name__ == '__main__':
                          allsubmodules=args.all_submodules)
 
     # Plain text?
-    if not args.html:
+    if not args.html and not args.markdown:
         output = module.text()
         try:
             print(output)
@@ -476,6 +507,11 @@ if __name__ == '__main__':
                 pass
             else:
                 raise e
+        sys.exit(0)
+
+    if args.markdown:
+        quit_if_exists(module)
+        markdown_out(module)
         sys.exit(0)
 
     # HTML output depends on whether the module being documented is a package

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -1,22 +1,25 @@
 #!/usr/bin/env python2
 
 from __future__ import absolute_import, division, print_function
+
+import os
+import re
+import sys
+import imp
+import yaml
+import codecs
+import pkgutil
 import argparse
+import datetime
+import tempfile
+import subprocess
+import os.path as path
+from operator import itemgetter
+
 try:
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 except ImportError:
     from http.server import BaseHTTPRequestHandler, HTTPServer
-import codecs
-import datetime
-import imp
-import os
-import os.path as path
-import pkgutil
-import re
-import subprocess
-import sys
-import tempfile
-import yaml
 
 import pdoc
 
@@ -504,6 +507,16 @@ def create_mkdocs_yaml(docs_dir):
         for p in path:
             page.append("\"%s\"" % p)
         config['pages'].append(page)
+
+    # sorting
+    home = ['index.md', 'Home']
+    if home in config['pages']:
+        config['pages'].remove(home)
+    else:
+        home = None
+    config['pages'] = sorted(config['pages'], key=itemgetter(1))
+    if home:
+        config['pages'].insert(0, home)
 
     for k in config:
         if type(config[k]) is str:

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -41,8 +41,8 @@ aa('--markdown', action='store_true',
 aa('--html', action='store_true',
    help='When set, the output will be HTML formatted.')
 aa('--output-dir', type=str, default='.',
-   help='The directory to output HTML or markdown files to. This option is ignored when '
-        'outputting documentation as plain text.')
+   help='The directory to output HTML or markdown files to.'
+        'This option is ignored when outputting documentation as plain text.')
 aa('--html-no-source', action='store_true',
    help='When set, source code will not be viewable in the generated HTML. '
         'This can speed up the time required to document large modules.')
@@ -317,7 +317,6 @@ def module_file_md(m):
         return '%s%s' % (mbase, pdoc.markdown_module_suffix)
 
 
-
 def quit_if_exists(m):
     def check_file(f):
         if os.access(f, os.R_OK):
@@ -496,8 +495,8 @@ if __name__ == '__main__':
         try:
             module = pdoc.import_module(module_name)
         except Exception as e:
-            # Get the module that we're documenting. Accommodate for import paths,
-            # files and directories.
+            # Get the module that we're documenting.
+            # Accommodate for import paths, files and directories.
             isdir = path.isdir(module_name)
             isfile = path.isfile(module_name)
             if isdir or isfile:
@@ -523,7 +522,6 @@ if __name__ == '__main__':
                 allsubmodules=args.all_submodules
                 )
             )
-
 
     for module in modules:
         # Plain text?

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -416,14 +416,23 @@ def walk_modules(path, followlinks=False):
             continue
         for root, dirs, files in os.walk(p, followlinks):
             for f in files:
+                filepath = os.path.join(root, f)
+                if os.path.islink(filepath):
+                    if followlinks:
+                        filepath = os.readlink(filepath)
+                    else:
+                        continue
                 if f == '__init__.py':
                     names.append(root)
                 elif len(f) > 3 and f[-3:] == '.py':
-                    names.append(os.path.join(root, f))
-                else:
-                    with open(os.path.join(root, f)) as fi:
-                        if 'python' in fi.readline():
-                            names.append(os.path.join(root, f))
+                    names.append(filepath)
+                elif '.' not in f:
+                    try:
+                        with open(filepath) as fi:
+                            if 'python' in fi.readline():
+                                names.append(filepath)
+                    except IOError as e:
+                        print(e)
     return names
 
 

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -410,29 +410,39 @@ def process_html_out(impath):
 
 def walk_modules(path, followlinks=False):
     names = []
+
+    def walk(root, names, followlinks):
+        dir_items = os.listdir(root)
+        if '__init__.py' in dir_items:
+            names.append(root)
+            return None
+        for item in dir_items:
+            item = os.path.join(root, item)
+            if os.path.islink(item):
+                if followlinks:
+                    item = os.readlink(item)
+                    if len(item) > 0 and item[0] == '.':
+                        item = os.path.join(root, item.lstrip('.'))
+                else:
+                    continue
+            if os.path.isdir(item):
+                walk(item, names, followlinks)
+            elif os.path.isfile(item):
+                if len(item) > 3 and item[-3:] == '.py':
+                    names.append(item)
+                elif '.' not in item:
+                    try:
+                        with open(item) as fi:
+                            if 'python' in fi.readline():
+                                names.append(item)
+                    except IOError as e:
+                        print(e)
+
     for p in path:
         if os.path.isfile(p):
             names.append(os.path.basename(p))
             continue
-        for root, dirs, files in os.walk(p, followlinks):
-            for f in files:
-                filepath = os.path.join(root, f)
-                if os.path.islink(filepath):
-                    if followlinks:
-                        filepath = os.readlink(filepath)
-                    else:
-                        continue
-                if f == '__init__.py':
-                    names.append(root)
-                elif len(f) > 3 and f[-3:] == '.py':
-                    names.append(filepath)
-                elif '.' not in f:
-                    try:
-                        with open(filepath) as fi:
-                            if 'python' in fi.readline():
-                                names.append(filepath)
-                    except IOError as e:
-                        print(e)
+        walk(p, names, followlinks)
     return names
 
 

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -483,13 +483,13 @@ def create_mkdocs_yaml(docs_dir):
         page = ["\"%s\"" % f]
         for c in ('-', '_'):
             f = f.replace(c, ' ')
-        f = f.replace(pdoc.markdown_module_suffix, '')
         if f == 'index.md':
             path = ['Home']
-        elif os.path.basename(f) == 'index.md':
+        elif os.path.basename(f) == pdoc.markdown_package_name:
             path = f.split(os.sep)
             del path[-1]
         else:
+            f = f.replace(pdoc.markdown_module_suffix, '')
             path = f.split(os.sep)
         if len(path) > 2:
             f, l = path[0], path[-1]

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -491,6 +491,11 @@ def create_mkdocs_yaml(docs_dir):
             del path[-1]
         else:
             path = f.split(os.sep)
+        if len(path) > 2:
+            f, l = path[0], path[-1]
+            path = []
+            path.append(f)
+            path.append(l)
         for p in path:
             page.append("\"%s\"" % p)
         config['pages'].append(page)

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -40,7 +40,7 @@ aa('--markdown', action='store_true',
    help='When set, the output will be markdown formatted.')
 aa('--html', action='store_true',
    help='When set, the output will be HTML formatted.')
-aa('--output-dir', type=str, default='.',
+aa('--output-dir', '--html-dir', type=str, default='.', dest='output_dir',
    help='The directory to output HTML or markdown files to.'
         'This option is ignored when outputting documentation as plain text.')
 aa('--html-no-source', action='store_true',

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -16,8 +16,10 @@ import re
 import subprocess
 import sys
 import tempfile
+import yaml
 
 import pdoc
+
 
 version_suffix = '%d.%d' % (sys.version_info[0], sys.version_info[1])
 default_http_dir = path.join(tempfile.gettempdir(), 'pdoc-%s' % version_suffix)
@@ -43,6 +45,9 @@ aa('--html', action='store_true',
 aa('--output-dir', '--html-dir', type=str, default='.', dest='output_dir',
    help='The directory to output HTML or markdown files to.'
         'This option is ignored when outputting documentation as plain text.')
+aa('--mkdocs-config', action='store_true', dest='mkdocs',
+   help='Create mkdocs yaml.'
+        'Requared output-dir option.')
 aa('--html-no-source', action='store_true',
    help='When set, source code will not be viewable in the generated HTML. '
         'This can speed up the time required to document large modules.')
@@ -446,6 +451,60 @@ def walk_modules(path, followlinks=False):
     return names
 
 
+def create_mkdocs_yaml(docs_dir):
+    config_path = os.path.join(*(docs_dir, os.pardir, 'mkdocs.yml'))
+
+    try:
+        with open(config_path) as f:
+            config = dict(yaml.load(f.read()))
+    except IOError:
+        config = {'site_name': 'My Docs', 'docs_dir': '', 'pages': []}
+
+    filenames = []
+    for root, dirs, files in os.walk(docs_dir):
+        for f in files:
+            path = os.path.join(root, f)
+            path = path.replace(docs_dir, '', 1)
+            path = path.lstrip(os.sep)
+            filenames.append(path)
+
+    config['docs_dir'] = docs_dir
+
+    if 'pages' not in config:
+        config['pages'] = []
+    else:
+        for p in config['pages']:
+            try:
+                filenames.remove(p[0])
+            except ValueError:
+                config['pages'].remove(p)
+
+    for f in filenames:
+        page = ["\"%s\"" % f]
+        for c in ('-', '_'):
+            f = f.replace(c, ' ')
+        f = f.replace(pdoc.markdown_module_suffix, '')
+        if f == 'index.md':
+            path = ['Home']
+        elif os.path.basename(f) == 'index.md':
+            path = f.split(os.sep)
+            del path[-1]
+        else:
+            path = f.split(os.sep)
+        for p in path:
+            page.append("\"%s\"" % p)
+        config['pages'].append(page)
+
+    for k in config:
+        if type(config[k]) is str:
+            config[k] = "\"%s\"" % config[k]
+
+    config = yaml.dump(config).replace('"', '')
+
+    with open(config_path, 'w') as f:
+        f.write(config)
+
+
 if __name__ == '__main__':
     if args.version:
         print(pdoc.__version__)
@@ -458,7 +517,8 @@ if __name__ == '__main__':
     except:
         pass
 
-    if not args.http and not args.module_names:
+    if not args.http and not args.module_names \
+        and not (args.mkdocs and args.output_dir):
         _eprint('No module name specified.')
         sys.exit(1)
 
@@ -582,7 +642,12 @@ if __name__ == '__main__':
         # subpackages are written to {MODULE_NAME}/{MODULE_NAME}/index.html. And
         # so on... The same rules apply for `http_dir` when `pdoc` is run as an
         # HTTP server.
-        else:
+        elif args.html:
             if not args.overwrite:
                 quit_if_exists(module)
             html_out(module)
+
+    if args.mkdocs and not args.output_dir:
+        _eprint('mkdocs-config option requared output-dir option.')
+    elif args.mkdocs and args.output_dir:
+        create_mkdocs_yaml(args.output_dir)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
                ],
     scripts=['scripts/pdoc'],
     provides=['pdoc'],
-    requires=['argparse', 'mako', 'markdown'],
+    requires=['argparse', 'mako', 'markdown', 'PyYAML'],
     install_requires=install_requires,
     extras_require={'syntax_highlighting': ['pygments']},
 )


### PR DESCRIPTION
Goals: add markdown as output format because readthedocs has support only for rst and md formats right now. 
- add cli options: --markdown, --walk-path, --walk-path-followlinks
- change cli option --html-dir to --output-dir
- add md.mako template based on text.mako
- you can now specify many modules per one executing
- walk-path option allows recursively find all modules in path via **init**.py file, '.py' extension and even via 'python' word in the shebang
