### PR TITLE
Documentation aware of decorators and annotations

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1096,6 +1096,9 @@ class Function (Doc):
         """
         params_spec = ', '.join(self.params())
         result_spec = self.result()
+        # TODO: it actually makes the return annotation, be displayed
+        # at the end of the arguments list, inside the parenthesis. This
+        # should be fixed.
         return (
             params_spec
             if result_spec is None
@@ -1113,8 +1116,14 @@ class Function (Doc):
             # I guess this is for C builtin functions?
             return None
         annotations = s.annotations if hasattr(s, 'annotations') else {}
-        ann = annotations['return'] if 'return' in annotations else None
-        return self.ann_clean(ann) if ann is not None else None
+        # Don't check for `annotations['return']` being `None` as the
+        # return annotation may be explicitly the `None` expression; so check
+        # for the existence of an entry, explicitly too.
+        if 'return' in annotations:
+            ann = annotations['return']
+            return self.ann_clean(ann)
+        else:
+            return None
 
     def params(self):
         """

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1076,6 +1076,18 @@ class Function (Doc):
         else:
             return '%s.%s' % (self.cls.refname, self.name)
 
+    def ann_clean(self, ann):
+        """
+        Returns a clean representation of an annotation. Actually
+        it makes all `<class 'xyz'>` appears as `xyz`.
+        """
+        # TODO: check if it's enough for most of typical annotation's
+        # expressions.
+        text = repr(ann)
+        text = text.replace("<class '", "")
+        text = text.replace("'>", "")
+        return text
+
     def spec(self):
         """
         Returns a nicely formatted spec of the function's parameter
@@ -1102,7 +1114,7 @@ class Function (Doc):
             return None
         annotations = s.annotations if hasattr(s, 'annotations') else {}
         ann = annotations['return'] if 'return' in annotations else None
-        return repr(ann) if ann is not None else None
+        return self.ann_clean(ann) if ann is not None else None
 
     def params(self):
         """
@@ -1133,7 +1145,7 @@ class Function (Doc):
                 if ann is None:
                     text = '%s=%s' % (param, default_repr)
                 else:
-                    ann_repr = repr(ann)
+                    ann_repr = self.ann_clean(ann)
                     text = '%s: %s=%s' % (param, ann_repr, default_repr)
                 params.append(text)
             else:
@@ -1141,7 +1153,7 @@ class Function (Doc):
                 if ann is None:
                     text = param_repr
                 else:
-                    ann_repr = repr(ann)
+                    ann_repr = self.ann_clean(ann)
                     text = '%s: %s' % (param_repr, ann_repr)
                 params.append(text)
         if s.varargs is not None:

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1083,9 +1083,11 @@ class Function (Doc):
         """
         # TODO: check if it's enough for most of typical annotation's
         # expressions.
+        module_prefix = '%s.' % self.func.__module__
         text = repr(ann)
-        text = text.replace("<class '", "")
+        text = text.replace("<class '", '')
         text = text.replace("'>", "")
+        text = text.replace(module_prefix, '')
         return text
 
     def spec(self):

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1096,13 +1096,10 @@ class Function (Doc):
         """
         params_spec = ', '.join(self.params())
         result_spec = self.result()
-        # TODO: it actually makes the return annotation, be displayed
-        # at the end of the arguments list, inside the parenthesis. This
-        # should be fixed.
         return (
-            params_spec
+            '(%s)' % params_spec
             if result_spec is None
-            else '%s -> %s' % (params_spec, result_spec))
+            else '(%s) -> %s' % (params_spec, result_spec))
 
     def result(self):
         """

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1049,7 +1049,7 @@ class Function (Doc):
         """
         super(Function, self).__init__(name, module, inspect.getdoc(func_obj))
 
-        self.func = func_obj
+        self.func = inspect.unwrap(func_obj)
         """The Python function object."""
 
         self.cls = cls

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -233,7 +233,7 @@
   <%def name="show_func(f)">
   <div class="item">
     <div class="name def" id="${f.refname}">
-    <p>def ${ident(f.name)}(</p><p>${f.spec() | h})</p>
+    <p>def ${ident(f.name)}</p><p>${f.spec() | h}</p>
     </div>
     ${show_inheritance(f)}
     ${show_desc(f)}


### PR DESCRIPTION
Using [inspect.unwrap](https://docs.python.org/3/library/inspect.html#inspect.unwrap), to document decorated functions, rather than the decorator's inner wrapper function, which is needed as `Function.params` uses [inspect.getfullargspec](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec), which unfortunately does not follow the `__wrapped__` attribute.
