### PR TITLE
Adding a local modules list

### DIFF
--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -28,6 +28,9 @@
     font-size: 130%;
     margin: 0 0 15px 0;
   }
+  #nav > * + * {
+    margin-left: 1em;
+  }
 
   #top {
     display: block;

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -196,7 +196,7 @@
 <%def name="show_module_list(modules)">
 <p id="nav">
   <span><a href="/local">Local packages</a></span>
-  <span><a href="/all">All packages</a></span>
+  <span><a href="/">All packages</a></span>
 </p>
 <h1>Python module list</h1>
 
@@ -482,3 +482,4 @@
 </div>
 </body>
 </html>
+Show source 

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -194,6 +194,10 @@
 </%def>
 
 <%def name="show_module_list(modules)">
+<p id="nav">
+  <span><a href="/local">Local packages</a></span>
+  <span><a href="/all">All packages</a></span>
+</p>
 <h1>Python module list</h1>
 
 % if len(modules) == 0:
@@ -242,11 +246,12 @@
 
   % if 'http_server' in context.keys() and http_server:
     <p id="nav">
-      <a href="/">All packages</a>
+      <span><a href="/local">Local packages</a></span>
+      <span><a href="/">All packages</a></span>
       <% parts = module.name.split('.')[:-1] %>
       % for i, m in enumerate(parts):
         <% parent = '.'.join(parts[:i+1]) %>
-        :: <a href="/${parent.replace('.', '/')}">${parent}</a>
+        <span>::&nbsp;<a href="/${parent.replace('.', '/')}">${parent}</a></span>
       % endfor
     </p>
   % endif

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -195,7 +195,7 @@
 
 <%def name="show_module_list(modules)">
 <p id="nav">
-  <span><a href="/local">Local packages</a></span>
+  <span><a href="/local-packages">Local packages</a></span>
   <span><a href="/">All packages</a></span>
 </p>
 <h1>Python module list</h1>
@@ -246,7 +246,7 @@
 
   % if 'http_server' in context.keys() and http_server:
     <p id="nav">
-      <span><a href="/local">Local packages</a></span>
+      <span><a href="/local-packages">Local packages</a></span>
       <span><a href="/">All packages</a></span>
       <% parts = module.name.split('.')[:-1] %>
       % for i, m in enumerate(parts):

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -78,9 +78,8 @@ aa('--http-html', action='store_true',
 args = parser.parse_args()
 
 
-class WebDoc (BaseHTTPRequestHandler):
     def do_HEAD(self):
-        if self.path not in {'/', '/local'}:
+        if self.path not in {'/', '/local-packages'}:
             out = self.html()
             if out is None:
                 self.send_response(404)
@@ -92,8 +91,8 @@ class WebDoc (BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self):
-        if self.path in {'/', '/local'}:
-            is_local = self.path == '/local'
+        if self.path in {'/', '/local-packages'}:
+            is_local = self.path == '/local-packages'
             is_all = not is_local
             cwd = os.getcwd()
             cwd_slash = os.path.join(cwd, '')

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -80,7 +80,7 @@ args = parser.parse_args()
 
 class WebDoc (BaseHTTPRequestHandler):
     def do_HEAD(self):
-        if self.path != '/':
+        if self.path not in {'/', '/local'}:
             out = self.html()
             if out is None:
                 self.send_response(404)
@@ -92,11 +92,19 @@ class WebDoc (BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self):
-        if self.path == '/':
+        if self.path in {'/', '/local'}:
+            is_local = self.path == '/local'
+            is_all = not is_local
+            cwd = os.getcwd()
+            cwd_slash = os.path.join(cwd, '')
             modules = []
             for (imp, name, ispkg) in pkgutil.iter_modules(pdoc.import_path):
-                if name == 'setup' and not ispkg:
-                    continue
+                if is_all:
+                    if name == 'setup' and not ispkg:
+                        continue
+                elif is_local:
+                    if imp.path != cwd and not imp.path.startswith(cwd_slash):
+                        continue
                 modules.append((name, quick_desc(imp, name, ispkg)))
             modules = sorted(modules, key=lambda x: x[0].lower())
 


### PR DESCRIPTION
It can be hard to deal with a big list of modules in HTTP server mode, so I propose to add a local module list, based on the current working directory (the one from within which the server was started) and to add a link “Local packages” along with the already existing “All packages”. The links are also added in the index page, where there was none before.
