### PR TITLE
Fixed side bar, removed design by and changed white-space to pre-wrapping for .desc

### DIFF
--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -14,7 +14,7 @@
   #content {
     width: 70%;
     margin-left: 25%;
-    max-width: 850px;
+    max-width: 90%;
     float: left;
     padding: 30px 60px;
     border-left: 1px solid #ddd;
@@ -99,10 +99,6 @@
   }
   .ident {
     color: #900;
-  }
-
-  code {
-    background: #f9f9f9;
   }
 
   pre {
@@ -245,7 +241,7 @@
     .source {
       display: none;
       max-height: 600px;
-      overflow-y: scroll;
+      overflow-y: auto;
       margin-bottom: 15px;
     }
 
@@ -272,7 +268,7 @@
         width: auto;
     }
     #content {
-      width: 65%;
+      width: 95%;
       margin-left: auto;
       border-left: none;
       padding: 30px;
@@ -544,7 +540,7 @@ pre,
 samp {
     font-family: monospace, serif;
     _font-family: 'courier new', monospace;
-    font-size: 1em;
+    font-size: 0.9em;
 }
 
 /**

--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -13,16 +13,20 @@
   }
   #content {
     width: 70%;
+    margin-left: 25%;
     max-width: 850px;
     float: left;
     padding: 30px 60px;
     border-left: 1px solid #ddd;
   }
   #sidebar {
+    position: fixed;
+    height: 100%;
     width: 25%;
     float: left;
     padding: 30px;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
   }
   #nav {
     font-size: 130%;
@@ -99,7 +103,7 @@
 
   code {
     background: #f9f9f9;
-  } 
+  }
 
   pre {
     background: #fefefe;
@@ -116,7 +120,7 @@
     .codehilite pre {
       margin: 0;
     }
-    .codehilite .err { background: #ff3300; color: #fff !important; } 
+    .codehilite .err { background: #ff3300; color: #fff !important; }
 
   table#module-list {
     font-size: 110%;
@@ -227,7 +231,7 @@
       text-transform: uppercase;
       color: #fff;
       text-shadow: 1px 1px 0 #f4b700;
-      
+
       padding: 3px 8px;
       border-radius: 2px;
       transition: background .3s ease-in-out;
@@ -252,16 +256,26 @@
   .desc h1, .desc h2, .desc h3 {
     font-size: 100% !important;
   }
+
+  .desc {
+    white-space: pre-wrap;
+  }
+
   .clear {
     clear: both;
   }
 
   @media all and (max-width: 950px) {
     #sidebar {
-      width: 35%;
+        position: inherit;
+        float: none;
+        width: auto;
     }
     #content {
       width: 65%;
+      margin-left: auto;
+      border-left: none;
+      padding: 30px;
     }
   }
   @media all and (max-width: 650px) {

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -419,6 +419,11 @@
   % endif
 
   <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300' rel='stylesheet' type='text/css'>
+
+  <!-- highlight.js for highlighting source code. -->
+  <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.2.0/styles/default.min.css">
+  <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.2.0/highlight.min.js"></script>
+
   <%namespace name="css" file="css.mako" />
   <style type="text/css">
   ${css.pre()}
@@ -479,5 +484,6 @@
     </p>
   </footer>
 </div>
+<script>hljs.initHighlightingOnLoad();</script>
 </body>
 </html>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -475,9 +475,8 @@
     </p>
 
     <p>pdoc is in the public domain with the
-      <a href="http://unlicense.org">UNLICENSE</a></p>
-
-    <p>Design by <a href="http://nadh.in">Kailash Nadh</a></p>
+      <a href="http://unlicense.org">UNLICENSE</a>
+    </p>
   </footer>
 </div>
 </body>


### PR DESCRIPTION
The changes are:
1. Fixed side bar: Side bar scroll is separate from the context so one can scroll down in the context and still see the side bar. Mentioned in #50
1. Removed design by from HTML page as discussed #92 
2. Set `white-space` to `pre-wrapping` for `.desc` class. This assures that docstring stays readable.

@BurntSushi I'm not sure if you wanted all these changes as it wasn't clear in the issues. 1 and 2 are design preferences. Number 3 looks like a bug to me.

Here you can see all the changes in one image:
![image](https://cloud.githubusercontent.com/assets/2915573/13179134/8bb65744-d6f0-11e5-91dc-02bc34f6d51b.png)
