### PR TITLE
Update markdown dependancy by using markdown2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Installation
     pip install pdoc
 
 Dependencies are [mako](https://pypi.python.org/pypi/Mako) and
-[markdown](https://pypi.python.org/pypi/Markdown). (If you're using Python
+[markdown2](https://pypi.python.org/pypi/markdown2). (If you're using Python
 2.6, then you'll also need [argparse](https://pypi.python.org/pypi/argparse).)
 
 [Pygments](https://pypi.python.org/pypi/Pygments) is an optional dependency. 

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -2,7 +2,7 @@
   import re
   import sys
 
-  import markdown
+  import markdown2
   try:
     import pygments
     import pygments.formatters
@@ -65,10 +65,8 @@
     if not module_list:
       s, _ = re.subn('`[^`]+`', linkify, s)
 
-    extensions = []
-    if use_pygments:
-      extensions = ['markdown.extensions.codehilite(linenums=False)']
-    s = markdown.markdown(s.strip(), extensions=extensions)
+    extensions = ["fenced-code-blocks"]
+    s = markdown2.markdown(s.strip(), extras=extensions)
     return s
 
   def glimpse(s, length=100):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import codecs
 from distutils.core import setup
 import os.path as path
 
-install_requires = ['mako', 'markdown < 2.5']
+install_requires = ['mako', 'markdown2']
 try:  # Is this really the right way? Couldn't find anything better...
     import argparse
 except ImportError:
@@ -50,7 +50,7 @@ setup(
                ],
     scripts=['scripts/pdoc'],
     provides=['pdoc'],
-    requires=['argparse', 'mako', 'markdown'],
+    requires=['argparse', 'mako', 'markdown2'],
     install_requires=install_requires,
     extras_require={'syntax_highlighting': ['pygments']},
 )


### PR DESCRIPTION
Currently, markdown module is used to render markdown to html.
If you want to add an exemple in your docsting, surrounded by triple backquote,
you can't.

With the markdown2 module and the extension "fenced-code-blocks", you
can.

Check out the difference with the attached image:

With the current 'markdown' module:
![markdown](https://cloud.githubusercontent.com/assets/6367936/20894857/5a435c5a-bb17-11e6-93c3-687144115845.png)

With the new 'markdown2' module:
![markdown2](https://cloud.githubusercontent.com/assets/6367936/20894878/6d9aade4-bb17-11e6-83ae-d3098796d6ab.png)


Here the base class for the picture:

```python
class Test():
    '''This is my test class

    *Parameters:*

    - `arg1`: The first argument
    - `arg2`: A second one

    *Exemple:*

    ```
    i = 0
    for i < 10:
        print(i)
        i += 1

    print("OK")
    ```
    '''
    def __init__(self):
        pass

```
