### PR TITLE
html template - show a "Module Index" in Index column

### DIFF
--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -373,20 +373,22 @@
 </%def>
 
 <%def name="list_module_tree(list_module, current_module)">
-  <ul>
-  % for m in list_module.submodules():
-    <%
-    url = top_module_url(current_module)
-    url += "/".join(m.name.split(".")[1:])
-    if m.is_package():
-      url += '/%s' % pdoc.html_package_name
-    else:
-      url += pdoc.html_module_suffix
-    %>
-    <li class="mono"><a href="${url}">${m.refname}</a></li>
-    ${list_module_tree(m, current_module)}
-  % endfor
-  </ul>
+  % if list_module.submodules():    
+    <ul>
+    % for m in list_module.submodules():
+      <%
+      url = top_module_url(current_module)
+      url += "/".join(m.name.split(".")[1:])
+      if m.is_package():
+        url += '/%s' % pdoc.html_package_name
+      else:
+        url += pdoc.html_module_suffix
+      %>
+      <li class="mono"><a href="${url}">${m.refname}</a></li>
+      ${list_module_tree(m, current_module)}
+    % endfor
+    </ul>
+  % endif
 </%def>
 
 <%def name="module_index(module)">

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -22,9 +22,8 @@
 
 
   def get_top_module(module):
-    if ('args' in context.keys() and hasattr(context['args'], 'module_name') and
-        module.name.startswith(context['args'].module_name)):
-      top_module_name = context['args'].module_name
+    if 'top_module' in context.keys() and module.name.startswith(context["top_module"]):
+      top_module_name = context["top_module"]
     else:
       top_module_name = module.name.split('.')[0]
 

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -107,7 +107,7 @@ class WebDoc (BaseHTTPRequestHandler):
             modules = sorted(modules, key=lambda x: x[0].lower())
 
             out = pdoc.tpl_lookup.get_template('/html.mako')
-            out = out.render(modules=modules, link_prefix=args.link_prefix, args=args)
+            out = out.render(modules=modules, link_prefix=args.link_prefix)
             out = out.strip()
         elif self.path.endswith('.ext'):
             # External links are a bit weird. You should view them as a giant
@@ -340,7 +340,7 @@ def html_out(m, html=True):
                              link_prefix=args.link_prefix,
                              http_server=args.http_html,
                              source=not args.html_no_source,
-                             args=args)
+                             top_module=args.module_name)
             print(out, file=w)
     except Exception:
         try:

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -107,7 +107,7 @@ class WebDoc (BaseHTTPRequestHandler):
             modules = sorted(modules, key=lambda x: x[0].lower())
 
             out = pdoc.tpl_lookup.get_template('/html.mako')
-            out = out.render(modules=modules, link_prefix=args.link_prefix)
+            out = out.render(modules=modules, link_prefix=args.link_prefix, args=args)
             out = out.strip()
         elif self.path.endswith('.ext'):
             # External links are a bit weird. You should view them as a giant
@@ -339,7 +339,8 @@ def html_out(m, html=True):
                 out = m.html(external_links=args.external_links,
                              link_prefix=args.link_prefix,
                              http_server=args.http_html,
-                             source=not args.html_no_source)
+                             source=not args.html_no_source,
+                             args=args)
             print(out, file=w)
     except Exception:
         try:


### PR DESCRIPTION
"Module Index" show the complete module hierarchy from the top-level package.
This should be useful for navigating.