### PR TITLE
Mark asynchronous functions as `async def`

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1079,6 +1079,33 @@ class Function (Doc):
         else:
             return '%s.%s' % (self.cls.refname, self.name)
 
+    def funcdef(self):
+        """
+        Generates the string of keywords used to define the function, for example `def` or
+        `async def`.
+        """
+        keywords = []
+
+        if self._is_async():
+            keywords.append("async")
+
+        keywords.append("def")
+
+        return " ".join(keywords)
+
+    def _is_async(self):
+        """
+        Returns whether is function is asynchronous, either as a coroutine or an async
+        generator.
+        """
+        try:
+            # Both of these are required because coroutines aren't classified as async
+            # generators and vice versa.
+            return inspect.iscoroutinefunction(self.func) or \
+                   inspect.isasyncgenfunction(self.func)
+        except AttributeError:
+            return False
+
     def spec(self):
         """
         Returns a nicely formatted spec of the function's parameter

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -238,7 +238,7 @@
   <%def name="show_func(f)">
   <div class="item">
     <div class="name def" id="${f.refname}">
-    <p>def ${ident(f.name)}(</p><p>${f.spec() | h})</p>
+    <p>${f.funcdef()} ${ident(f.name)}(</p><p>${f.spec() | h})</p>
     </div>
     ${show_inheritance(f)}
     ${show_desc(f)}


### PR DESCRIPTION
This change marks [asynchronous/coroutine functions](https://docs.python.org/3/reference/compound_stmts.html#async-def) as `async def` in the generated docs, since they're used and overridden differently than regular functions.

It should be backwards compatible with python < 3.5 as well.