### PR TITLE
Add --docformat argument for reStructuredText or plaintext input

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Prominent features include:
   [namedtuple](http://docs.python.org/2.7/library/collections.html#namedtuple-factory-function-for-tuples-with-named-fields)),
   the special variable `__pdoc__` can be used in your module to
   document any identifier in your public interface.
-* Usage is simple. Just write your documentation as Markdown. There are no 
-  added special syntax rules.
+* Usage is simple. Just write all your docstring documentation as Markdown
+  (default), or reStructuredText. There are no added special syntax rules.
 * `pdoc` respects your `__all__` variable when present.
 * `pdoc` will automatically link identifiers in your docstrings to its
   corresponding documentation.

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -238,7 +238,8 @@ object's `directories` attribute.
 
 
 def html(module_name, docfilter=None, allsubmodules=False,
-         external_links=False, link_prefix='', source=True):
+         external_links=False, link_prefix='', source=True,
+         docformat="markdown"):
     """
     Returns the documentation for the module `module_name` in HTML
     format. The module must be importable.
@@ -262,12 +263,17 @@ def html(module_name, docfilter=None, allsubmodules=False,
     If `source` is `True`, then source code will be retrieved for
     every Python object whenever possible. This can dramatically
     decrease performance when documenting large modules.
+
+    Argument `docformat` should be a string like `'markdown'`, or
+    `'restructuredtext'` or `'plaintext'` which specifies how the
+    docstring text should be processed.
     """
     mod = Module(import_module(module_name),
                  docfilter=docfilter,
                  allsubmodules=allsubmodules)
     return mod.html(external_links=external_links,
-                    link_prefix=link_prefix, source=source)
+                    link_prefix=link_prefix, source=source,
+                    docformat=docformat)
 
 
 def text(module_name, docfilter=None, allsubmodules=False):
@@ -653,7 +659,7 @@ class Module (Doc):
         return text
 
     def html(self, external_links=False, link_prefix='',
-             source=True, **kwargs):
+             source=True, docformat="markdown", **kwargs):
         """
         Returns the documentation for this module as
         self-contained HTML.
@@ -668,6 +674,9 @@ class Module (Doc):
         every Python object whenever possible. This can dramatically
         decrease performance when documenting large modules.
 
+        `docformat` should be `'markdown'` or `'restructuredtext'`
+        and specified how the docstring text should be processed.
+
         `kwargs` is passed to the `mako` render function.
         """
         t = _get_tpl('/html.mako')
@@ -675,6 +684,7 @@ class Module (Doc):
                      external_links=external_links,
                      link_prefix=link_prefix,
                      show_source_code=source,
+                     docformat=docformat,
                      **kwargs)
         return t.strip()
 

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -2,6 +2,8 @@
   import re
   import sys
 
+  import docutils
+  import docutils.core
   import markdown
   try:
     import pygments
@@ -65,11 +67,19 @@
     if not module_list:
       s, _ = re.subn('`[^`]+`', linkify, s)
 
-    extensions = []
-    if use_pygments:
-      extensions = ['markdown.extensions.codehilite(linenums=False)']
-    s = markdown.markdown(s.strip(), extensions=extensions)
-    return s
+    if docformat == "markdown":
+      extensions = []
+      if use_pygments:
+        extensions = ['markdown.extensions.codehilite(linenums=False)']
+      m = markdown.markdown(s.strip(), extensions=extensions)
+    elif docformat == "restructuredtext":
+      m = docutils.core.publish_parts(s, writer_name='html')['html_body']
+    else:
+      # e.g. plaintext
+      m = "<pre>%s</pre>" % s
+    # For debugging:
+    # m = "<p>Given:</p><pre>%s</pre>\n<p>Treated as %s, giving:</p>\n%s" % (s, docformat, m)
+    return m
 
   def glimpse(s, length=100):
     if len(s) < length:

--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -42,6 +42,9 @@ aa('ident_name', type=str, nargs='?',
         'Has no effect when --http is set.')
 aa('--version', action='store_true',
    help='Print the version of pdoc and exit.')
+aa('--docformat', type=str, default='markdown',
+   help='The markup language used for the docstring content.',
+   choices=['markdown', 'restructuredtext', 'plaintext'])
 aa('--html', action='store_true',
    help='When set, the output will be HTML formatted.')
 aa('--html-dir', type=str, default='.',
@@ -339,7 +342,8 @@ def html_out(m, html=True):
                 out = m.html(external_links=args.external_links,
                              link_prefix=args.link_prefix,
                              http_server=args.http_html,
-                             source=not args.html_no_source)
+                             source=not args.html_no_source,
+			     docformat=args.docformat)
             print(out, file=w)
     except Exception:
         try:

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
                ],
     scripts=['scripts/pdoc'],
     provides=['pdoc'],
-    requires=['argparse', 'mako', 'markdown'],
+    requires=['argparse', 'docutils', 'mako', 'markdown'],
     install_requires=install_requires,
     extras_require={'syntax_highlighting': ['pygments']},
 )


### PR DESCRIPTION
This leaves markdown as the default for rendering the docstrings, but adds a new ``--docformat`` option (named after the ``epydoc`` option) allowing the use of reStructuredText (via ``docutils``) or plain text (using an HTML ``<pre>`` block).

This will be useful for anyone hoping to migrate from epydoc which did not support Markdown, but did support its own format epydoc and the Python standard reStructuredText.

This will also indirectly greatly improve the display of doctests or Python snippets using the `>>>` notation which the Markdown rendering does not understand (see #63).

It would be relatively simple to make the ``markdown``/``docutils`` import lazy, so that people using one input format would not require the other dependency be installed.

This would close the main goal of #111 (although it does not make life complicated by looking at the per-file settings in any ``__docformat__`` declaration).

Thank you to @j6k4m8 whose work on  #101 was very useful. I would be happy to include his work by adding GitHub Flavoured Markdown as another option here, e.g. ``--docformat gfm``?