### PR TITLE
Fix windows install

### DIFF
--- a/pdoc/cli.py
+++ b/pdoc/cli.py
@@ -389,7 +389,9 @@ def process_html_out(impath):
         print(out)
 
 
-if __name__ == '__main__':
+def cli():
+    """ Command-line entry point """
+
     if args.version:
         print(pdoc.__version__)
         sys.exit(0)
@@ -504,3 +506,6 @@ if __name__ == '__main__':
         quit_if_exists(module)
         html_out(module, args.html)
         sys.exit(0)
+
+if __name__ == '__main__':
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
                                 'UNLICENSE', 'INSTALL', 'CHANGELOG']),
                 ('share/doc/pdoc', ['doc/pdoc/index.html']),
                ],
-    scripts=['scripts/pdoc'],
+    entry_points={'console_scripts':['pdoc = pdoc.cli:cli'] },
     provides=['pdoc'],
     requires=['argparse', 'mako', 'markdown'],
     install_requires=install_requires,


### PR DESCRIPTION
This:
- Fixes Windows installs, including anaconda (it's not special in this regards). Having reviewed the issues, I believe this will fix #127, #123, #52 and #20.
- Should not affect Linux installs (but I can't test this unfortunately).

As in #127 you said you didn't use Python on Windows I'll try to explain:

Basically, the Windows install issue was down to using distutils' `scripts` argument in `setup.py` to create the CLI tool. This simply copies the named script into the Scripts folder on install. This didn't work on Windows as you ended up with a no-extension, non-executable file on your $PATH.

What this PR does instead is to use setuptools' `entry_points:console_scripts` feature, which is apparently now the preferred/cross-platform way to create CLI tools. Instead of just copying a file, it generates a wrapper for the appropriate platform (i.e. an .exe on Windows). However the wrapper has to point to an entry point inside the package, hence the change from `scripts/pdoc` to `pdoc/cli.py` and the addition of `cli()`. I can't test but I suspect the "wrapper" on Linux will simply be the script itself, chmoded to executable.

Motivated to fix this as pdoc looks like exactly what Python needs - many thanks!