### PR TITLE
Fix mako default encoding from ascii to utf-8

### DIFF
--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -1,3 +1,4 @@
+## -*- coding: utf-8 -*-
 <%
   import re
   import sys


### PR DESCRIPTION
Fixes https://github.com/BurntSushi/pdoc/issues/134
Replaces/Closes https://github.com/BurntSushi/pdoc/pull/122

See also:
http://docs.makotemplates.org/en/latest/unicode.html#specifying-the-encoding-of-a-template-file