### PR TITLE
Revamp import and module extraction

### DIFF
--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -183,12 +183,6 @@ def _get_tpl(name):
     return t
 
 
-def _eprint(*args, **kwargs):
-    """Print to stderr."""
-    kwargs["file"] = sys.stderr
-    print(*args, **kwargs)
-
-
 def _safe_import(module_name):
     """
     A function for safely importing `module_name`, where errors are

--- a/pdoc/extract.py
+++ b/pdoc/extract.py
@@ -1,0 +1,55 @@
+import os
+import importlib
+
+
+class ExtractError(Exception):
+    pass
+
+
+def extract_module(spec: str):
+    """
+        Extracts and returns a module objectd. The spec argument can have the
+        following forms:
+
+        Simple module: "foo.bar"
+        Module path: "./path/to/module"
+        File path: "./path/to/file.py"
+
+        This function always invalidates caches to enable hot load and reload.
+
+        May raise ExtactError.
+    """
+    importlib.invalidate_caches()
+    if (os.sep in spec) or (os.altsep and os.altsep in spec):
+        if spec.endswith(".py"):
+            mname = os.path.splitext(os.path.basename(spec))[0]
+            location = spec
+            if not os.path.isfile(location):
+                raise ExtractError("File not found: %s" % location)
+        else:
+            mname = os.path.basename(spec)
+            if "." in mname:
+                raise ExtractError(
+                    f"Invalid module name {mname}. "
+                    "Mixing path and module specifications is not supported."
+                )
+            if os.path.isfile(spec + ".py"):
+                location = spec + ".py"
+            elif os.path.isfile(os.path.join(spec, "__init__.py")):
+                location = os.path.join(spec, "__init__.py")
+            else:
+                raise ExtractError(f"Module not found: {spec}")
+        ispec = importlib.util.spec_from_file_location(mname, location)
+        module = importlib.util.module_from_spec(ispec)
+        # This can literally raise anything
+        try:
+            ispec.loader.exec_module(module)
+        except Exception as e:
+            raise ExtractError(f"Error importing {spec}: {e}")
+        return module
+    else:
+        try:
+            return importlib.import_module(spec)
+        except ModuleNotFoundError:
+            raise ExtractError(f"Module not found: {spec}")
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[flake8]
+max-line-length = 140
+max-complexity = 25
+ignore = E251,C901,W503,W292,E722,E741
+exclude = mitmproxy/contrib/*,test/mitmproxy/data/*,release/build/*
+addons = file,open,basestring,xrange,unicode,long,cmp
+
+[tool:pytest]
+testpaths = test
+addopts = --capture=no --color=yes
+
+[coverage:run]
+branch = False
+
+[coverage:report]
+show_missing = True
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError()

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 max-line-length = 140
 max-complexity = 25
 ignore = E251,C901,W503,W292,E722,E741
-exclude = mitmproxy/contrib/*,test/mitmproxy/data/*,release/build/*
+exclude = mitmproxy/contrib/*,test/mitmproxy/data/*,release/build/*,*malformed*
 addons = file,open,basestring,xrange,unicode,long,cmp
 
 [tool:pytest]

--- a/test/modules/dirmod/__init__.py
+++ b/test/modules/dirmod/__init__.py
@@ -1,0 +1,6 @@
+
+def simple():
+    """
+        A docstring.
+    """
+    pass

--- a/test/modules/malformed/syntax.py
+++ b/test/modules/malformed/syntax.py
@@ -1,0 +1,3 @@
+
+# Syntax error
+class

--- a/test/modules/one.py
+++ b/test/modules/one.py
@@ -1,0 +1,6 @@
+
+def simple():
+    """
+        A docstring.
+    """
+    pass

--- a/test/packages/malformed_syntax.py
+++ b/test/packages/malformed_syntax.py
@@ -1,0 +1,3 @@
+
+# Syntax error
+class

--- a/test/packages/simple.py
+++ b/test/packages/simple.py
@@ -1,0 +1,3 @@
+
+def simple():
+    pass

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -1,0 +1,38 @@
+import contextlib
+import os
+
+import pytest
+
+import pdoc.extract
+
+
+@contextlib.contextmanager
+def tdir():
+    old_dir = os.getcwd()
+    os.chdir(os.path.dirname(__file__))
+    yield
+    os.chdir(old_dir)
+
+
+def test_extract_module():
+    with tdir():
+        with pytest.raises(pdoc.extract.ExtractError, match="File not found"):
+            pdoc.extract.extract_module("./modules/nonexistent.py")
+        with pytest.raises(pdoc.extract.ExtractError, match="Module not found"):
+            pdoc.extract.extract_module("./modules/nonexistent/foo")
+        with pytest.raises(pdoc.extract.ExtractError, match="Invalid module name"):
+            pdoc.extract.extract_module("./modules/one.two")
+        with pytest.raises(pdoc.extract.ExtractError, match="Module not found"):
+            pdoc.extract.extract_module("nonexistent.module")
+        with pytest.raises(pdoc.extract.ExtractError, match="Error importing"):
+            pdoc.extract.extract_module("./modules/malformed/syntax.py")
+        with pytest.raises(pdoc.extract.ExtractError, match="Error importing"):
+            pdoc.extract.extract_module("packages/malformed_syntax")
+
+        assert pdoc.extract.extract_module("./modules/one.py")
+        assert pdoc.extract.extract_module("./modules/one")
+        assert pdoc.extract.extract_module("./modules/dirmod")
+        assert pdoc.extract.extract_module("csv")
+        assert pdoc.extract.extract_module("html.parser")
+        assert pdoc.extract.extract_module("packages.simple")
+

--- a/test/test_pdoc.py
+++ b/test/test_pdoc.py
@@ -2,4 +2,4 @@ import pdoc
 
 
 def test_pdoc():
-    print(pdoc)
+    assert pdoc


### PR DESCRIPTION
In modern Python this is much cleaner with importlib. Also remove special handling of PYTHONPATH 0 either the interpreter can discover the module, or we use a filesystem path, no other complications. 