### PR TITLE
Define unicode in Python 3

### DIFF
--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -1,6 +1,10 @@
 import ast
 import inspect
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 __pdoc__ = {}
 
@@ -673,7 +677,7 @@ class Function(Doc):
         """
 
         def fmt_param(el):
-            if isinstance(el, str) or isinstance(el, unicode):
+            if isinstance(el, (str, unicode)):
                 return el
             else:
                 return "(%s)" % (", ".join(map(fmt_param, el)))


### PR DESCRIPTION
Without this change __NameError__ could be raised at runtime because __unicode__ was removed in Python 3 because all __str__ are Unicode.

flake8 testing of https://github.com/mitmproxy/pdoc on Python 3.7.0

$ flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
```
            if isinstance(el, str) or isinstance(el, unicode):
                                                     ^
1     F821 undefined name 'unicode'
1
```