### PR TITLE
Handle newlines in docs

### DIFF
--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -82,7 +82,9 @@
     color: #e08524;
     transition: color .3s ease-in-out;
   }
-
+  p, pre {
+    white-space: pre-wrap;
+  }
   pre, code, .mono, .name {
     font-family: "Ubuntu Mono", "Cousine", "DejaVu Sans Mono", monospace;
   }


### PR DESCRIPTION
Newlines aren't shown in currently compiled docs.

This fixes #179 with the suggestion made by @armant: https://github.com/mitmproxy/pdoc/issues/179#issuecomment-466465655