### PR TITLE
Fixed bad module path generation

### DIFF
--- a/pdoc/static.py
+++ b/pdoc/static.py
@@ -17,10 +17,7 @@ def module_to_path(m: pdoc.doc.Module) -> pathlib.Path:
     if m.submodules:
         p /= "index.html"
     else:
-        if p.stem == "index":
-            p = p.with_suffix(".m.html")
-        else:
-            p = p.with_suffix(".html")
+        p = p.with_suffix(".m.html")
     return p
 
 
@@ -30,7 +27,7 @@ def path_to_module(
     """
         Retrieves the matching module for a given path from a module tree.
     """
-    if path.suffix == ".html":
+    if path.suffix == ".m.html":
         path = path.with_suffix("")
     parts = list(path.parts)
     if parts[-1] == "index":


### PR DESCRIPTION
`pdoc` is generating incorrect filepaths for modules, causing links to modules to be broken. This seems to fix the issue on the generated docs for a package I'm maintaining; however, I don't know if this is breaking something else in the process.