### PR TITLE
Align docstrings with locals/attributes

### DIFF
--- a/pdoc/templates/default/module.html.jinja2
+++ b/pdoc/templates/default/module.html.jinja2
@@ -230,6 +230,7 @@
 
                 /* Page Heading */
                 .pdoc .modulename {
+                    margin-left: 1rem;
                     margin-top: 0;
                     font-weight: bold;
                 }
@@ -289,7 +290,7 @@
 
                 /* Docstrings */
                 .pdoc .docstring {
-                    margin-bottom: 1.5rem;
+                    margin: 0 1rem 1.5rem 1rem;
                 }
 
                 .pdoc > section:first-of-type > .docstring {


### PR DESCRIPTION
This is a small tweak to the CSS which makes the documentation page slightly more readable. 

It's definitely bikeshedding territory. But to me, it's nicer when the docstrings are aligned with the text of the classes/functions instead of with the border.

<details>
<summary>Before screenshot</summary>
<img src="https://user-images.githubusercontent.com/1123589/106791092-c4cd3180-6654-11eb-91d1-e9c441e4576a.png">
</details>

<details>
<summary>After screenshot</summary>
<img src="https://user-images.githubusercontent.com/1123589/106791113-cac31280-6654-11eb-8963-3a91a40e53ae.png">
</details>

Thanks for the great project!