### PR TITLE
fix wrong links in index.html

### DIFF
--- a/pdoc/templates/default/index.html.jinja2
+++ b/pdoc/templates/default/index.html.jinja2
@@ -107,7 +107,7 @@
                 root => `
                     <a
                     class="${filtered.length === 1 || root === filt ? 'active' : ''}"
-                    href="${root.replace(".", "/")}.html"
+                    href="${root.replaceAll(".", "/")}.html"
                     >${root}</a>`
             ).join("");
         }


### PR DESCRIPTION
The `replace`-method in JavaScript does only replace the first "." in the modulename. 

This does not work for modules with depth > 2 (e.g. `module.submodule.subsubmodule`, which would generate `href="module/submodule.subsubmodule.html"`.