### PR TITLE
require Jinja2 >= 2.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     entry_points={"console_scripts": ["pdoc = pdoc.__main__:cli"]},
     python_requires=">=3.7",
     install_requires=[
-        "Jinja2",
+        "Jinja2 >= 2.11.0",
         "pygments",
         "MarkupSafe",
         "astunparse; python_version<'3.9'",


### PR DESCRIPTION
Jinja 2.10.* included a bug that escaped the output of the `indent` function, see issue https://github.com/pallets/jinja/issues/823. This affects the default templates of pdoc, e.g. in the navigation for classes:
https://github.com/mitmproxy/pdoc/blob/d45f24ce73825e27a34f1165a068d6c6f1b420f6/pdoc/templates/default/module.html.jinja2#L580

This was fixed in Jinja2 with version 2.11.0 (see PR https://github.com/pallets/jinja/pull/826) (published January 2020), therefore I'd suggest to add 2.11.0 as the minimal required version to the setup.py to prevent the usage with older version.