### PR TITLE
Proposal: Always add "Home / Module Index / Search" button

### DIFF
--- a/pdoc/templates/default/module.html.jinja2
+++ b/pdoc/templates/default/module.html.jinja2
@@ -150,6 +150,20 @@
                     border-color: var(--text);
                 }
 
+                nav.pdoc .index-button {
+                    display: inline-flex;
+                    align-items: center;
+                    color: var(--text);
+                    border-color: var(--muted);
+                    margin-bottom: 1rem;
+                    margin-right: var(--pad);
+                    float: right;
+                }
+
+                nav.pdoc .index-button:hover {
+                    border-color: var(--text);
+                }
+
                 nav.pdoc ul {
                     list-style: none;
                     padding-left: 0;
@@ -664,6 +678,10 @@
                             {% include "box-arrow-in-left.svg" %}
                             &nbsp;
                             {{- parentmodule -}}
+                        </a>
+
+                        <a class="pdoc-button index-button" href="./{{ "../" * module.modulename.count(".") }}">
+                            Module Index
                         </a>
                     {% elif all_modules|length > 1 %}
                         <a class="pdoc-button module-list-button" href="./{{ "../" * module.modulename.count(".") }}">


### PR DESCRIPTION
It would be great to have a button leading to the top-level index-page in lower-nested pages by default. Not sure what would be the nicest way visually, I just added a simple text button, but also a home or search-magnification icon could be used, maybe even without any text.

![Screenshot from 2021-04-22 14-18-28](https://user-images.githubusercontent.com/7216331/115712988-c6fe7c80-a375-11eb-8ea5-d05948a6f305.png)

A simple icon without text would also prevent more line-breaks:
![Screenshot from 2021-04-22 14-18-59](https://user-images.githubusercontent.com/7216331/115712986-c665e600-a375-11eb-8639-2cb040b10103.png)

I'm sorry if this proposal is too specific, I just thought it might be useful in the default templates.