### PR TITLE
Fix blank lines breaking indented code blocks

### DIFF
--- a/pdoc/docstrings.py
+++ b/pdoc/docstrings.py
@@ -78,6 +78,21 @@ def _google_section(m: re.Match[str]) -> str:
             contents += "\n"
     else:
         contents = indent(contents, "> ", lambda line: True)
+        if '```' in contents:
+            lines = contents.split('\n')
+            inside_code_block = False
+            for index, line in enumerate(lines):
+                if '```' in line:
+                    inside_code_block = not inside_code_block
+                elif inside_code_block:
+                    if line[2:].startswith(' ') and lines[index - 1] == '> ':
+                        # if the line, minus the blockquote chars, starts with an indent
+                        # and the previous line was blank
+                        # the blockquote will be considered broken up by said blank line.
+                        # add in a character that doesn't register as a space to trick
+                        # the markdown parser into rendering the blockquote as one item
+                        lines[index - 1] = '> \u2028'
+            contents = '\n'.join(lines)
 
     return f"\n###### {name}\n{contents}\n"
 

--- a/test/testdata/flavors_google.html
+++ b/test/testdata/flavors_google.html
@@ -99,6 +99,9 @@
             <li>
                     <a class="function" href="#example_code">example_code</a>
             </li>
+            <li>
+                    <a class="function" href="#indented_code_blank_lines">indented_code_blank_lines</a>
+            </li>
     </ul>
 
 
@@ -582,6 +585,21 @@ with it.</p></li>
 <span class="sd">        tmp = a2()</span>
 
 <span class="sd">        tmp2 = a()</span>
+<span class="sd">        ```</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+
+<span class="k">def</span> <span class="nf">indented_code_blank_lines</span><span class="p">():</span>
+    <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">    Test case for blank lines interrupting code blocks when inside an indented block</span>
+
+<span class="sd">    Example:</span>
+<span class="sd">        ```python</span>
+<span class="sd">        if True:</span>
+<span class="sd">            print()</span>
+
+<span class="sd">            print()</span>
+
+<span class="sd">            print()</span>
 <span class="sd">        ```</span>
 <span class="sd">    &quot;&quot;&quot;</span>
 </pre></div>
@@ -1648,6 +1666,51 @@ there is a colon missing in the previous line</li>
   <div class="codehilite"><pre><span></span><code><span class="n">tmp</span> <span class="o">=</span> <span class="n">a2</span><span class="p">()</span>
 
 <span class="n">tmp2</span> <span class="o">=</span> <span class="n">a</span><span class="p">()</span>
+</code></pre></div>
+</blockquote>
+</div>
+
+
+                </section>
+                <section id="indented_code_blank_lines">
+                            <div class="attr function"><a class="headerlink" href="#indented_code_blank_lines">#&nbsp;&nbsp</a>
+
+        
+            <span class="def">def</span>
+            <span class="name">indented_code_blank_lines</span><span class="signature">()</span>:
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span><span class="k">def</span> <span class="nf">indented_code_blank_lines</span><span class="p">():</span>
+    <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">    Test case for blank lines interrupting code blocks when inside an indented block</span>
+
+<span class="sd">    Example:</span>
+<span class="sd">        ```python</span>
+<span class="sd">        if True:</span>
+<span class="sd">            print()</span>
+
+<span class="sd">            print()</span>
+
+<span class="sd">            print()</span>
+<span class="sd">        ```</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+</pre></div>
+
+        </details>
+
+            <div class="docstring"><p>Test case for blank lines interrupting code blocks when inside an indented block</p>
+
+<h6 id="example">Example</h6>
+
+<blockquote>
+  <div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+    <span class="nb">print</span><span class="p">()</span>
+ 
+    <span class="nb">print</span><span class="p">()</span>
+ 
+    <span class="nb">print</span><span class="p">()</span>
 </code></pre></div>
 </blockquote>
 </div>

--- a/test/testdata/flavors_google.py
+++ b/test/testdata/flavors_google.py
@@ -424,3 +424,18 @@ def example_code():
         tmp2 = a()
         ```
     """
+
+def indented_code_blank_lines():
+    """
+    Test case for blank lines interrupting code blocks when inside an indented block
+
+    Example:
+        ```python
+        if True:
+            print()
+
+            print()
+
+            print()
+        ```
+    """

--- a/test/testdata/flavors_google.txt
+++ b/test/testdata/flavors_google.txt
@@ -28,4 +28,5 @@
         <method def __init__(self, likes_spam=False): ...  # Inits SampleClass wi…>
         <method def public_method(self): ...  # Performs operation b…>>
     <function def invalid_format(test): ...  # In this example, the…>
-    <function def example_code(): ...  # Test case for https:…>>
+    <function def example_code(): ...  # Test case for https:…>
+    <function def indented_code_blank_lines(): ...  # Test case for blank …>>


### PR DESCRIPTION
Fixed this:
![image](https://user-images.githubusercontent.com/57498990/120108177-f1eda480-c15b-11eb-89ea-fdc86815a069.png)

Being rendered as this:
![image](https://user-images.githubusercontent.com/57498990/120108188-fc0fa300-c15b-11eb-8b8f-a8c79ecd486a.png)


This doesn't seem like the cleanest fix, however, it only applies to this specific scenario so it shouldn't mess anything up.

It works by replacing blank lines in code blockquotes with line seperator characters (U+2028), which tricks the markdown parser into rendering the blockquote "properly".
I also added a test case for this scenario.