### PR TITLE
Add `Doc.source_lines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    had a poor user experience as building the search index took too long.
  - Improve documentation of `pdoc.extract`. `pdoc.extract.parse_specs` has been renamed to `walk_specs`, 
    the old API now emits a deprecation warning.
+ - Add `pdoc.doc.Doc.source_lines` to access where in a file an object is defined.
 
 # 2021-05-30: pdoc 7.0.3
 

--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -152,6 +152,20 @@ class Doc(Generic[T]):
             return None
 
     @cached_property
+    def source_lines(self) -> Optional[tuple[int, int]]:
+        """
+        Return a `(start, end)` line number tuple for this object.
+
+        If no source file can be found, `None` is returned.
+        """
+        try:
+            obj = inspect.unwrap(self.obj)  # type: ignore
+            lines, start = inspect.getsourcelines(obj)
+            return start, start + len(lines) - 1
+        except Exception:
+            return None
+
+    @cached_property
     def is_inherited(self) -> bool:
         """
         If True, the doc object is inherited from another location.

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -33,6 +33,7 @@ def test_attrs():
     assert m.variables
     assert m.classes
     assert m.functions
+    assert m.source_lines
 
     c = m.members["Foo"]
     assert isinstance(c, Class)
@@ -84,9 +85,10 @@ def test_class_with_raising_getattr():
         assert c.members
 
 
-def test_builtin_source_file():
+def test_builtin_source():
     m = Module(builtins)
     assert m.source_file is None
+    assert m.source_lines is None
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="3.9+ only")


### PR DESCRIPTION
We don't use this for pdoc itself, but this can be quite useful to link to specific lines on GitHub etc.


@jedie: Is this API matching what you had in mind, or is there anything we can do make it more convenient?