### PR TITLE
 Allow google docstring section headers to contain spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased: pdoc next
 
  - Fix hot-reloading of included Markdown files.
+ - Allow google docstring section headers to contain spaces
 
 # 2021-06-11: pdoc 7.1.1
 

--- a/pdoc/docstrings.py
+++ b/pdoc/docstrings.py
@@ -45,7 +45,7 @@ def google(docstring: str) -> str:
     """Convert Google-style docstring sections into Markdown."""
     return re.sub(
         r"""
-        ^(?P<name>[A-Z][A-Za-z]+):\n
+        ^(?P<name>[A-Z][A-Z a-z]+):\n
         (?P<contents>(
             \n        # empty lines
             |         # or


### PR DESCRIPTION
This PR allows google docstring sections to be parsed if they have multiple words in their headers, EG: "Instance Variables" or "Class Attributes".

Currently, custom headers can be added using the `pdoc.docstrings.GOOGLE_LIST_SECTIONS` constant but if the header contains mutliple words then it is ignored.
This is because I forgot to check whether multiple word headers worked when creating #266, I just assumed it would work like single word headers, so this should fix that.