### PR TITLE
Add show_source flag to allow for hiding of source code in output

### DIFF
--- a/pdoc/__main__.py
+++ b/pdoc/__main__.py
@@ -85,6 +85,11 @@ parser.add_argument(
     action="store_true",
     help="Don't open a browser after the web server has started.",
 )
+parser.add_argument(
+    "--hide-source",
+    action="store_true",
+    help="Hide source code of documented functions",
+)
 parser.add_argument("--help", action="help", help="Show this help message and exit.")
 parser.add_argument(
     "--version",
@@ -153,6 +158,7 @@ def cli(args: list[str] = None) -> None:
         edit_url_map=dict(x.split("=", 1) for x in opts.edit_url),
         template_directory=opts.template_directory,
         docformat=opts.docformat,
+        show_source=not opts.hide_source,
     )
 
     if opts.output_directory:

--- a/pdoc/render.py
+++ b/pdoc/render.py
@@ -29,6 +29,7 @@ def configure(
     template_directory: Optional[Path] = None,
     docformat: Optional[Literal["google", "numpy", "restructuredtext"]] = None,
     edit_url_map: Optional[Mapping[str, str]] = None,
+    show_source: bool = True,
 ):
     """
     Configure the rendering output.
@@ -55,6 +56,7 @@ def configure(
 
     env.globals["edit_url_map"] = edit_url_map or {}
     env.globals["docformat"] = docformat
+    env.globals["show_source"] = show_source
 
 
 def html_module(
@@ -151,4 +153,5 @@ env.filters["minify_css"] = minify_css
 env.globals["__version__"] = pdoc.__version__
 env.globals["edit_url_map"] = {}
 env.globals["docformat"] = ""
+env.globals["show_source"] = True
 env.globals["env"] = os.environ

--- a/pdoc/templates/default/module.html.jinja2
+++ b/pdoc/templates/default/module.html.jinja2
@@ -651,7 +651,7 @@
 {% enddefaultmacro %}
 {# fmt: on #}
 {% defaultmacro view_source(doc) %}
-    {% if doc.source %}
+    {% if show_source and doc.source %}
         <details>
             <summary>View Source</summary>
             {{ doc.source | highlight }}


### PR DESCRIPTION
This adds a commandline flag `--hide-source`, which disables the source of the documented functions from appearing in the output. I think the view source button is a great feature, but for **many** projects it is not acceptable to distribute the source of the function with the documentation because the source is proprietary and under copyright. For example, at my work we use [Cython](https://cython.org/) to compile and ship Python code to help obfuscate the source, but we also need to document the Python APIs that users will program against.

This is mostly just a passthrough flag to change the behaviour of the Jinja template behind the scenes, but I think that hiding the source is a make-or-break feature for many users (including me) and expecting users to edit a Jinja template is far too big of a hurdle to expect people to actually jump over to use a "completely automatic" library.

I've set it to default to showing the source by default.