### PR TITLE
Fix formatting on Google docstrings that have multiple colons

### DIFF
--- a/pdoc/docstrings.py
+++ b/pdoc/docstrings.py
@@ -69,8 +69,8 @@ def _google_section(m: re.Match[str]) -> str:
         contents = ""
         for item in items:
             try:
-                # last ":" on the first line
-                _, attr, desc = re.split(r"^(.+:)", item, maxsplit=1)
+                # first ":" on the first line
+                _, attr, desc = re.split(r"^(.+?:)", item, maxsplit=1)
             except ValueError:
                 contents += " - " + indent(item, "   ")[3:]
             else:


### PR DESCRIPTION
This changes the Google docstring parser to match the first colon on the line rather than the last. This change means that this code:

```
Args:
    my_list: A list which defaults to: a, b, c 
```
will be highlighted as "**my_list**: A list which defaults to: a, b, c"  instead of the current "**my_list: A list which defaults to**: a, b, c".

[Google's styleguide](https://google.github.io/styleguide/pyguide.html#doc-function-args) does not explicitly state what should happen when there are multiple colons, but the description of the syntax implies that the first colon is the significant one because `:` is not a valid character in a Python identifier.

