### PR TITLE
Detect imports from TYPE_CHECKING blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # Unreleased: pdoc next
 
  - Display error webpage for template errors.
+ - When processing type hints, detect imports in 
+   [`TYPE_CHECKING`](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING) 
+   blocks.
 
 # 2021-08-09: pdoc 7.3.1
 

--- a/pdoc/_compat.py
+++ b/pdoc/_compat.py
@@ -19,7 +19,14 @@ else:  # pragma: no cover
 if sys.version_info >= (3, 9):
     from types import GenericAlias
 else:  # pragma: no cover
-    from typing import _GenericAlias as GenericAlias  # type: ignore
+    class GenericAlias:
+        pass
+
+if sys.version_info >= (3, 10):
+    from types import UnionType
+else:  # pragma: no cover
+    class UnionType:
+        pass
 
 if sys.version_info >= (3, 9):
     removesuffix = str.removesuffix
@@ -36,98 +43,6 @@ else:  # pragma: no cover
         if x.startswith(prefix):
             x = x[len(prefix):]
         return x
-
-if sys.version_info >= (3, 9):
-    from typing import ForwardRef
-else:  # pragma: no cover
-    from typing import _Final, _type_check, _GenericAlias
-
-    # https://github.com/python/cpython/blob/4db8988420e0a122d617df741381b0c385af032c/Lib/typing.py#L298-L314
-    # ✂ start ✂
-    def _eval_type(t, globalns, localns, recursive_guard=frozenset()):
-        """Evaluate all forward references in the given type t.
-        For use of globalns and localns see the docstring for get_type_hints().
-        recursive_guard is used to prevent prevent infinite recursion
-        with recursive ForwardRef.
-        """
-        if isinstance(t, ForwardRef):
-            return t._evaluate(globalns, localns, recursive_guard)
-        if isinstance(t, (_GenericAlias, GenericAlias)):
-            ev_args = tuple(_eval_type(a, globalns, localns, recursive_guard) for a in t.__args__)
-            if ev_args == t.__args__:
-                return t
-            if isinstance(t, GenericAlias):
-                return GenericAlias(t.__origin__, ev_args)
-            else:
-                return t.copy_with(ev_args)
-        return t
-    # ✂ end ✂
-
-    # https://github.com/python/cpython/blob/4db8988420e0a122d617df741381b0c385af032c/Lib/typing.py#L569-L629
-    # ✂ start ✂
-    class ForwardRef(_Final, _root=True):
-        """Internal wrapper to hold a forward reference."""
-
-        __slots__ = ('__forward_arg__', '__forward_code__',
-                     '__forward_evaluated__', '__forward_value__',
-                     '__forward_is_argument__')
-
-        def __init__(self, arg, is_argument=True):
-            if not isinstance(arg, str):
-                raise TypeError(f"Forward reference must be a string -- got {arg!r}")
-
-            # Double-stringified forward references is a result of activating
-            # the 'annotations' future by default. This way, we eliminate them in
-            # the runtime.
-            if arg.startswith(("'", '\"')) and arg.endswith(("'", '"')):
-                arg = arg[1:-1]
-
-            try:
-                code = compile(arg, '<string>', 'eval')
-            except SyntaxError:
-                raise SyntaxError(f"Forward reference must be an expression -- got {arg!r}")
-            self.__forward_arg__ = arg
-            self.__forward_code__ = code
-            self.__forward_evaluated__ = False
-            self.__forward_value__ = None
-            self.__forward_is_argument__ = is_argument
-
-        def _evaluate(self, globalns, localns, recursive_guard):
-            if self.__forward_arg__ in recursive_guard:
-                return self
-            if not self.__forward_evaluated__ or localns is not globalns:
-                if globalns is None and localns is None:
-                    globalns = localns = {}
-                elif globalns is None:
-                    globalns = localns
-                elif localns is None:
-                    localns = globalns
-                type_ = _type_check(
-                    eval(self.__forward_code__, globalns, localns),
-                    "Forward references must evaluate to types.",
-                    is_argument=self.__forward_is_argument__,
-                )
-                self.__forward_value__ = _eval_type(
-                    type_, globalns, localns, recursive_guard | {self.__forward_arg__}
-                )
-                self.__forward_evaluated__ = True
-            return self.__forward_value__
-
-        def __eq__(self, other):
-            if not isinstance(other, ForwardRef):
-                return NotImplemented
-            if self.__forward_evaluated__ and other.__forward_evaluated__:
-                return (self.__forward_arg__ == other.__forward_arg__ and
-                        self.__forward_value__ == other.__forward_value__)
-            return self.__forward_arg__ == other.__forward_arg__
-
-        def __hash__(self):
-            return hash(self.__forward_arg__)
-
-        def __repr__(self):
-            return f'ForwardRef({self.__forward_arg__!r})'
-    # ✂ end ✂
-
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -191,11 +106,11 @@ else:  # pragma: no cover
 if sys.version_info >= (3, 8):
     from typing import get_origin, get_args, Literal
 else:  # pragma: no cover
-    from typing import Generic
+    from typing import Generic, _GenericAlias
     import collections.abc
-    from unittest import mock
     # There is no Literal on 3.7, so we just make one up. It should not be used anyways!
-    Literal = mock.MagicMock()
+    class Literal:
+        pass
 
     # get_origin and get_args are adapted from
     # https://github.com/python/cpython/blob/863eb7170b3017399fb2b786a1e3feb6457e54c2/Lib/typing.py#L1474-L1515
@@ -273,11 +188,12 @@ __all__ = [
     "cache",
     "ast_unparse",
     "GenericAlias",
+    "UnionType",
     "removesuffix",
-    "ForwardRef",
     "cached_property",
     "get_origin",
     "get_args",
     "Literal",
     "_tuplegetter",
+    "BooleanOptionalAction",
 ]

--- a/pdoc/_compat.py
+++ b/pdoc/_compat.py
@@ -19,11 +19,10 @@ else:  # pragma: no cover
 if sys.version_info >= (3, 9):
     from types import GenericAlias
 else:  # pragma: no cover
-    class GenericAlias:
-        pass
+    from typing import _GenericAlias as GenericAlias
 
 if sys.version_info >= (3, 10):
-    from types import UnionType
+    from types import UnionType  # type: ignore
 else:  # pragma: no cover
     class UnionType:
         pass
@@ -109,6 +108,7 @@ else:  # pragma: no cover
     from typing import Generic, _GenericAlias
     import collections.abc
     # There is no Literal on 3.7, so we just make one up. It should not be used anyways!
+
     class Literal:
         pass
 

--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -833,11 +833,11 @@ class Function(Doc[types.FunctionType]):
         else:
             sig = sig.replace(
                 return_annotation=safe_eval_type(
-                    sig.return_annotation, globalns, self.fullname
+                    sig.return_annotation, globalns, mod, self.fullname
                 )
             )
         for p in sig.parameters.values():
-            p._annotation = safe_eval_type(p.annotation, globalns, self.fullname)  # type: ignore
+            p._annotation = safe_eval_type(p.annotation, globalns, mod, self.fullname)  # type: ignore
         return sig
 
     @cached_property

--- a/pdoc/doc_ast.py
+++ b/pdoc/doc_ast.py
@@ -168,6 +168,30 @@ def sort_by_source(
     return sorted, unsorted
 
 
+def type_checking_sections(mod: types.ModuleType) -> ast.Module:
+    """
+    Walks the abstract syntax tree for `mod` and returns all statements guarded by TYPE_CHECKING blocks.
+    """
+    ret = ast.Module(body=[], type_ignores=[])
+    tree = _parse_module(get_source(mod))
+    for node in tree.body:
+        if (
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.Name)
+            and node.test.id == "TYPE_CHECKING"
+        ):
+            ret.body.extend(node.body)
+        if (
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.Attribute)
+            and isinstance(node.test.value, ast.Name)
+            and node.test.value.id == "typing"
+            and node.test.attr == "TYPE_CHECKING"
+        ):
+            ret.body.extend(node.body)
+    return ret
+
+
 @cache
 def _parse_module(source: str) -> ast.Module:
     """

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -114,6 +114,7 @@ snapshots = [
         "logo_link": "https://example.com/",
         "footer_text": "custom footer text"
     }),
+    Snapshot("type_checking_imports"),
 ]
 
 

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -136,8 +136,8 @@ def test_snapshots(snapshot: Snapshot, format: str):
 
 
 if __name__ == "__main__":
-    if sys.version_info < (3, 9):  # pragma: no cover
-        raise RuntimeError("Snapshots need to be generated on Python 3.9+")
+    if sys.version_info < (3, 10):  # pragma: no cover
+        raise RuntimeError("Snapshots need to be generated on Python 3.10+")
     for snapshot in snapshots:
         for format in ["html", "repr"]:
             print(f"Rendering {snapshot} to {format}...")

--- a/test/testdata/misc_py310.py
+++ b/test/testdata/misc_py310.py
@@ -5,5 +5,9 @@ import demo_long
 bad_qualname = demo_long.DataDemo.__init__
 
 
-def new_union(a: int | str) -> bool | None:
+def new_union(a: int | dict[str, "Foo"]) -> bool | None:
     """Testing Python 3.10's new type union syntax."""""
+
+
+class Foo:
+    pass

--- a/test/testdata/misc_py310.txt
+++ b/test/testdata/misc_py310.txt
@@ -1,2 +1,4 @@
 <module misc_py310
-    <function def new_union(a: int | str) -> bool | None: ...  # Testing Python 3.10'…>>
+    <function def new_union(a: int | dict[str, misc_py310.Foo]) -> bool | None: ...  # Testing Python 3.10'…>
+    <class misc_py310.Foo
+        <method def __init__(): ...>>>

--- a/test/testdata/misc_py39.html
+++ b/test/testdata/misc_py39.html
@@ -38,6 +38,18 @@
                 </ul>
 
             </li>
+            <li>
+                    <a class="class" href="#Foo">Foo</a>
+                            <ul class="memberlist">
+                </ul>
+
+            </li>
+            <li>
+                    <a class="class" href="#Bar">Bar</a>
+                            <ul class="memberlist">
+                </ul>
+
+            </li>
     </ul>
 
 
@@ -62,7 +74,8 @@ misc_py39    </h1>
             <div class="codehilite"><pre><span></span><span class="sd">&quot;&quot;&quot;</span>
 <span class="sd">Testing features that either are 3.9+ only or render slightly different on 3.9.</span>
 <span class="sd">&quot;&quot;&quot;</span>
-<span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">NamedTuple</span>
+<span class="kn">from</span> <span class="nn">__future__</span> <span class="kn">import</span> <span class="n">annotations</span>
+<span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">NamedTuple</span><span class="p">,</span> <span class="n">Optional</span><span class="p">,</span> <span class="n">TypedDict</span>
 
 
 <span class="c1"># Testing a typing.NamedTuple</span>
@@ -77,6 +90,15 @@ misc_py39    </h1>
     <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
     <span class="sd">&quot;&quot;&quot;Name of our example tuple.&quot;&quot;&quot;</span>
     <span class="nb">id</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
+
+
+<span class="c1"># Testing some edge cases in our inlined implementation of ForwardRef._evaluate in _eval_type.</span>
+<span class="k">class</span> <span class="nc">Foo</span><span class="p">(</span><span class="n">TypedDict</span><span class="p">):</span>
+    <span class="n">a</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">int</span><span class="p">]</span>
+
+
+<span class="k">class</span> <span class="nc">Bar</span><span class="p">(</span><span class="n">Foo</span><span class="p">,</span> <span class="n">total</span><span class="o">=</span><span class="kc">False</span><span class="p">):</span>
+    <span class="n">b</span><span class="p">:</span> <span class="nb">int</span>
 </pre></div>
 
         </details>
@@ -149,6 +171,106 @@ misc_py39    </h1>
                                     <div><dt>builtins.tuple</dt>
                                 <dd id="NamedTupleExample.index" class="function">index</dd>
                 <dd id="NamedTupleExample.count" class="function">count</dd>
+
+            </div>
+                                </dl>
+                            </div>
+                </section>
+                <section id="Foo">
+                                <div class="attr class">
+        <a class="headerlink" href="#Foo">#&nbsp;&nbsp</a>
+
+        
+        <span class="def">class</span>
+        <span class="name">Foo</span><wbr>(<span class="base">typing.TypedDict</span>):
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Foo</span><span class="p">(</span><span class="n">TypedDict</span><span class="p">):</span>
+    <span class="n">a</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">int</span><span class="p">]</span>
+</pre></div>
+
+        </details>
+
+            <div class="docstring"><p>dict() -> new empty dictionary
+dict(mapping) -> new dictionary initialized from a mapping object's
+    (key, value) pairs
+dict(iterable) -> new dictionary initialized as if via:
+    d = {}
+    for k, v in iterable:
+        d[k] = v
+dict(**kwargs) -> new dictionary initialized with the name=value pairs
+    in the keyword argument list.  For example:  dict(one=1, two=2)</p>
+</div>
+
+
+                            <div class="inherited">
+                                <h5>Inherited Members</h5>
+                                <dl>
+                                    <div><dt>builtins.dict</dt>
+                                <dd id="Foo.__init__" class="class">dict</dd>
+                <dd id="Foo.get" class="function">get</dd>
+                <dd id="Foo.setdefault" class="function">setdefault</dd>
+                <dd id="Foo.pop" class="function">pop</dd>
+                <dd id="Foo.popitem" class="function">popitem</dd>
+                <dd id="Foo.keys" class="function">keys</dd>
+                <dd id="Foo.items" class="function">items</dd>
+                <dd id="Foo.values" class="function">values</dd>
+                <dd id="Foo.update" class="function">update</dd>
+                <dd id="Foo.fromkeys" class="function">fromkeys</dd>
+                <dd id="Foo.clear" class="function">clear</dd>
+                <dd id="Foo.copy" class="function">copy</dd>
+
+            </div>
+                                </dl>
+                            </div>
+                </section>
+                <section id="Bar">
+                                <div class="attr class">
+        <a class="headerlink" href="#Bar">#&nbsp;&nbsp</a>
+
+        
+        <span class="def">class</span>
+        <span class="name">Bar</span><wbr>(<span class="base">builtins.dict</span>):
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Bar</span><span class="p">(</span><span class="n">Foo</span><span class="p">,</span> <span class="n">total</span><span class="o">=</span><span class="kc">False</span><span class="p">):</span>
+    <span class="n">b</span><span class="p">:</span> <span class="nb">int</span>
+</pre></div>
+
+        </details>
+
+            <div class="docstring"><p>dict() -> new empty dictionary
+dict(mapping) -> new dictionary initialized from a mapping object's
+    (key, value) pairs
+dict(iterable) -> new dictionary initialized as if via:
+    d = {}
+    for k, v in iterable:
+        d[k] = v
+dict(**kwargs) -> new dictionary initialized with the name=value pairs
+    in the keyword argument list.  For example:  dict(one=1, two=2)</p>
+</div>
+
+
+                            <div class="inherited">
+                                <h5>Inherited Members</h5>
+                                <dl>
+                                    <div><dt>builtins.dict</dt>
+                                <dd id="Bar.__init__" class="class">dict</dd>
+                <dd id="Bar.get" class="function">get</dd>
+                <dd id="Bar.setdefault" class="function">setdefault</dd>
+                <dd id="Bar.pop" class="function">pop</dd>
+                <dd id="Bar.popitem" class="function">popitem</dd>
+                <dd id="Bar.keys" class="function">keys</dd>
+                <dd id="Bar.items" class="function">items</dd>
+                <dd id="Bar.values" class="function">values</dd>
+                <dd id="Bar.update" class="function">update</dd>
+                <dd id="Bar.fromkeys" class="function">fromkeys</dd>
+                <dd id="Bar.clear" class="function">clear</dd>
+                <dd id="Bar.copy" class="function">copy</dd>
 
             </div>
                                 </dl>

--- a/test/testdata/misc_py39.py
+++ b/test/testdata/misc_py39.py
@@ -1,7 +1,8 @@
 """
 Testing features that either are 3.9+ only or render slightly different on 3.9.
 """
-from typing import NamedTuple
+from __future__ import annotations
+from typing import NamedTuple, Optional, TypedDict
 
 
 # Testing a typing.NamedTuple
@@ -16,3 +17,12 @@ class NamedTupleExample(NamedTuple):
     name: str
     """Name of our example tuple."""
     id: int = 3
+
+
+# Testing some edge cases in our inlined implementation of ForwardRef._evaluate in _eval_type.
+class Foo(TypedDict):
+    a: Optional[int]
+
+
+class Bar(Foo, total=False):
+    b: int

--- a/test/testdata/misc_py39.txt
+++ b/test/testdata/misc_py39.txt
@@ -4,4 +4,54 @@
         <var name: str  # Name of our example …>
         <var id: int  # Alias for field numb…>
         <method def index(self, value, start=0, stop=9223372036854775807, /): ...  # inherited from builtins.tuple.index, Return first index o…>
-        <method def count(self, value, /): ...  # inherited from builtins.tuple.count, Return number of occ…>>>
+        <method def count(self, value, /): ...  # inherited from builtins.tuple.count, Return number of occ…>>
+    <class misc_py39.Foo  # dict() -> new empty …
+        <class misc_py39.Foo.__init__  # inherited from builtins.dict.__init__, dict() -> new empty …
+            <method def __init__(self, /, *args, **kwargs): ...  # inherited from builtins.dict.__init__>
+            <method def get(self, key, default=None, /): ...  # inherited from builtins.dict.get, Return the value for…>
+            <method def setdefault(self, key, default=None, /): ...  # inherited from builtins.dict.setdefault, Insert key with a va…>
+            <method def pop(unknown): ...  # inherited from builtins.dict.pop, D.pop(k[,d]) -> v, r…>
+            <method def popitem(self, /): ...  # inherited from builtins.dict.popitem, Remove and return a …>
+            <method def keys(unknown): ...  # inherited from builtins.dict.keys, D.keys() -> a set-li…>
+            <method def items(unknown): ...  # inherited from builtins.dict.items, D.items() -> a set-l…>
+            <method def values(unknown): ...  # inherited from builtins.dict.values, D.values() -> an obj…>
+            <method def update(unknown): ...  # inherited from builtins.dict.update, D.update([E, ]**F) -…>
+            <method def fromkeys(type, iterable, value=None, /): ...  # inherited from builtins.dict.fromkeys, Create a new diction…>
+            <method def clear(unknown): ...  # inherited from builtins.dict.clear, D.clear() -> None.  …>
+            <method def copy(unknown): ...  # inherited from builtins.dict.copy, D.copy() -> a shallo…>>
+        <method def get(self, key, default=None, /): ...  # inherited from builtins.dict.get, Return the value for…>
+        <method def setdefault(self, key, default=None, /): ...  # inherited from builtins.dict.setdefault, Insert key with a va…>
+        <method def pop(unknown): ...  # inherited from builtins.dict.pop, D.pop(k[,d]) -> v, r…>
+        <method def popitem(self, /): ...  # inherited from builtins.dict.popitem, Remove and return a …>
+        <method def keys(unknown): ...  # inherited from builtins.dict.keys, D.keys() -> a set-li…>
+        <method def items(unknown): ...  # inherited from builtins.dict.items, D.items() -> a set-l…>
+        <method def values(unknown): ...  # inherited from builtins.dict.values, D.values() -> an obj…>
+        <method def update(unknown): ...  # inherited from builtins.dict.update, D.update([E, ]**F) -…>
+        <method def fromkeys(type, iterable, value=None, /): ...  # inherited from builtins.dict.fromkeys, Create a new diction…>
+        <method def clear(unknown): ...  # inherited from builtins.dict.clear, D.clear() -> None.  …>
+        <method def copy(unknown): ...  # inherited from builtins.dict.copy, D.copy() -> a shallo…>>
+    <class misc_py39.Bar  # dict() -> new empty …
+        <class misc_py39.Bar.__init__  # inherited from builtins.dict.__init__, dict() -> new empty …
+            <method def __init__(self, /, *args, **kwargs): ...  # inherited from builtins.dict.__init__>
+            <method def get(self, key, default=None, /): ...  # inherited from builtins.dict.get, Return the value for…>
+            <method def setdefault(self, key, default=None, /): ...  # inherited from builtins.dict.setdefault, Insert key with a va…>
+            <method def pop(unknown): ...  # inherited from builtins.dict.pop, D.pop(k[,d]) -> v, r…>
+            <method def popitem(self, /): ...  # inherited from builtins.dict.popitem, Remove and return a …>
+            <method def keys(unknown): ...  # inherited from builtins.dict.keys, D.keys() -> a set-li…>
+            <method def items(unknown): ...  # inherited from builtins.dict.items, D.items() -> a set-l…>
+            <method def values(unknown): ...  # inherited from builtins.dict.values, D.values() -> an obj…>
+            <method def update(unknown): ...  # inherited from builtins.dict.update, D.update([E, ]**F) -…>
+            <method def fromkeys(type, iterable, value=None, /): ...  # inherited from builtins.dict.fromkeys, Create a new diction…>
+            <method def clear(unknown): ...  # inherited from builtins.dict.clear, D.clear() -> None.  …>
+            <method def copy(unknown): ...  # inherited from builtins.dict.copy, D.copy() -> a shallo…>>
+        <method def get(self, key, default=None, /): ...  # inherited from builtins.dict.get, Return the value for…>
+        <method def setdefault(self, key, default=None, /): ...  # inherited from builtins.dict.setdefault, Insert key with a va…>
+        <method def pop(unknown): ...  # inherited from builtins.dict.pop, D.pop(k[,d]) -> v, r…>
+        <method def popitem(self, /): ...  # inherited from builtins.dict.popitem, Remove and return a …>
+        <method def keys(unknown): ...  # inherited from builtins.dict.keys, D.keys() -> a set-li…>
+        <method def items(unknown): ...  # inherited from builtins.dict.items, D.items() -> a set-l…>
+        <method def values(unknown): ...  # inherited from builtins.dict.values, D.values() -> an obj…>
+        <method def update(unknown): ...  # inherited from builtins.dict.update, D.update([E, ]**F) -…>
+        <method def fromkeys(type, iterable, value=None, /): ...  # inherited from builtins.dict.fromkeys, Create a new diction…>
+        <method def clear(unknown): ...  # inherited from builtins.dict.clear, D.clear() -> None.  …>
+        <method def copy(unknown): ...  # inherited from builtins.dict.copy, D.copy() -> a shallo…>>>

--- a/test/testdata/type_checking_imports.html
+++ b/test/testdata/type_checking_imports.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="generator" content="pdoc $VERSION" />
-    <title>misc_py310 API documentation</title>
+    <title>type_checking_imports API documentation</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2264%22%20height%3D%2264%22%20viewBox%3D%2244.5%202.5%2015%2015%22%3E%3Cpath%20d%3D%22M49.351%2021.041c-.233-.721-.546-2.408-.772-4.076-.042-.09-.067-.187-.046-.288-.166-1.347-.277-2.625-.241-3.351-1.378-1.008-2.271-2.586-2.271-4.362%200-.976.272-1.935.788-2.774.057-.094.122-.18.184-.268-.033-.167-.052-.339-.052-.516%200-1.477%201.202-2.679%202.679-2.679.791%200%201.496.352%201.987.9a6.3%206.3%200%200%201%201.001.029c.492-.564%201.207-.929%202.012-.929%201.477%200%202.679%201.202%202.679%202.679a2.65%202.65%200%200%201-.269%201.148c.383.747.595%201.572.595%202.41%200%202.311-1.507%204.29-3.635%205.107.037.699.147%202.27.423%203.294l.137.461c.156%202.136-4.612%205.166-5.199%203.215zm.127-4.919a4.78%204.78%200%200%200%20.775-.584c-.172-.115-.505-.254-.88-.378zm.331%202.302l.828-.502c-.202-.143-.576-.328-.984-.49zm.45%202.157l.701-.403c-.214-.115-.536-.249-.891-.376l.19.779zM49.13%204.141c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm.735-.389a1.15%201.15%200%200%201%20.314.783%201.16%201.16%200%200%201-1.162%201.162c-.457%200-.842-.27-1.032-.653-.026.117-.042.238-.042.362a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.843-.626-1.535-1.436-1.654zm3.076%201.654a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.037-.009-.072-.011-.109-.21.3-.541.508-.935.508a1.16%201.16%200%200%201-1.162-1.162%201.14%201.14%200%200%201%20.474-.912c-.015%200-.03-.005-.045-.005-.926.001-1.679.754-1.679%201.68zm1.861-1.265c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm1.823%204.823c0-.52-.103-1.035-.288-1.52-.466.394-1.06.64-1.717.64-1.144%200-2.116-.725-2.499-1.738-.383%201.012-1.355%201.738-2.499%201.738-.867%200-1.631-.421-2.121-1.062-.307.605-.478%201.267-.478%201.942%200%202.486%202.153%204.51%204.801%204.51s4.801-2.023%204.801-4.51zm-3.032%209.156l-.146-.492c-.276-1.02-.395-2.457-.444-3.268a6.11%206.11%200%200%201-1.18.115%206.01%206.01%200%200%201-2.536-.562l.006.175c.802.215%201.848.612%202.021%201.25.079.295-.021.601-.274.837l-.598.501c.667.304%201.243.698%201.311%201.179.02.144.022.507-.393.787l-.564.365c1.285.521%201.361.96%201.381%201.126.018.142.011.496-.427.746l-.854.489c.064-1.19%201.985-2.585%202.697-3.248zM49.34%209.925c0-.667%201-.667%201%200%200%20.653.818%201.205%201.787%201.205s1.787-.552%201.787-1.205c0-.667%201-.667%201%200%200%201.216-1.25%202.205-2.787%202.205s-2.787-.989-2.787-2.205zm-.887-7.633c-.093.077-.205.114-.317.114a.5.5%200%200%201-.318-.886L49.183.397a.5.5%200%200%201%20.703.068.5.5%200%200%201-.069.703zm7.661-.065c-.086%200-.173-.022-.253-.068l-1.523-.893c-.575-.337-.069-1.2.506-.863l1.523.892a.5.5%200%200%201%20.179.685c-.094.158-.261.247-.432.247z%22%20fill%3D%22%233bb300%22/%3E%3C/svg%3E"/>
 
 
@@ -24,16 +24,7 @@
                     <h2>API Documentation</h2>
                         <ul class="memberlist">
             <li>
-                    <a class="function" href="#new_union">new_union</a>
-            </li>
-            <li>
-                    <a class="class" href="#Foo">Foo</a>
-                            <ul class="memberlist">
-                        <li>
-                                <a class="function" href="#Foo.__init__">Foo</a>
-                        </li>
-                </ul>
-
+                    <a class="function" href="#foo">foo</a>
             </li>
     </ul>
 
@@ -49,62 +40,41 @@
     <main class="pdoc">
             <section>
                     <h1 class="modulename">
-misc_py310    </h1>
+type_checking_imports    </h1>
 
                 
                         <details>
             <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="kn">import</span> <span class="nn">demo_long</span>
+            <div class="codehilite"><pre><span></span><span class="kn">from</span> <span class="nn">__future__</span> <span class="kn">import</span> <span class="n">annotations</span>
 
-<span class="c1"># Testing a proper __module__, but no useful __qualname__ attribute.</span>
+<span class="kn">import</span> <span class="nn">typing</span>
+<span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">TYPE_CHECKING</span>
 
-<span class="n">bad_qualname</span> <span class="o">=</span> <span class="n">demo_long</span><span class="o">.</span><span class="n">DataDemo</span><span class="o">.</span><span class="fm">__init__</span>
+<span class="k">if</span> <span class="n">typing</span><span class="o">.</span><span class="n">TYPE_CHECKING</span><span class="p">:</span>
+    <span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">Sequence</span>
+
+<span class="k">if</span> <span class="n">TYPE_CHECKING</span><span class="p">:</span>
+    <span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">Dict</span>
 
 
-<span class="k">def</span> <span class="nf">new_union</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="s2">&quot;Foo&quot;</span><span class="p">])</span> <span class="o">-&gt;</span> <span class="nb">bool</span> <span class="o">|</span> <span class="kc">None</span><span class="p">:</span>
-    <span class="sd">&quot;&quot;&quot;Testing Python 3.10&#39;s new type union syntax.&quot;&quot;&quot;</span><span class="s2">&quot;&quot;</span>
-
-
-<span class="k">class</span> <span class="nc">Foo</span><span class="p">:</span>
+<span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">],</span> <span class="n">b</span><span class="p">:</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]):</span>
     <span class="k">pass</span>
 </pre></div>
 
         </details>
 
             </section>
-                <section id="new_union">
-                            <div class="attr function"><a class="headerlink" href="#new_union">#&nbsp;&nbsp</a>
+                <section id="foo">
+                            <div class="attr function"><a class="headerlink" href="#foo">#&nbsp;&nbsp</a>
 
         
             <span class="def">def</span>
-            <span class="name">new_union</span><span class="signature">(a: int | dict[str, <a href="#Foo">misc_py310.Foo</a>]) -&gt; bool | None</span>:
+            <span class="name">foo</span><span class="signature">(a: Sequence[str], b: Dict[str, str])</span>:
     </div>
 
                 <details>
             <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">def</span> <span class="nf">new_union</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="s2">&quot;Foo&quot;</span><span class="p">])</span> <span class="o">-&gt;</span> <span class="nb">bool</span> <span class="o">|</span> <span class="kc">None</span><span class="p">:</span>
-    <span class="sd">&quot;&quot;&quot;Testing Python 3.10&#39;s new type union syntax.&quot;&quot;&quot;</span><span class="s2">&quot;&quot;</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Testing Python 3.10's new type union syntax.</p>
-</div>
-
-
-                </section>
-                <section id="Foo">
-                                <div class="attr class">
-        <a class="headerlink" href="#Foo">#&nbsp;&nbsp</a>
-
-        
-        <span class="def">class</span>
-        <span class="name">Foo</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Foo</span><span class="p">:</span>
+            <div class="codehilite"><pre><span></span><span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">],</span> <span class="n">b</span><span class="p">:</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]):</span>
     <span class="k">pass</span>
 </pre></div>
 
@@ -112,17 +82,6 @@ misc_py310    </h1>
 
     
 
-                            <div id="Foo.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Foo.__init__">#&nbsp;&nbsp</a>
-
-        
-            <span class="name">Foo</span><span class="signature">()</span>
-    </div>
-
-        
-    
-
-                            </div>
                 </section>
     </main>
 </body>

--- a/test/testdata/type_checking_imports.py
+++ b/test/testdata/type_checking_imports.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import typing
+from typing import TYPE_CHECKING
+
+if typing.TYPE_CHECKING:
+    from typing import Sequence
+
+if TYPE_CHECKING:
+    from typing import Dict
+
+
+def foo(a: Sequence[str], b: Dict[str, str]):
+    pass

--- a/test/testdata/type_checking_imports.txt
+++ b/test/testdata/type_checking_imports.txt
@@ -1,0 +1,2 @@
+<module type_checking_imports
+    <function def foo(a: Sequence[str], b: Dict[str, str]): ...>>


### PR DESCRIPTION
This PR fixes #291. If pdoc cannot ordinarily resolve a forward reference type hint, it now tries to execute the contents of `if TYPE_CHECKING` or `if typing.TYPE_CHECKING` blocks in the current namespace before re-executing the forward reference.