### PR TITLE
Prefer epydoc-style docstrings after variable assignments over the variable's `__doc__`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Unreleased: pdoc next
 
  - Add CSS styling for Markdown tables. (@sitic)
+ - Prefer epydoc-style docstrings after variable assignments 
+   over the variable's `__doc__`.
 
 # 2021-10-29: pdoc 8.0.1
 

--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -270,20 +270,26 @@ class Namespace(Doc[T], metaclass=ABCMeta):
                 doc = Module(obj)
                 doc.modulename = self.modulename
                 doc.qualname = qualname
-            else:
-                docstring = self._var_docstrings.get(name, "")
-                default_value = obj
-                if not docstring and inspect.isdatadescriptor(obj):
-                    docstring = getattr(obj, "__doc__", None) or ""
-                    default_value = empty
+            elif inspect.isdatadescriptor(obj):
                 doc = Variable(
                     self.modulename,
                     qualname,
-                    docstring=docstring,
+                    docstring=getattr(obj, "__doc__", None) or "",
                     annotation=self._var_annotations.get(name, empty),
-                    default_value=default_value,
+                    default_value=empty,
                     taken_from=taken_from,
                 )
+            else:
+                doc = Variable(
+                    self.modulename,
+                    qualname,
+                    docstring="",
+                    annotation=self._var_annotations.get(name, empty),
+                    default_value=obj,
+                    taken_from=taken_from,
+                )
+            if self._var_docstrings.get(name):
+                doc.docstring = self._var_docstrings[name]
             members[doc.name] = doc
         return members
 

--- a/pdoc/extract.py
+++ b/pdoc/extract.py
@@ -119,7 +119,7 @@ def parse_spec(spec: Union[Path, str]) -> str:
             return parse_spec(spec.resolve().parent) + f".{spec.stem}"
         if str(spec.parent) not in sys.path:
             sys.path.insert(0, str(spec.parent))
-        if spec.stem in sys.modules:
+        if spec.stem in sys.modules and sys.modules[spec.stem].__file__:
             local_dir = spec.resolve()
             origin = Path(sys.modules[spec.stem].__file__).resolve()
             if local_dir not in (origin, origin.parent, origin.with_suffix("")):

--- a/test/testdata/misc.html
+++ b/test/testdata/misc.html
@@ -197,6 +197,15 @@
                 </ul>
 
             </li>
+            <li>
+                    <a class="function" href="#add_four">add_four</a>
+            </li>
+            <li>
+                    <a class="function" href="#add_five">add_five</a>
+            </li>
+            <li>
+                    <a class="function" href="#add_six">add_six</a>
+            </li>
     </ul>
 
 
@@ -255,7 +264,7 @@ misc    </h1>
 <span class="n">var_with_default_obj</span> <span class="o">=</span> <span class="n">default_obj</span>
 <span class="sd">&quot;&quot;&quot;this shouldn&#39;t render the object address&quot;&quot;&quot;</span>
 <span class="n">var_with_default_func</span> <span class="o">=</span> <span class="n">default_func</span>
-<span class="sd">&quot;&quot;&quot;this just render like a normal function&quot;&quot;&quot;</span>
+<span class="sd">&quot;&quot;&quot;this just renders like a normal function&quot;&quot;&quot;</span>
 
 
 <span class="k">def</span> <span class="nf">func_with_defaults</span><span class="p">(</span>
@@ -496,6 +505,21 @@ misc    </h1>
         <span class="k">pass</span>
 
 
+<span class="c1"># Adapted from https://github.com/mitmproxy/pdoc/issues/320</span>
+
+<span class="k">def</span> <span class="nf">make_adder</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">add_func</span><span class="p">(</span><span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+        <span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
+        <span class="k">return</span> <span class="n">a</span> <span class="o">+</span> <span class="n">b</span>
+    <span class="k">return</span> <span class="n">add_func</span>
+
+
+<span class="n">add_four</span> <span class="o">=</span> <span class="n">make_adder</span><span class="p">(</span><span class="mi">4</span><span class="p">)</span>
+<span class="n">add_five</span> <span class="o">=</span> <span class="n">make_adder</span><span class="p">(</span><span class="mi">5</span><span class="p">)</span>
+<span class="sd">&quot;&quot;&quot;This function adds five.&quot;&quot;&quot;</span>
+<span class="n">add_six</span> <span class="o">=</span> <span class="n">make_adder</span><span class="p">(</span><span class="mi">6</span><span class="p">)</span>
+<span class="n">add_six</span><span class="o">.</span><span class="vm">__doc__</span> <span class="o">=</span> <span class="s2">&quot;This function adds six.&quot;</span>
+
 <span class="n">__all__</span> <span class="o">=</span> <span class="p">[</span>  <span class="c1"># noqa</span>
     <span class="s2">&quot;Issue226&quot;</span><span class="p">,</span>
     <span class="s2">&quot;var_with_default_obj&quot;</span><span class="p">,</span>
@@ -517,6 +541,9 @@ misc    </h1>
     <span class="s2">&quot;fun_with_protected_decorator&quot;</span><span class="p">,</span>
     <span class="s2">&quot;unhashable&quot;</span><span class="p">,</span>
     <span class="s2">&quot;AbstractClass&quot;</span><span class="p">,</span>
+    <span class="s2">&quot;add_four&quot;</span><span class="p">,</span>
+    <span class="s2">&quot;add_five&quot;</span><span class="p">,</span>
+    <span class="s2">&quot;add_six&quot;</span><span class="p">,</span>
 <span class="p">]</span>
 </pre></div>
 
@@ -594,7 +621,9 @@ misc    </h1>
 
         </details>
 
-    
+            <div class="docstring"><p>this just renders like a normal function</p>
+</div>
+
 
                 </section>
                 <section id="func_with_defaults">
@@ -1587,6 +1616,72 @@ indents</p>
     
 
                             </div>
+                </section>
+                <section id="add_four">
+                            <div class="attr function"><a class="headerlink" href="#add_four">#&nbsp;&nbsp</a>
+
+        
+            <span class="def">def</span>
+            <span class="name">add_four</span><span class="signature">(b: int) -&gt; int</span>:
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">add_func</span><span class="p">(</span><span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+        <span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
+        <span class="k">return</span> <span class="n">a</span> <span class="o">+</span> <span class="n">b</span>
+</pre></div>
+
+        </details>
+
+            <div class="docstring"><p>This function adds two numbers.</p>
+</div>
+
+
+                </section>
+                <section id="add_five">
+                            <div class="attr function"><a class="headerlink" href="#add_five">#&nbsp;&nbsp</a>
+
+        
+            <span class="def">def</span>
+            <span class="name">add_five</span><span class="signature">(b: int) -&gt; int</span>:
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">add_func</span><span class="p">(</span><span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+        <span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
+        <span class="k">return</span> <span class="n">a</span> <span class="o">+</span> <span class="n">b</span>
+</pre></div>
+
+        </details>
+
+            <div class="docstring"><p>This function adds five.</p>
+</div>
+
+
+                </section>
+                <section id="add_six">
+                            <div class="attr function"><a class="headerlink" href="#add_six">#&nbsp;&nbsp</a>
+
+        
+            <span class="def">def</span>
+            <span class="name">add_six</span><span class="signature">(b: int) -&gt; int</span>:
+    </div>
+
+                <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">add_func</span><span class="p">(</span><span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+        <span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
+        <span class="k">return</span> <span class="n">a</span> <span class="o">+</span> <span class="n">b</span>
+</pre></div>
+
+        </details>
+
+            <div class="docstring"><p>This function adds six.</p>
+</div>
+
+
                 </section>
     </main>
 </body>

--- a/test/testdata/misc.py
+++ b/test/testdata/misc.py
@@ -37,7 +37,7 @@ default_obj = object()
 var_with_default_obj = default_obj
 """this shouldn't render the object address"""
 var_with_default_func = default_func
-"""this just render like a normal function"""
+"""this just renders like a normal function"""
 
 
 def func_with_defaults(
@@ -278,6 +278,21 @@ class AbstractClass(metaclass=abc.ABCMeta):
         pass
 
 
+# Adapted from https://github.com/mitmproxy/pdoc/issues/320
+
+def make_adder(a: int):
+    def add_func(b: int) -> int:
+        """This function adds two numbers."""
+        return a + b
+    return add_func
+
+
+add_four = make_adder(4)
+add_five = make_adder(5)
+"""This function adds five."""
+add_six = make_adder(6)
+add_six.__doc__ = "This function adds six."
+
 __all__ = [  # noqa
     "Issue226",
     "var_with_default_obj",
@@ -299,4 +314,7 @@ __all__ = [  # noqa
     "fun_with_protected_decorator",
     "unhashable",
     "AbstractClass",
+    "add_four",
+    "add_five",
+    "add_six",
 ]

--- a/test/testdata/misc.txt
+++ b/test/testdata/misc.txt
@@ -3,7 +3,7 @@
         <method def __init__(): ...>
         <var size  # This is the size>>
     <var var_with_default_obj = <object object>  # this shouldn't rende…>
-    <method def var_with_default_func(): ...  # inherited from misc.default_func>
+    <method def var_with_default_func(): ...  # inherited from misc.default_func, this just renders li…>
     <function def func_with_defaults(a=<object object>, b=<function default_func>): ...  # this shouldn't rende…>
     <class misc.ClassmethodLink  # You can either do
 
@@ -58,4 +58,7 @@
     <@_protected_decorator function def fun_with_protected_decorator(): ...  # This function has a …>
     <method def unhashable(unknown): ...>
     <class misc.AbstractClass  # This class shouldn't…
-        <@abc.abstractmethod method def foo(self): ...>>>
+        <@abc.abstractmethod method def foo(self): ...>>
+    <method def add_four(b: int) -> int: ...  # This function adds t…>
+    <method def add_five(b: int) -> int: ...  # This function adds f…>
+    <method def add_six(b: int) -> int: ...  # This function adds s…>>


### PR DESCRIPTION
This fixes #320