### PR TITLE
Add an option to ignore modules with a regex 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    *View Source* button.
  - Add negated module specs to exclude specific (sub)modules.
    For example, `pdoc foo !foo.bar` documents `foo` and all submodules of `foo` except `foo.bar`.
+ - Only display headings up to a depth of 2 in the table of contents for module docstrings.
 
 # 2022-01-05: pdoc 8.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
  - Work around a Blink renderer bug to make sure that the small "expand" triangle is displayed next to the
    *View Source* button.
+ - Add negated module specs to exclude specific (sub)modules.
+   For example, `pdoc foo !foo.bar` documents `foo` and all submodules of `foo` except `foo.bar`.
 
 # 2022-01-05: pdoc 8.2.0
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -64,7 +64,7 @@ Additionally, all docstrings are interpreted as Markdown.
 For example, the todo list in the example will be rendered with bullet points in your documentation.
 
 
-### Invoking pdoc
+## Invoking pdoc
 
 Let's run pdoc on this module to see what we get:
 
@@ -82,7 +82,7 @@ pdoc -o ./docs ./shelter.py
 
 This will create an HTML file at `docs/shelter.html` which contains our module documentation.
 
-### Configuring pdoc
+## Configuring pdoc
 
 We can configure some parts of pdoc's output via command line flags.
 For example, we can add a project logo to the documentation:
@@ -100,7 +100,7 @@ pdoc --help
 Library users can call `pdoc.render.configure` to configure rendering.
 
 
-### Editing pdoc's HTML template
+## Editing pdoc's HTML template
 
 For more advanced customization, we can edit pdoc's
 [default HTML template](https://github.com/mitmproxy/pdoc/blob/main/pdoc/templates/default/module.html.jinja2),

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -373,7 +373,8 @@ from pdoc._compat import Literal
 def pdoc(
     *modules: Union[Path, str],
     output_directory: Optional[Path] = None,
-    format: Literal["html"] = "html") -> str:
+    format: Literal["html"] = "html",
+) -> str:
     """
     Render the documentation for a list of modules.
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -364,6 +364,7 @@ import io
 import traceback
 import warnings
 from pathlib import Path
+from re import Pattern
 from typing import Optional, Union
 
 from pdoc import doc, extract, render
@@ -374,6 +375,7 @@ def pdoc(
     *modules: Union[Path, str],
     output_directory: Optional[Path] = None,
     format: Literal["html"] = "html",
+    ignore_pattern: Optional[Pattern] = None
 ) -> str:
     """
     Render the documentation for a list of modules.
@@ -399,7 +401,7 @@ def pdoc(
         def write(mod: doc.Module):
             retval.write(r(mod))
 
-    all_modules = extract.walk_specs(modules)
+    all_modules = extract.walk_specs(modules, ignore_pattern)
     doc_objects: dict[str, doc.Module] = {}
 
     if format == "html":

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -364,7 +364,6 @@ import io
 import traceback
 import warnings
 from pathlib import Path
-from re import Pattern
 from typing import Optional, Union
 
 from pdoc import doc, extract, render
@@ -374,9 +373,7 @@ from pdoc._compat import Literal
 def pdoc(
     *modules: Union[Path, str],
     output_directory: Optional[Path] = None,
-    format: Literal["html"] = "html",
-    ignore_pattern: Optional[Pattern] = None
-) -> str:
+    format: Literal["html"] = "html") -> str:
     """
     Render the documentation for a list of modules.
 
@@ -401,7 +398,7 @@ def pdoc(
         def write(mod: doc.Module):
             retval.write(r(mod))
 
-    all_modules = extract.walk_specs(modules, ignore_pattern)
+    all_modules = extract.walk_specs(modules)
     doc_objects: dict[str, doc.Module] = {}
 
     if format == "html":

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -218,6 +218,20 @@ As a last resort, you can override pdoc's behavior with a custom module template
 You can find an example at
 [`examples/custom-template/module.html.jinja2`](https://github.com/mitmproxy/pdoc/blob/main/examples/custom-template/module.html.jinja2).
 
+### ...exclude submodules from being documented?
+
+If you would like to exclude specific submodules from the documentation, the recommended way is to specify `__all__` as
+shown in the previous section. Alternatively, you can pass negative regular expression `!patterns` as part of the
+module specification. Each pattern removes all previously specified (sub)module names that match. For example, the following
+invocation documents `foo` and all submodules of `foo`, but not `foo.bar`:
+
+```
+pdoc foo !foo.bar
+```
+
+Likewise, `pdoc pdoc !pdoc.` would document the pdoc module itself, but none of its submodules. Patterns are always
+matched on the final module name, even if modules are passed as file paths.
+
 ## ...link to other identifiers?
 
 In your documentation, you can link to other identifiers by enclosing them in backticks:

--- a/pdoc/__main__.py
+++ b/pdoc/__main__.py
@@ -45,13 +45,7 @@ mainargs.add_argument(
     type=Path,
     help="Write rendered documentation to the specified directory, don't start a webserver.",
 )
-mainargs.add_argument(
-    "-i",
-    "--ignore",
-    metavar="PATTERN",
-    type=str,
-    help="Ignore modules matching the given regular expression pattern.",
-)
+
 # may be added again in the future:
 # formats = parser.add_mutually_exclusive_group()
 # formats.add_argument("--html", dest="format", action="store_const", const="html")
@@ -187,18 +181,15 @@ def cli(args: list[str] = None) -> None:
         footer_text=opts.footer_text,
     )
 
-    ignore_pattern = re.compile(opts.ignore) if opts.ignore else None
-
     if opts.output_directory:
         pdoc.pdoc(
             *opts.modules,
             output_directory=opts.output_directory,
-            format="html",  # opts.format or
-            ignore_pattern=ignore_pattern,
+            format="html"  # opts.format or
         )
         return
     else:
-        all_modules = extract.walk_specs(opts.modules, ignore_pattern)
+        all_modules = extract.walk_specs(opts.modules)
         with pdoc.web.DocServer(
             (opts.host, opts.port),
             all_modules,

--- a/pdoc/__main__.py
+++ b/pdoc/__main__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import platform
-import re
 import subprocess
 import sys
 import warnings
@@ -45,7 +44,6 @@ mainargs.add_argument(
     type=Path,
     help="Write rendered documentation to the specified directory, don't start a webserver.",
 )
-
 # may be added again in the future:
 # formats = parser.add_mutually_exclusive_group()
 # formats.add_argument("--html", dest="format", action="store_const", const="html")
@@ -185,7 +183,7 @@ def cli(args: list[str] = None) -> None:
         pdoc.pdoc(
             *opts.modules,
             output_directory=opts.output_directory,
-            format="html"  # opts.format or
+            format="html",  # opts.format or
         )
         return
     else:

--- a/pdoc/__main__.py
+++ b/pdoc/__main__.py
@@ -35,7 +35,8 @@ mainargs.add_argument(
     default=[],
     metavar="module",
     nargs="*",
-    help='Python module names. These may be importable Python module names ("pdoc.doc") or file paths ("./pdoc/doc.py").',
+    help='Python module names. These may be importable Python module names ("pdoc.doc") or file paths ("./pdoc/doc.py")'
+    '. Exclude submodules by specifying a negative !regex pattern, e.g. "foo !foo.bar".',
 )
 mainargs.add_argument(
     "-o",
@@ -195,7 +196,7 @@ def cli(args: list[str] = None) -> None:
             url = f"http://{opts.host}:{opts.port}"
             print(f"pdoc server ready at {url}")
             if not opts.no_browser:
-                if len(opts.modules) == 1:
+                if len(opts.modules) == 1 or len(all_modules) == 1:
                     mod = next(iter(all_modules))
                     url += f"/{mod.replace('.', '/')}.html"
                 pdoc.web.open_browser(url)

--- a/pdoc/__main__.py
+++ b/pdoc/__main__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import platform
+import re
 import subprocess
 import sys
 import warnings
@@ -43,6 +44,13 @@ mainargs.add_argument(
     metavar="DIR",
     type=Path,
     help="Write rendered documentation to the specified directory, don't start a webserver.",
+)
+mainargs.add_argument(
+    "-i",
+    "--ignore",
+    metavar="PATTERN",
+    type=str,
+    help="Ignore modules matching the given regular expression pattern.",
 )
 # may be added again in the future:
 # formats = parser.add_mutually_exclusive_group()
@@ -179,15 +187,18 @@ def cli(args: list[str] = None) -> None:
         footer_text=opts.footer_text,
     )
 
+    ignore_pattern = re.compile(opts.ignore) if opts.ignore else None
+
     if opts.output_directory:
         pdoc.pdoc(
             *opts.modules,
             output_directory=opts.output_directory,
             format="html",  # opts.format or
+            ignore_pattern=ignore_pattern,
         )
         return
     else:
-        all_modules = extract.walk_specs(opts.modules)
+        all_modules = extract.walk_specs(opts.modules, ignore_pattern)
         with pdoc.web.DocServer(
             (opts.host, opts.port),
             all_modules,

--- a/pdoc/_compat.py
+++ b/pdoc/_compat.py
@@ -103,10 +103,11 @@ else:  # pragma: no cover
     # ✂ end ✂
 
 if sys.version_info >= (3, 8):
-    from typing import get_origin, get_args, Literal
+    from typing import Literal, get_args, get_origin
 else:  # pragma: no cover
-    from typing import Generic, _GenericAlias
     import collections.abc
+    from typing import Generic, _GenericAlias
+
     # There is no Literal on 3.7, so we just make one up. It should not be used anyways!
 
     class Literal:

--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -39,6 +39,7 @@ from pdoc.doc_types import (
     resolve_annotations,
     safe_eval_type,
 )
+
 from ._compat import cache, cached_property, get_origin
 
 

--- a/pdoc/doc_types.py
+++ b/pdoc/doc_types.py
@@ -15,12 +15,8 @@ import types
 import typing
 import warnings
 from types import BuiltinFunctionType, ModuleType
-from typing import (
-    Any,
-    Optional,
-    TYPE_CHECKING,
-)
 from typing import _GenericAlias  # type: ignore
+from typing import TYPE_CHECKING, Any, Optional
 
 from . import extract
 from ._compat import GenericAlias, Literal, UnionType, get_args, get_origin

--- a/pdoc/extract.py
+++ b/pdoc/extract.py
@@ -48,9 +48,8 @@ def walk_specs(specs: Sequence[Union[Path, str]]) -> dict[str, None]:
     all_modules: dict[str, None] = {}
     for spec in specs:
 
-        str_spec = str(spec)
-        if len(str_spec) > 0 and str_spec[0] == '!':
-            ignore_pattern = re.compile(str_spec[1:])
+        if isinstance(spec, str) and spec.startswith("!"):
+            ignore_pattern = re.compile(spec[1:])
             all_modules = {k: v for k, v in all_modules.items() if not ignore_pattern.match(k)}
             continue
 

--- a/pdoc/extract.py
+++ b/pdoc/extract.py
@@ -46,7 +46,6 @@ def walk_specs(specs: Sequence[Union[Path, str]]) -> dict[str, None]:
     *This function has side-effects:* See `parse_spec`.
     """
     all_modules: dict[str, None] = {}
-
     for spec in specs:
 
         str_spec = str(spec)
@@ -205,8 +204,8 @@ def _all_submodules(modulename: str) -> bool:
 
 
 def walk_packages2(
-        modules: Iterable[pkgutil.ModuleInfo],
-        module_filter: Callable[[str], bool] = _all_submodules
+    modules: Iterable[pkgutil.ModuleInfo],
+    module_filter: Callable[[str], bool] = _all_submodules
 ) -> Iterator[pkgutil.ModuleInfo]:
     """
     For a given list of modules, recursively yield their names and all their submodules' names.

--- a/pdoc/extract.py
+++ b/pdoc/extract.py
@@ -76,7 +76,7 @@ def walk_specs(specs: Sequence[Union[Path, str]], ignore_pattern: Optional[Patte
                 all_modules[m.name] = None
 
     if not all_modules:
-        raise ValueError(f"Module not found: {', '.join(str(x) for x in specs)}.")
+        raise ValueError(f"Module not found: {', '.join(str(x) for x in specs)}, or all modules ignored.")
 
     return all_modules
 

--- a/pdoc/extract.py
+++ b/pdoc/extract.py
@@ -12,6 +12,7 @@ import linecache
 import os
 import pkgutil
 import platform
+import re
 import subprocess
 import sys
 import traceback
@@ -19,14 +20,13 @@ import types
 import warnings
 from contextlib import contextmanager
 from pathlib import Path
-from re import Pattern
 from typing import Callable, Iterable, Iterator, Optional, Sequence, Union
 from unittest.mock import patch
 
 from . import doc_ast, docstrings
 
 
-def walk_specs(specs: Sequence[Union[Path, str]], ignore_pattern: Optional[Pattern] = None) -> dict[str, None]:
+def walk_specs(specs: Sequence[Union[Path, str]]) -> dict[str, None]:
     """
     This function processes a list of module specifications and returns a collection of module names, including all
     submodules, that should be processed by pdoc.
@@ -46,7 +46,15 @@ def walk_specs(specs: Sequence[Union[Path, str]], ignore_pattern: Optional[Patte
     *This function has side-effects:* See `parse_spec`.
     """
     all_modules: dict[str, None] = {}
+
     for spec in specs:
+
+        str_spec = str(spec)
+        if len(str_spec) > 0 and str_spec[0] == '!':
+            ignore_pattern = re.compile(str_spec[1:])
+            all_modules = {k: v for k, v in all_modules.items() if not ignore_pattern.match(k)}
+            continue
+
         modname = parse_spec(spec)
 
         try:
@@ -65,7 +73,7 @@ def walk_specs(specs: Sequence[Union[Path, str]], ignore_pattern: Optional[Patte
                 name=modname,
                 ispkg=bool(modspec.submodule_search_locations),
             )
-            for m in walk_packages2([mod_info], ignore_pattern=ignore_pattern):
+            for m in walk_packages2([mod_info]):
                 if m.name in all_modules:
                     warnings.warn(
                         f"The module specification {spec!r} adds a module named {m.name}, but a module with this name "
@@ -197,9 +205,8 @@ def _all_submodules(modulename: str) -> bool:
 
 
 def walk_packages2(
-    modules: Iterable[pkgutil.ModuleInfo],
-    module_filter: Callable[[str], bool] = _all_submodules,
-    ignore_pattern: Optional[Pattern] = None,
+        modules: Iterable[pkgutil.ModuleInfo],
+        module_filter: Callable[[str], bool] = _all_submodules
 ) -> Iterator[pkgutil.ModuleInfo]:
     """
     For a given list of modules, recursively yield their names and all their submodules' names.
@@ -217,10 +224,6 @@ def walk_packages2(
     for mod in modules:
         # is __all__ defined and the module not in __all__?
         if not module_filter(mod.name.rpartition(".")[2]):
-            continue
-
-        # does the module match with the ignore pattern?
-        if ignore_pattern and ignore_pattern.fullmatch(mod.name):
             continue
 
         yield mod
@@ -241,7 +244,7 @@ def walk_packages2(
             # don't traverse path items we've seen before
             path = [p for p in (getattr(module, "__path__", None) or []) if not seen(p)]
 
-            yield from walk_packages2(pkgutil.iter_modules(path, f"{mod.name}."), filt, ignore_pattern)
+            yield from walk_packages2(pkgutil.iter_modules(path, f"{mod.name}."), filt)
 
 
 def module_mtime(modulename: str) -> Optional[float]:

--- a/pdoc/extract.py
+++ b/pdoc/extract.py
@@ -50,7 +50,9 @@ def walk_specs(specs: Sequence[Union[Path, str]]) -> dict[str, None]:
 
         if isinstance(spec, str) and spec.startswith("!"):
             ignore_pattern = re.compile(spec[1:])
-            all_modules = {k: v for k, v in all_modules.items() if not ignore_pattern.match(k)}
+            all_modules = {
+                k: v for k, v in all_modules.items() if not ignore_pattern.match(k)
+            }
             continue
 
         modname = parse_spec(spec)
@@ -82,7 +84,9 @@ def walk_specs(specs: Sequence[Union[Path, str]]) -> dict[str, None]:
                 all_modules[m.name] = None
 
     if not all_modules:
-        raise ValueError(f"No modules found matching spec: {', '.join(str(x) for x in specs)}")
+        raise ValueError(
+            f"No modules found matching spec: {', '.join(str(x) for x in specs)}"
+        )
 
     return all_modules
 
@@ -204,7 +208,7 @@ def _all_submodules(modulename: str) -> bool:
 
 def walk_packages2(
     modules: Iterable[pkgutil.ModuleInfo],
-    module_filter: Callable[[str], bool] = _all_submodules
+    module_filter: Callable[[str], bool] = _all_submodules,
 ) -> Iterator[pkgutil.ModuleInfo]:
     """
     For a given list of modules, recursively yield their names and all their submodules' names.

--- a/pdoc/extract.py
+++ b/pdoc/extract.py
@@ -83,7 +83,7 @@ def walk_specs(specs: Sequence[Union[Path, str]]) -> dict[str, None]:
                 all_modules[m.name] = None
 
     if not all_modules:
-        raise ValueError(f"Module not found: {', '.join(str(x) for x in specs)}, or all modules ignored.")
+        raise ValueError(f"No modules found matching spec: {', '.join(str(x) for x in specs)}")
 
     return all_modules
 

--- a/pdoc/render_helpers.py
+++ b/pdoc/render_helpers.py
@@ -15,10 +15,12 @@ try:
     from jinja2 import pass_context  # type: ignore
 except ImportError:  # pragma: no cover
     from jinja2 import contextfilter as pass_context  # type: ignore
+
 from jinja2.runtime import Context
 from markupsafe import Markup
 
 import pdoc.markdown2
+
 from . import docstrings
 from ._compat import cache, removesuffix
 

--- a/pdoc/render_helpers.py
+++ b/pdoc/render_helpers.py
@@ -35,18 +35,18 @@ The pygments formatter used for pdoc.render_helpers.highlight.
 Overwrite this to configure pygments highlighting.
 """
 
-markdown_extensions = [
-    "code-friendly",
-    "cuddled-lists",
-    "fenced-code-blocks",
-    "footnotes",
-    "header-ids",
-    "pyshell",
-    "strike",
-    "tables",
-    "task_list",
-    "toc",
-]
+markdown_extensions = {
+    "code-friendly": None,
+    "cuddled-lists": None,
+    "fenced-code-blocks": None,
+    "footnotes": None,
+    "header-ids": None,
+    "pyshell": None,
+    "strike": None,
+    "tables": None,
+    "task_list": None,
+    "toc": {"depth": 2},
+}
 """
 The default extensions loaded for `markdown2`.
 Overwrite this to configure Markdown rendering.

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -10,7 +10,15 @@ here = Path(__file__).parent
 
 def test_walk_specs():
     assert list(walk_specs(["dataclasses"])) == ["dataclasses"]
-    with pytest.raises(ValueError, match="Module not found"):
+    assert list(walk_specs(['test.testdata.demopackage',
+                            '!test.testdata.demopackage',
+                            'test.testdata.demopackage.child_b'])) == ['test.testdata.demopackage.child_b']
+
+    assert list(walk_specs(['test.testdata.demopackage',
+                            '!test.testdata.demopackage.child_b',
+                            '!test.testdata.demopackage.child_c'])) == ['test.testdata.demopackage',
+                                                                        'test.testdata.demopackage._child_e']
+    with pytest.raises(ValueError, match="No modules found matching spec: unknown"):
         with pytest.warns(UserWarning, match="Cannot find spec for unknown"):
             assert walk_specs(["unknown"])
     with pytest.warns(UserWarning, match="Cannot find spec for unknown"):
@@ -21,7 +29,7 @@ def test_walk_specs():
             "test.import_err",
             "test.import_err.err",
         ]
-    with pytest.raises(ValueError, match="Module not found"):
+    with pytest.raises(ValueError, match="No modules found matching spec: "):
         assert walk_specs([])
 
     with pytest.warns(UserWarning, match="The module specification 'dataclasses' adds a module named dataclasses, "

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -10,14 +10,25 @@ here = Path(__file__).parent
 
 def test_walk_specs():
     assert list(walk_specs(["dataclasses"])) == ["dataclasses"]
-    assert list(walk_specs(['test.testdata.demopackage',
-                            '!test.testdata.demopackage',
-                            'test.testdata.demopackage.child_b'])) == ['test.testdata.demopackage.child_b']
+    assert list(
+        walk_specs(
+            [
+                "test.testdata.demopackage",
+                "!test.testdata.demopackage",
+                "test.testdata.demopackage.child_b",
+            ]
+        )
+    ) == ["test.testdata.demopackage.child_b"]
 
-    assert list(walk_specs(['test.testdata.demopackage',
-                            '!test.testdata.demopackage.child_b',
-                            '!test.testdata.demopackage.child_c'])) == ['test.testdata.demopackage',
-                                                                        'test.testdata.demopackage._child_e']
+    assert list(
+        walk_specs(
+            [
+                "test.testdata.demopackage",
+                "!test.testdata.demopackage.child_b",
+                "!test.testdata.demopackage.child_c",
+            ]
+        )
+    ) == ["test.testdata.demopackage", "test.testdata.demopackage._child_e"]
     with pytest.raises(ValueError, match="No modules found matching spec: unknown"):
         with pytest.warns(UserWarning, match="Cannot find spec for unknown"):
             assert walk_specs(["unknown"])
@@ -32,8 +43,11 @@ def test_walk_specs():
     with pytest.raises(ValueError, match="No modules found matching spec: "):
         assert walk_specs([])
 
-    with pytest.warns(UserWarning, match="The module specification 'dataclasses' adds a module named dataclasses, "
-                                         "but a module with this name has already been added."):
+    with pytest.warns(
+        UserWarning,
+        match="The module specification 'dataclasses' adds a module named dataclasses, "
+        "but a module with this name has already been added.",
+    ):
         assert list(walk_specs(["dataclasses", "dataclasses"])) == ["dataclasses"]
 
 
@@ -67,12 +81,16 @@ def test_parse_spec_mod_and_dir(tmp_path, monkeypatch):
     (tmp_path / "pdoc" / "__init__.py").touch()
     monkeypatch.chdir(tmp_path)
 
-    with pytest.warns(RuntimeWarning,
-                      match="'dataclasses' may refer to either the installed Python module or the local file/directory"):
+    with pytest.warns(
+        RuntimeWarning,
+        match="'dataclasses' may refer to either the installed Python module or the local file/directory",
+    ):
         assert parse_spec("dataclasses") == "dataclasses"
 
-    with pytest.warns(RuntimeWarning,
-                      match="pdoc cannot load 'pdoc' because a module with the same name is already imported"):
+    with pytest.warns(
+        RuntimeWarning,
+        match="pdoc cannot load 'pdoc' because a module with the same name is already imported",
+    ):
         assert parse_spec("./pdoc") == "pdoc"
 
     monkeypatch.chdir(here / "testdata")

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -12,10 +12,6 @@ here = Path(__file__).parent
 def test_walk_specs():
     assert list(walk_specs(["dataclasses"])) == ["dataclasses"]
 
-    ignore_pattern = re.compile("demopackage.child_.*")
-    assert list(walk_specs([here / "testdata" / "demopackage"],
-                           ignore_pattern=ignore_pattern)) == ["demopackage", "demopackage._child_e"]
-
     with pytest.raises(ValueError, match="Module not found"):
         with pytest.warns(UserWarning, match="Cannot find spec for unknown"):
             assert walk_specs(["unknown"])

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -1,5 +1,4 @@
 import importlib
-import re
 import pytest
 import sys
 from pathlib import Path
@@ -11,7 +10,6 @@ here = Path(__file__).parent
 
 def test_walk_specs():
     assert list(walk_specs(["dataclasses"])) == ["dataclasses"]
-
     with pytest.raises(ValueError, match="Module not found"):
         with pytest.warns(UserWarning, match="Cannot find spec for unknown"):
             assert walk_specs(["unknown"])

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -1,4 +1,5 @@
 import importlib
+import re
 import pytest
 import sys
 from pathlib import Path
@@ -10,6 +11,11 @@ here = Path(__file__).parent
 
 def test_walk_specs():
     assert list(walk_specs(["dataclasses"])) == ["dataclasses"]
+
+    ignore_pattern = re.compile("demopackage.child_.*")
+    assert list(walk_specs([here / "testdata" / "demopackage"],
+                           ignore_pattern=ignore_pattern)) == ["demopackage", "demopackage._child_e"]
+
     with pytest.raises(ValueError, match="Module not found"):
         with pytest.warns(UserWarning, match="Cannot find spec for unknown"):
             assert walk_specs(["unknown"])

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -40,7 +40,7 @@ def test_api(tmp_path):
     assert pdoc(here / "testdata" / "demo_long.py").startswith("<!doctype html>")
     with pytest.raises(ValueError, match="Invalid rendering format"):
         assert pdoc(here / "testdata" / "demo_long.py", format="invalid")
-    with pytest.raises(ValueError, match="Module not found"):
+    with pytest.raises(ValueError, match="No modules found matching spec"):
         with pytest.warns(UserWarning, match="Cannot find spec"):
             assert pdoc(
                 here / "notfound.py",

--- a/test/testdata/flavors_google.html
+++ b/test/testdata/flavors_google.html
@@ -19,13 +19,6 @@
 
 
 
-                    <h2>Contents</h2>
-                    <ul>
-  <li><a href="#example">Example</a></li>
-  <li><a href="#attributes">Attributes</a></li>
-  <li><a href="#todo">Todo</a></li>
-</ul>
-
 
 
                     <h2>API Documentation</h2>

--- a/test/testdata/flavors_numpy.html
+++ b/test/testdata/flavors_numpy.html
@@ -19,13 +19,6 @@
 
 
 
-                    <h2>Contents</h2>
-                    <ul>
-  <li><a href="#example">Example</a></li>
-  <li><a href="#notes">Notes</a></li>
-  <li><a href="#attributes">Attributes</a></li>
-</ul>
-
 
 
                     <h2>API Documentation</h2>


### PR DESCRIPTION
A user can now add modules prefixed by a "!" to exclude them from the list of modules to process. 

Usage:
``` python

pdoc foo !foo.bar foo.bar.baz
```

Fixes #310

