### PR TITLE
Fix blank lines breaking indented sections within fenced code blocks

### DIFF
--- a/pdoc/markdown2/__init__.py
+++ b/pdoc/markdown2/__init__.py
@@ -1927,9 +1927,11 @@ class Markdown(object):
             ((?=^[ ]{0,%d}\S)|\Z)   # Lookahead for non-space at line-start, or end of doc
             # Lookahead to make sure this block isn't already in a code block.
             # Needed when syntax highlighting is being used.
-            (?![^<]*\</code\>)
+            # (?![^<]*\</code\>)
+            (?![^*]*\</code\>)  # updated regex to fix https://github.com/mitmproxy/pdoc/pull/267
             ''' % (self.tab_width, self.tab_width),
             re.M | re.X)
+
         return code_block_re.sub(self._code_block_sub, text)
 
     _fenced_code_block_re = re.compile(r'''

--- a/test/testdata/flavors_google.html
+++ b/test/testdata/flavors_google.html
@@ -92,6 +92,9 @@
             <li>
                     <a class="function" href="#example_code">example_code</a>
             </li>
+            <li>
+                    <a class="function" href="#indented_code_with_blank_lines">indented_code_with_blank_lines</a>
+            </li>
     </ul>
 
 
@@ -576,6 +579,24 @@ with it.</p></li>
 <span class="sd">        tmp = a2()</span>
 
 <span class="sd">        tmp2 = a()</span>
+<span class="sd">        ```</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+
+
+<span class="k">def</span> <span class="nf">indented_code_with_blank_lines</span><span class="p">():</span>
+    <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">    Test case for blank lines interrupting a code block when inside an indented block</span>
+
+<span class="sd">    Example:</span>
+<span class="sd">        ```python</span>
+<span class="sd">        if True:</span>
+<span class="sd">            print()</span>
+
+<span class="sd">            print()</span>
+
+<span class="sd">            print()</span>
+
+<span class="sd">            print()</span>
 <span class="sd">        ```</span>
 <span class="sd">    &quot;&quot;&quot;</span>
 </pre></div>
@@ -1646,6 +1667,55 @@ there is a colon missing in the previous line</li>
   <div class="codehilite"><pre><span></span><code><span class="n">tmp</span> <span class="o">=</span> <span class="n">a2</span><span class="p">()</span>
 
 <span class="n">tmp2</span> <span class="o">=</span> <span class="n">a</span><span class="p">()</span>
+</code></pre></div>
+</blockquote>
+</div>
+
+
+                </section>
+                <section id="indented_code_with_blank_lines">
+                            <div class="attr function"><a class="headerlink" href="#indented_code_with_blank_lines">#&nbsp;&nbsp</a>
+
+        
+            <span class="def">def</span>
+            <span class="name">indented_code_with_blank_lines</span><span class="signature">()</span>:
+    </div>
+
+            <details>
+            <summary>View Source</summary>
+            <div class="codehilite"><pre><span></span><span class="k">def</span> <span class="nf">indented_code_with_blank_lines</span><span class="p">():</span>
+    <span class="sd">&quot;&quot;&quot;</span>
+<span class="sd">    Test case for blank lines interrupting a code block when inside an indented block</span>
+
+<span class="sd">    Example:</span>
+<span class="sd">        ```python</span>
+<span class="sd">        if True:</span>
+<span class="sd">            print()</span>
+
+<span class="sd">            print()</span>
+
+<span class="sd">            print()</span>
+
+<span class="sd">            print()</span>
+<span class="sd">        ```</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+</pre></div>
+
+        </details>
+
+            <div class="docstring"><p>Test case for blank lines interrupting a code block when inside an indented block</p>
+
+<h6 id="example">Example</h6>
+
+<blockquote>
+  <div class="codehilite"><pre><span></span><code><span class="k">if</span> <span class="kc">True</span><span class="p">:</span>
+    <span class="nb">print</span><span class="p">()</span>
+
+    <span class="nb">print</span><span class="p">()</span>
+
+    <span class="nb">print</span><span class="p">()</span>
+
+    <span class="nb">print</span><span class="p">()</span>
 </code></pre></div>
 </blockquote>
 </div>

--- a/test/testdata/flavors_google.py
+++ b/test/testdata/flavors_google.py
@@ -424,3 +424,22 @@ def example_code():
         tmp2 = a()
         ```
     """
+
+
+def indented_code_with_blank_lines():
+    """
+    Test case for blank lines interrupting a code block when inside an indented block.
+    See https://github.com/mitmproxy/pdoc/issues/267
+
+    Example:
+        ```python
+        if True:
+            print()
+
+            print()
+
+            print()
+
+            print()
+        ```
+    """

--- a/test/testdata/flavors_google.txt
+++ b/test/testdata/flavors_google.txt
@@ -28,4 +28,5 @@
         <method def __init__(self, likes_spam=False): ...  # Inits SampleClass wi…>
         <method def public_method(self): ...  # Performs operation b…>>
     <function def invalid_format(test): ...  # In this example, the…>
-    <function def example_code(): ...  # Test case for https:…>>
+    <function def example_code(): ...  # Test case for https:…>
+    <function def indented_code_with_blank_lines(): ...  # Test case for blank …>>


### PR DESCRIPTION
Hello again!

I've decided to take another crack at this problem. This time I think the fix is a bit more promising.
As mentioned previously (in #267), the problem was in the `pdoc.markdown2.Markdown._do_code_blocks` function. The regex expression there would attempt to detect code blocks.

It did have a regex look-ahead to prevent matching against text already inside a code block, which looked like this:
```
(?![^<]*\</code\>)
```
However, this will only check the next HTML tag to see if it is a `</code>` tag, and then stop. Since every line of markdown rendered code usually contains multiple `<span></span>` tags, this does not work. I have altered this look-ahead to:
```
(?![^*]*\</code\>)
```
Which checks the entire rest of the string for `</code>` tags.