### PR TITLE
Skip test_formatannotation_still_unfixed test on Python >= 3.10.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,13 +33,13 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            py: 3.10.0
+            py: 3.10.2
           - os: macos-latest
-            py: 3.10.0
+            py: 3.10.2
           - os: ubuntu-latest
-            py: 3.10.0
+            py: 3.10.2
           - os: ubuntu-latest
-            py: 3.9.7
+            py: 3.9.9
           - os: ubuntu-latest
             py: 3.8.12
           - os: ubuntu-latest

--- a/pdoc/_compat.py
+++ b/pdoc/_compat.py
@@ -133,6 +133,19 @@ else:  # pragma: no cover
             return tp.__args__
         return ()
 
+if (3, 9) <= sys.version_info < (3, 9, 8) or (3, 10) <= sys.version_info < (3, 10, 1):  # pragma: no cover
+    import inspect
+    import types
+
+    def formatannotation(annotation) -> str:
+        """
+        https://github.com/python/cpython/pull/29212
+        """
+        if isinstance(annotation, types.GenericAlias):
+            return str(annotation)
+        return inspect.formatannotation(annotation)
+else:
+    from inspect import formatannotation
 
 if True:
     # https://github.com/python/cpython/pull/27672
@@ -189,5 +202,6 @@ __all__ = [
     "get_origin",
     "get_args",
     "Literal",
+    "formatannotation",
     "BooleanOptionalAction",
 ]

--- a/pdoc/_compat.py
+++ b/pdoc/_compat.py
@@ -103,17 +103,16 @@ else:  # pragma: no cover
     # ✂ end ✂
 
 if sys.version_info >= (3, 8):
-    from typing import Literal, get_args, get_origin
+    from typing import Literal, get_origin
 else:  # pragma: no cover
-    import collections.abc
-    from typing import Generic, _GenericAlias
+    from typing import Generic
 
     # There is no Literal on 3.7, so we just make one up. It should not be used anyways!
 
     class Literal:
         pass
 
-    # get_origin and get_args are adapted from
+    # get_origin is adapted from
     # https://github.com/python/cpython/blob/863eb7170b3017399fb2b786a1e3feb6457e54c2/Lib/typing.py#L1474-L1515
     # with Annotations removed (not present in 3.7)
     def get_origin(tp):  # type: ignore
@@ -122,16 +121,6 @@ else:  # pragma: no cover
         if tp is Generic:
             return Generic
         return None
-
-    def get_args(tp):  # type: ignore
-        if isinstance(tp, _GenericAlias):
-            res = tp.__args__
-            if tp.__origin__ is collections.abc.Callable and res[0] is not Ellipsis:
-                res = (list(res[:-1]), res[-1])
-            return res
-        if isinstance(tp, GenericAlias):
-            return tp.__args__
-        return ()
 
 if (3, 9) <= sys.version_info < (3, 9, 8) or (3, 10) <= sys.version_info < (3, 10, 1):  # pragma: no cover
     import inspect
@@ -200,7 +189,6 @@ __all__ = [
     "removesuffix",
     "cached_property",
     "get_origin",
-    "get_args",
     "Literal",
     "formatannotation",
     "BooleanOptionalAction",

--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -36,12 +36,11 @@ from pdoc import doc_ast, extract
 from pdoc.doc_types import (
     NonUserDefinedCallables,
     empty,
-    formatannotation,
     resolve_annotations,
     safe_eval_type,
 )
 
-from ._compat import cache, cached_property, get_origin
+from ._compat import cache, cached_property, formatannotation, get_origin
 
 
 def _include_fullname_in_traceback(f):

--- a/pdoc/doc_types.py
+++ b/pdoc/doc_types.py
@@ -19,7 +19,7 @@ from typing import _GenericAlias  # type: ignore
 from typing import TYPE_CHECKING, Any
 
 from . import extract
-from ._compat import GenericAlias, Literal, UnionType, get_args, get_origin
+from ._compat import GenericAlias, Literal, UnionType, get_origin
 from .doc_ast import type_checking_sections
 
 if TYPE_CHECKING:

--- a/pdoc/doc_types.py
+++ b/pdoc/doc_types.py
@@ -53,17 +53,6 @@ NonUserDefinedCallables = (
 # ✂ end ✂
 
 
-def formatannotation(annotation: Any) -> str:
-    """
-    Like `inspect.formatannotation()`, but with a small bugfix for Python 3.9's GenericAlias annotations.
-    """
-    # a small inconsistency in Python 3.9,
-    # formatannotation(list[str]) returns "list".
-    if isinstance(annotation, type) and get_args(annotation):
-        return repr(annotation)
-    return inspect.formatannotation(annotation)
-
-
 def resolve_annotations(
     annotations: dict[str, Any],
     module: ModuleType | None,

--- a/test/test_doc_types.py
+++ b/test/test_doc_types.py
@@ -1,4 +1,3 @@
-import inspect
 import typing
 
 import pytest
@@ -6,14 +5,7 @@ import sys
 import types
 
 from pdoc import doc_ast
-from pdoc.doc_types import formatannotation, safe_eval_type
-
-
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="3.9+ only")
-def test_formatannotation_still_unfixed():
-    """when this tests starts to fail, we can remove the workaround in our formatannotation wrapper"""
-    assert formatannotation(list[str]) == "list[str]"
-    assert inspect.formatannotation(list[str]) == "list"
+from pdoc.doc_types import safe_eval_type
 
 
 @pytest.mark.parametrize(

--- a/test/testdata/demo_eager.html
+++ b/test/testdata/demo_eager.html
@@ -87,7 +87,7 @@ demo_eager    </h1>
 
         
             <span class="def">def</span>
-            <span class="name">bar</span><span class="signature">(x: list, /) -&gt; List[int]</span>:
+            <span class="name">bar</span><span class="signature">(x: list[int], /) -&gt; List[int]</span>:
     </div>
 
             <details>

--- a/test/testdata/demo_eager.txt
+++ b/test/testdata/demo_eager.txt
@@ -1,3 +1,3 @@
 <module demo_eager
     <function def foo(x: Literal['r', 'w']) -> Union[str, int]: ...>
-    <function def bar(x: list, /) -> List[int]: ...>>
+    <function def bar(x: list[int], /) -> List[int]: ...>>


### PR DESCRIPTION
#### Description
`inspect.formatannotation` was [fixed][1] and it seems to have appeared in Python 3.10.1+. (Currently CI uses maximum 3.10.0).

I'm curious why snapshots have `x: list` annotations instead of `x: list[int]` if they use `formatannotation` from `doc_types.py` which have a fix :thinking:.

[1]: https://github.com/python/cpython/commit/d02ffd1b5c0fd8dec6dd2f7e3f2b0cfae48b7899

