### PR TITLE
Ditch Codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,13 +34,10 @@ jobs:
         include:
           - os: windows-latest
             py: 3.10.2
-            coverage: --cov-fail-under=100
           - os: macos-latest
             py: 3.10.2
-            coverage: --cov-fail-under=100
           - os: ubuntu-latest
             py: 3.10.2
-            coverage: --cov-fail-under=100
           - os: ubuntu-latest
             py: 3.9.9
           - os: ubuntu-latest
@@ -55,7 +52,7 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - run: pip install tox
-      - run: tox -e py -- -vvv ${{ matrix.coverage }}
+      - run: tox -e py -- -vvv ${{ contains(['3.7.12','3.8.12','3.9.9'], matrix.py) && '' || '--cov-fail-under=100' }}
 
   deploy:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,9 @@ jobs:
           python-version: ${{ matrix.py }}
       - run: pip install tox
       - run: tox -e py -- -vvv --cov-fail-under=100
-        if: startsWith('3.10', matrix.py)
+        if: matrix.py == '3.10.2'
       - run: tox -e py -- -vvv
-        if: ! startsWith('3.10', matrix.py)
+        if: matrix.py != '3.10.2'
 
   deploy:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,10 +53,8 @@ jobs:
           python-version: ${{ matrix.py }}
       - run: pip install tox
       - run: tox -e py -- -vvv
-      - uses: codecov/codecov-action@a1ed4b322b4b38cb846afb5a0ebfa17086917d27
-        with:
-          file: ./coverage.xml
-          name: ${{ matrix.os }}
+      - run: python -m coverage report --fail-under=100
+        if: matrix.py == '3.10.2'
 
   deploy:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,10 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - run: pip install tox
-      - run: tox -e py -- -vvv ${{ contains(['3.7.12','3.8.12','3.9.9'], matrix.py) && '' || '--cov-fail-under=100' }}
+      - run: tox -e py -- -vvv --cov-fail-under=100
+        if: startsWith('3.10', matrix.py)
+      - run: tox -e py -- -vvv
+        if: !startsWith('3.10', matrix.py)
 
   deploy:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,10 +34,13 @@ jobs:
         include:
           - os: windows-latest
             py: 3.10.2
+            coverage: --cov-fail-under=100
           - os: macos-latest
             py: 3.10.2
+            coverage: --cov-fail-under=100
           - os: ubuntu-latest
             py: 3.10.2
+            coverage: --cov-fail-under=100
           - os: ubuntu-latest
             py: 3.9.9
           - os: ubuntu-latest
@@ -52,9 +55,7 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - run: pip install tox
-      - run: tox -e py -- -vvv
-      - run: python -m coverage report --fail-under=100
-        if: matrix.py == '3.10.2'
+      - run: tox -e py -- -vvv ${{ matrix.coverage }}
 
   deploy:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       - run: tox -e py -- -vvv --cov-fail-under=100
         if: startsWith('3.10', matrix.py)
       - run: tox -e py -- -vvv
-        if: !startsWith('3.10', matrix.py)
+        if: ! startsWith('3.10', matrix.py)
 
   deploy:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 <a href="https://pdoc.dev/"><img alt="pdoc" src="https://pdoc.dev/logo.svg" width="200" height="100" /></a>
 <br><br>
 <a href="https://pdoc.dev/docs/pdoc.html"><img height="20" alt="pdoc documentation" src="https://shields.mitmproxy.org/badge/docs-pdoc.dev-brightgreen.svg"></a>
-<a href="https://github.com/mitmproxy/pdoc/actions?query=branch%3Amain"><img height="20" alt="CI Status" src="https://shields.mitmproxy.org/github/workflow/status/mitmproxy/pdoc/CI?label=CI&logo=github"></a>
-<a href="https://codecov.io/gh/mitmproxy/pdoc"><img height="20" alt="Code Coverage" src="https://shields.mitmproxy.org/codecov/c/github/mitmproxy/pdoc/main.svg?label=codecov&logo=codecov&logoColor=white"></a>
+<img height="20" alt="CI Status" src="https://shields.mitmproxy.org/github/workflow/status/mitmproxy/pdoc/CI?label=CI&logo=github">
+<img height="20" alt="Code Coverage" src="https://shields.mitmproxy.org/badge/coverage-100%25-brightgreen">
 <a href="https://pypi.python.org/pypi/pdoc"><img height="20" alt="PyPI Version" src="https://shields.mitmproxy.org/pypi/v/pdoc.svg"></a>
-<a href="https://pypi.python.org/pypi/pdoc"><img height="20" alt="Supported Python Versions" src="https://shields.mitmproxy.org/pypi/pyversions/pdoc.svg"></a>
+<img height="20" alt="Supported Python Versions" src="https://shields.mitmproxy.org/pypi/pyversions/pdoc.svg">
 </p>
 
 API Documentation for Python Projects.

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     -e .
 commands =
     pdoc --version
-    pytest --cov=pdoc --cov-config=tox.ini --cov-report xml --cov-report term-missing {posargs:-m "not slow"}
+    pytest --cov=pdoc --cov-config=tox.ini --cov-report term-missing {posargs:-m "not slow"}
 
 [testenv:flake8]
 commands = flake8 pdoc test {posargs}


### PR DESCRIPTION
Codecov's new uploader cannot be used securely [1], so we take that opportunity to switch to something simpler.

[1] https://github.com/codecov/codecov-action/issues/574