### PR TITLE
shorten submodule text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
  - Fix catastrophic backtracking in a markdown2 regex that processes pyshell examples.
    ([#376](https://github.com/mitmproxy/pdoc/issues/376), [@Andrew-Sheridan](https://github.com/Andrew-Sheridan) and [@mhils](https://github.com/mhils))
+-  pdoc now uses the submodule name in the rendered sidebar, rather than the full import path. 
+   ([#374](https://github.com/mitmproxy/pdoc/issues/374), [@jacksund](https://github.com/jacksund))
 
 # 2022-04-06: pdoc 11.0.0
 

--- a/pdoc/templates/default/module.html.jinja2
+++ b/pdoc/templates/default/module.html.jinja2
@@ -44,7 +44,7 @@
         <h2>Submodules</h2>
         <ul>
             {% for submodule in module.submodules if is_public(submodule) | trim %}
-                <li>{{ submodule.taken_from | link }}</li>
+                <li>{{ submodule.taken_from | link(text=submodule.name) }}</li>
             {% endfor %}
         </ul>
     {% endif %}

--- a/test/testdata/demopackage.html
+++ b/test/testdata/demopackage.html
@@ -24,9 +24,9 @@
 
         <h2>Submodules</h2>
         <ul>
-                <li><a href="demopackage/child_b.html">demopackage.child_b</a></li>
-                <li><a href="demopackage/child_c.html">demopackage.child_c</a></li>
-                <li><a href="demopackage/_child_e.html">demopackage._child_e</a></li>
+                <li><a href="demopackage/child_b.html">child_b</a></li>
+                <li><a href="demopackage/child_c.html">child_c</a></li>
+                <li><a href="demopackage/_child_e.html">_child_e</a></li>
         </ul>
 
         <h2>API Documentation</h2>

--- a/test/testdata/demopackage_dir.html
+++ b/test/testdata/demopackage_dir.html
@@ -545,9 +545,9 @@ demopackage2    </h1>
 
         <h2>Submodules</h2>
         <ul>
-                <li><a href=&quot;demopackage/child_b.html&quot;>demopackage.child_b</a></li>
-                <li><a href=&quot;demopackage/child_c.html&quot;>demopackage.child_c</a></li>
-                <li><a href=&quot;demopackage/_child_e.html&quot;>demopackage._child_e</a></li>
+                <li><a href=&quot;demopackage/child_b.html&quot;>child_b</a></li>
+                <li><a href=&quot;demopackage/child_c.html&quot;>child_c</a></li>
+                <li><a href=&quot;demopackage/_child_e.html&quot;>_child_e</a></li>
         </ul>
 
         <h2>API Documentation</h2>


### PR DESCRIPTION
fixes #374 

Note, I haven't added functionality to keep the original verbose names. This PR forces the new format of short names. 