### PR TITLE
Add "Markdown support" section to main docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 # Unreleased: pdoc next
 
+
  - Extend auto-linking of URLs in Markdown.
    ([#401](https://github.com/mitmproxy/pdoc/issues/401), [@mhils](https://github.com/mhils))
+ - Mention which implementation of Markdown is supported, with what extras enabled
+   ([#403](https://github.com/mitmproxy/pdoc/issues/403), [@f3ndot](https://github.com/f3ndot))
 
 # 2022-06-03: pdoc 12.0.1
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Under the hood...
   
 If you have substantially more complex documentation needs, we recommend using [Sphinx](https://www.sphinx-doc.org/)!
 
-[^1]: `pdoc` supports the original [Markdown 1.0.1 spec](https://daringfireball.net/projects/markdown/) with some extras.
+[^1]: `pdoc` supports the original [Markdown 1.0.1 spec](https://daringfireball.net/projects/markdown/) with some extras. See the [Markdown support](https://pdoc.dev/docs/pdoc.html#markdown-support) section of the docs.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ or check our [hosted copy of the documentation](https://pdoc.dev/docs/pdoc.html)
 pdoc's main feature is a focus on simplicity: pdoc aims to do one thing and do it well.  
 
 
-* Documentation is plain Markdown[^1].
+* Documentation is plain [Markdown](https://pdoc.dev/docs/pdoc.html#markdown-support).
 * First-class support for type annotations and all other modern Python 3 features.
 * Builtin web server with live reloading.
 * Customizable HTML templates.
@@ -58,7 +58,6 @@ Under the hood...
   
 If you have substantially more complex documentation needs, we recommend using [Sphinx](https://www.sphinx-doc.org/)!
 
-[^1]: `pdoc` supports the original [Markdown 1.0.1 spec](https://daringfireball.net/projects/markdown/) with some extras. See the [Markdown support](https://pdoc.dev/docs/pdoc.html#markdown-support) section of the docs.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ or check our [hosted copy of the documentation](https://pdoc.dev/docs/pdoc.html)
 pdoc's main feature is a focus on simplicity: pdoc aims to do one thing and do it well.  
 
 
-* Documentation is plain Markdown.
+* Documentation is plain Markdown<a href="#markdown-note"><sup>[1]</sup></a>.
 * First-class support for type annotations and all other modern Python 3 features.
 * Builtin web server with live reloading.
 * Customizable HTML templates.
@@ -58,6 +58,9 @@ Under the hood...
   
 If you have substantially more complex documentation needs, we recommend using [Sphinx](https://www.sphinx-doc.org/)!
 
+* * *
+
+<small><a id="markdown-note"><sup>1</sup></a> `pdoc` supports the original [Markdown 1.0.1 spec](https://daringfireball.net/projects/markdown/) with some extras</small>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ or check our [hosted copy of the documentation](https://pdoc.dev/docs/pdoc.html)
 pdoc's main feature is a focus on simplicity: pdoc aims to do one thing and do it well.  
 
 
-* Documentation is plain Markdown<a href="#markdown-note"><sup>[1]</sup></a>.
+* Documentation is plain Markdown[^1].
 * First-class support for type annotations and all other modern Python 3 features.
 * Builtin web server with live reloading.
 * Customizable HTML templates.
@@ -58,9 +58,7 @@ Under the hood...
   
 If you have substantially more complex documentation needs, we recommend using [Sphinx](https://www.sphinx-doc.org/)!
 
-* * *
-
-<small><a id="markdown-note"><sup>1</sup></a> `pdoc` supports the original [Markdown 1.0.1 spec](https://daringfireball.net/projects/markdown/) with some extras</small>
+[^1]: `pdoc` supports the original [Markdown 1.0.1 spec](https://daringfireball.net/projects/markdown/) with some extras.
 
 ## Contributing
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -6,7 +6,7 @@ pdoc auto-generates API documentation that follows your project's Python module 
 pdoc's main feature is a focus on simplicity: pdoc aims to do one thing and do it well.
 
  - Easy setup, no configuration necessary.
- - Documentation is plain Markdown.
+ - Documentation is plain [Markdown](#markdown-support).
  - First-class support for type annotations.
  - Builtin web server with live reloading.
  - Customizable HTML templates.
@@ -378,6 +378,59 @@ code, then it will automatically attach the docstring for `Dog.bark` to
     generator that only accepts Markdown, that may work nonetheless – take a look at
     [integrating pdoc into other systems](https://pdoc.dev/docs/pdoc.html#integrate-pdoc-into-other-systems).
 
+
+# Markdown support
+
+There are many versions or *"flavors"* of Markdown out there. pdoc
+supports the original [Markdown 1.0.1 spec](https://daringfireball.net/projects/markdown/)
+as implemented by [`markdown2`](https://github.com/trentm/python-markdown2)
+with the following extras/extensions enabled:
+
+  - **[code-friendly][]:** Disable `_` and `__` for `em` and `strong`.
+  - **[cuddled-lists][]:** Allow lists to be cuddled to the preceding
+    paragraph.
+  - **[fenced-code-blocks][]:** Allows a code block to not have to be
+    indented by fencing it with '```' on a line before and after.
+    Based on [GitHub-Flavored Markdown][] with support for syntax highlighting.
+  - **[footnotes][]:** Support footnotes as in use on daringfireball.net
+    and implemented in other Markdown processors.
+  - **[header-ids][]:** Adds "id" attributes to headers. The id value
+    is a slug of the header text.
+  - **[markdown-in-html][]:** Allow the use of `markdown="1"` in a
+    block HTML tag to have markdown processing be done on its contents.
+    Similar to [PHP-Markdown Extra][] but with some limitations.
+  - **[pyshell][]:** Treats unindented Python interactive shell
+    sessions as `<code>` blocks. 
+  - **`strike`:** Parse `~~strikethrough~~` formatting.
+  - **[tables][]:** Tables using the same format as [GitHub-Flavored Markdown][] and
+    [PHP-Markdown Extra][].
+  - **`task_list`:** Allows GitHub-style task lists (i.e. check boxes)
+  - **`toc`:** The returned HTML string gets a new "toc_html"
+    attribute which is a Table of Contents for the document.
+
+[code-friendly]: https://github.com/trentm/python-markdown2/wiki/code-friendly
+[cuddled-lists]: https://github.com/trentm/python-markdown2/wiki/cuddled-lists
+[fenced-code-blocks]: https://github.com/trentm/python-markdown2/wiki/fenced-code-blocks
+[footnotes]: https://github.com/trentm/python-markdown2/wiki/footnotes
+[header-ids]: https://github.com/trentm/python-markdown2/wiki/header-ids
+[markdown-in-html]: https://github.com/trentm/python-markdown2/wiki/markdown-in-html
+[pyshell]: https://github.com/trentm/python-markdown2/wiki/pyshell
+[tables]: https://github.com/trentm/python-markdown2/wiki/tables
+[GitHub-Flavored Markdown]: http://github.github.com/github-flavored-markdown/
+[PHP-Markdown Extra]: https://michelf.ca/projects/php-markdown/extra/#table
+
+pdoc's philosophy is to be simple, robust and not require any
+configuration. As such it does not support [CommonMark](https://spec.commonmark.org/current/),
+[GitHub-Flavoured Markdown](https://github.github.com/gfm/) or other
+variants. Supporting multiple specifications of Markdown adds
+complexity, requires maintaining different feature sets, and
+introduces additional processor dependencies of varying levels quality
+or support.
+
+By contrast `markdown2` is an actively maintained, stable processor
+written pure in Python. Its extensions allow for more useful
+enhancements to the original "Markdown core" without the
+aforementioned burdens.
 
 # Using pdoc as a library
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -379,18 +379,19 @@ code, then it will automatically attach the docstring for `Dog.bark` to
     [integrating pdoc into other systems](https://pdoc.dev/docs/pdoc.html#integrate-pdoc-into-other-systems).
 
 
-# Markdown support
+# Markdown Support
 
-There are many versions or *"flavors"* of Markdown out there. pdoc
-supports the original [Markdown 1.0.1 spec](https://daringfireball.net/projects/markdown/)
-as implemented by [`markdown2`](https://github.com/trentm/python-markdown2)
-with the following extras/extensions enabled:
+[Markdown](https://guides.github.com/features/mastering-markdown/) is a lightweight and popular markup language for text
+formatting. There are many versions or *"flavors"* of Markdown.
+pdoc uses the [markdown2](https://github.com/trentm/python-markdown2) library, which closely matches
+the behavior of the original [Markdown 1.0.1 spec][].
+In addition, the following extra syntax elements are enabled:
 
   - **[code-friendly][]:** Disable `_` and `__` for `em` and `strong`.
   - **[cuddled-lists][]:** Allow lists to be cuddled to the preceding
     paragraph.
   - **[fenced-code-blocks][]:** Allows a code block to not have to be
-    indented by fencing it with '```' on a line before and after.
+    indented by fencing it with <code>```</code> on a line before and after.
     Based on [GitHub-Flavored Markdown][] with support for syntax highlighting.
   - **[footnotes][]:** Support footnotes as in use on daringfireball.net
     and implemented in other Markdown processors.
@@ -400,14 +401,15 @@ with the following extras/extensions enabled:
     block HTML tag to have markdown processing be done on its contents.
     Similar to [PHP-Markdown Extra][] but with some limitations.
   - **[pyshell][]:** Treats unindented Python interactive shell
-    sessions as `<code>` blocks. 
-  - **`strike`:** Parse `~~strikethrough~~` formatting.
+    sessions as `<code>` blocks.
+  - **strike:** Parse `~~strikethrough~~` formatting.
   - **[tables][]:** Tables using the same format as [GitHub-Flavored Markdown][] and
     [PHP-Markdown Extra][].
-  - **`task_list`:** Allows GitHub-style task lists (i.e. check boxes)
-  - **`toc`:** The returned HTML string gets a new "toc_html"
+  - **task_list:** Allows GitHub-style task lists (i.e. check boxes)
+  - **toc:** The returned HTML string gets a new "toc_html"
     attribute which is a Table of Contents for the document.
 
+[Markdown 1.0.1 spec]: https://daringfireball.net/projects/markdown/
 [code-friendly]: https://github.com/trentm/python-markdown2/wiki/code-friendly
 [cuddled-lists]: https://github.com/trentm/python-markdown2/wiki/cuddled-lists
 [fenced-code-blocks]: https://github.com/trentm/python-markdown2/wiki/fenced-code-blocks
@@ -416,21 +418,7 @@ with the following extras/extensions enabled:
 [markdown-in-html]: https://github.com/trentm/python-markdown2/wiki/markdown-in-html
 [pyshell]: https://github.com/trentm/python-markdown2/wiki/pyshell
 [tables]: https://github.com/trentm/python-markdown2/wiki/tables
-
-pdoc's philosophy is to be simple, robust and not require any
-configuration. As such it does not support [CommonMark][],
-[GitHub-Flavored Markdown][] or other variants. Supporting multiple
-specifications of Markdown adds complexity, requires maintaining
-different feature sets, and introduces additional processor
-dependencies of varying levels of quality or support.
-
-By contrast `markdown2` is an actively maintained, stable processor
-written pure in Python. Its extensions allow for more useful
-enhancements to the original "Markdown core" without the
-aforementioned burdens.
-
 [GitHub-Flavored Markdown]: https://github.github.com/gfm/
-[CommonMark]: https://spec.commonmark.org/current/
 [PHP-Markdown Extra]: https://michelf.ca/projects/php-markdown/extra/#table
 
 # Using pdoc as a library

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -422,7 +422,7 @@ configuration. As such it does not support [CommonMark][],
 [GitHub-Flavored Markdown][] or other variants. Supporting multiple
 specifications of Markdown adds complexity, requires maintaining
 different feature sets, and introduces additional processor
-dependencies of varying levels quality or support.
+dependencies of varying levels of quality or support.
 
 By contrast `markdown2` is an actively maintained, stable processor
 written pure in Python. Its extensions allow for more useful

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -416,21 +416,22 @@ with the following extras/extensions enabled:
 [markdown-in-html]: https://github.com/trentm/python-markdown2/wiki/markdown-in-html
 [pyshell]: https://github.com/trentm/python-markdown2/wiki/pyshell
 [tables]: https://github.com/trentm/python-markdown2/wiki/tables
-[GitHub-Flavored Markdown]: http://github.github.com/github-flavored-markdown/
-[PHP-Markdown Extra]: https://michelf.ca/projects/php-markdown/extra/#table
 
 pdoc's philosophy is to be simple, robust and not require any
-configuration. As such it does not support [CommonMark](https://spec.commonmark.org/current/),
-[GitHub-Flavoured Markdown](https://github.github.com/gfm/) or other
-variants. Supporting multiple specifications of Markdown adds
-complexity, requires maintaining different feature sets, and
-introduces additional processor dependencies of varying levels quality
-or support.
+configuration. As such it does not support [CommonMark][],
+[GitHub-Flavored Markdown][] or other variants. Supporting multiple
+specifications of Markdown adds complexity, requires maintaining
+different feature sets, and introduces additional processor
+dependencies of varying levels quality or support.
 
 By contrast `markdown2` is an actively maintained, stable processor
 written pure in Python. Its extensions allow for more useful
 enhancements to the original "Markdown core" without the
 aforementioned burdens.
+
+[GitHub-Flavored Markdown]: https://github.github.com/gfm/
+[CommonMark]: https://spec.commonmark.org/current/
+[PHP-Markdown Extra]: https://michelf.ca/projects/php-markdown/extra/#table
 
 # Using pdoc as a library
 

--- a/pdoc/render_helpers.py
+++ b/pdoc/render_helpers.py
@@ -50,6 +50,7 @@ The pygments formatter used for pdoc.render_helpers.format_signature.
 Overwrite this to configure pygments highlighting of signatures.
 """
 
+# Keep in sync with the documentation in pdoc/__init__.py!
 markdown_extensions = {
     "code-friendly": None,
     "cuddled-lists": None,


### PR DESCRIPTION
Born out of #401 this adds documentation describing what Markdown spec pdoc supports, why, and what additional extras are enabled.

Screenshots for the lazy:

<img width="858" alt="Screen Shot 2022-06-07 at 9 14 16 PM" src="https://user-images.githubusercontent.com/740289/172510220-bbaeaa75-1b03-4a47-99bc-a09f976f6e86.png">

As for the README I'm personally torn between using a footnote or just hyperlinking `Markdown` to the new doc section. I don't feel strongly one way or the other. You can see I tried a few variations in some commits. It's whatever you prefer!