### PR TITLE
Documentation: fix #422.

### DIFF
--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -629,6 +629,15 @@ class Class(Namespace[type]):
 
     @cached_property
     def own_members(self) -> list[Doc]:
+        """A list of all own (i.e. non-inherited) members.
+
+        .. note::
+            The `__init__` method of an abstract class will not be included in 
+            the list returned by `own_members` if it does not have a docstring. 
+            See https://github.com/mitmproxy/pdoc/issues/273. This can cause 
+            unexpected results in some edge cases. See 
+            https://github.com/mitmproxy/pdoc/issues/422 for more details.
+        """
         members = self._members_by_origin.get((self.modulename, self.qualname), [])
         if self.taken_from != (self.modulename, self.qualname):
             # .taken_from may be != (self.modulename, self.qualname), for example when


### PR DESCRIPTION
This adds a single docstring to `pdoc.doc.Class.own_members` in order to make the behavior regarding `__init__` methods on abstract classes more clear to users.

I believe the docstring should be concise enough, but I did use a note admonition, which is not used anywhere else in the documentation that I know of, so if the style/formatting needs to be changed, please let me know!