### PR TITLE
Improve conversion of ReST to Markdown by converting the text for :me…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@
  - `pdoc.doc.Doc.members` now includes variables without type annotation and docstring.
    They continue to not be documented in the default HTML template.
    ([#107](https://github.com/mitmproxy/pdoc/issues/107), @mhils)
- - Improve the conversion of ReST to Markdown for function and method references.
+ - Improve the conversion of reStructuredText to Markdown for function and method references.
    ([#463](https://github.com/mitmproxy/pdoc/pull/463), @vsajip)
 
 ## 2022-11-10: pdoc 12.2.2
 
  - Fix a CSS issue for overflowing math equations.
    ([#456](https://github.com/mitmproxy/pdoc/pull/456), @mhils)
- - Fix a regression from poc 12.2: Enum members are now always documented 
+ - Fix a regression from pdoc 12.2: Enum members are now always documented 
    even if they do not have a docstring.
    ([#457](https://github.com/mitmproxy/pdoc/pull/457), @mhils)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
  - `pdoc.doc.Doc.members` now includes variables without type annotation and docstring.
    They continue to not be documented in the default HTML template.
    ([#107](https://github.com/mitmproxy/pdoc/issues/107), @mhils)
+ - Improve the conversion of ReST to Markdown for function and method references.
+   ([#463](https://github.com/mitmproxy/pdoc/pull/463), @vsajip)
 
 ## 2022-11-10: pdoc 12.2.2
 

--- a/pdoc/docstrings.py
+++ b/pdoc/docstrings.py
@@ -237,7 +237,7 @@ def rst(contents: str, source_file: Path | None) -> str:
     contents = _rst_admonitions(contents, source_file)
     contents = _rst_links(contents)
 
-    def replacer(m):
+    def replace_reference(m):
         _, kind, name = m.groups()
         if kind in ("meth", "func"):
             return f"`{name}()`"
@@ -247,7 +247,7 @@ def rst(contents: str, source_file: Path | None) -> str:
     # Code References: :obj:`foo` -> `foo`
     contents = re.sub(
         r"(:py)?:(mod|func|data|const|class|meth|attr|exc|obj):`([^`]+)`",
-        replacer,
+        replace_reference,
         contents,
     )
 

--- a/pdoc/docstrings.py
+++ b/pdoc/docstrings.py
@@ -237,9 +237,17 @@ def rst(contents: str, source_file: Path | None) -> str:
     contents = _rst_admonitions(contents, source_file)
     contents = _rst_links(contents)
 
+    def replacer(m):
+        _, kind, name = m.groups()
+        if kind in ("meth", "func"):
+            return f"`{name}()`"
+        else:
+            return f"`{name}`"
+
     # Code References: :obj:`foo` -> `foo`
     contents = re.sub(
-        r"(:py)?:(mod|func|data|const|class|meth|attr|exc|obj):", "", contents
+        r"(:py)?:(mod|func|data|const|class|meth|attr|exc|obj):`([^`]+)`",
+        replacer, contents
     )
 
     # Math: :math:`foo` -> \\( foo \\)

--- a/pdoc/docstrings.py
+++ b/pdoc/docstrings.py
@@ -247,7 +247,8 @@ def rst(contents: str, source_file: Path | None) -> str:
     # Code References: :obj:`foo` -> `foo`
     contents = re.sub(
         r"(:py)?:(mod|func|data|const|class|meth|attr|exc|obj):`([^`]+)`",
-        replacer, contents
+        replacer,
+        contents,
     )
 
     # Math: :math:`foo` -> \\( foo \\)

--- a/test/testdata/flavors_rst.html
+++ b/test/testdata/flavors_rst.html
@@ -312,7 +312,7 @@ See the <a href="http://www.python.org">Python home page </a> for info.</p>
 </span></pre></div>
 
 
-            <div class="docstring"><p>Here we have refs to <code><a href="#links">links</a></code> and <code><a href="#admonitions">admonitions</a></code>.</p>
+            <div class="docstring"><p>Here we have refs to <code><a href="#links">links</a></code> and <code><a href="#admonitions">admonitions()</a></code>.</p>
 </div>
 
 
@@ -401,7 +401,7 @@ The <em>spam</em> parameter.</p>
 The <em>spam</em> parameter.</p>
 
 <p><em>Deprecated since version 3.1:</em>
-Use <code>spam</code> instead.</p>
+Use <code>spam()</code> instead.</p>
 
 <p><em>Deprecated since version 3.1.</em></p>
 


### PR DESCRIPTION
…th:`foo` or :func:`foo` references to `foo()` rather than just `foo`