### PR TITLE
pdoc: fold variable values

### DIFF
--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -87,15 +87,15 @@ class Doc(Generic[T]):
     qualname: str
     """
     The qualified identifier name for this object. For example, if we have the following code:
-    
+
     ```python
     class Foo:
         def bar(self):
             pass
     ```
-    
+
     The qualname of `Foo`'s `bar` method is `Foo.bar`. The qualname of the `Foo` class is just `Foo`.
-    
+
     See <https://www.python.org/dev/peps/pep-3155/> for details.
     """
 
@@ -998,7 +998,7 @@ class Variable(Doc[None]):
     default_value: Any | empty  # technically Any includes empty, but this conveys intent.
     """
     The variable's default value.
-    
+
     In some cases, no default value is known. This may either be because a variable is only defined in the constructor,
     or it is only declared with a type annotation without assignment (`foo: int`).
     To distinguish this case from a default value of `None`, `pdoc.doc_types.empty` is used as a placeholder.
@@ -1007,7 +1007,7 @@ class Variable(Doc[None]):
     annotation: type | empty
     """
     The variable's type annotation.
-    
+
     If there is no type annotation, `pdoc.doc_types.empty` is used as a placeholder.
     """
 
@@ -1070,6 +1070,14 @@ class Variable(Doc[None]):
                 )
             except Exception:
                 return " = <unable to get value representation>"
+
+    @cached_property
+    def source(self) -> str:
+        """
+        Returns the "source" for a variable. This is the same as
+        `default_value_str`, i.e. the variable's default (RHS) value.
+        """
+        return self.default_value_str
 
     @cached_property
     def annotation_str(self) -> str:

--- a/pdoc/templates/default/module.html.jinja2
+++ b/pdoc/templates/default/module.html.jinja2
@@ -141,7 +141,8 @@ See https://pdoc.dev/docs/pdoc/render_helpers.html#DefaultMacroExtension for an 
 {% enddefaultmacro %}
 {% defaultmacro default_value(var) -%}
     {%- if var.default_value_str -%}
-        <span class="default_value">{{ var.default_value_str | escape | linkify }}</span>
+        {{ view_source_code(var.default_value_str) }}
+        {{ docstring(var.default_value_str) }}
     {%- endif -%}
 {% enddefaultmacro %}
 {% defaultmacro annotation(var) %}

--- a/test/testdata/demo.html
+++ b/test/testdata/demo.html
@@ -69,19 +69,19 @@ demo    </h1>
 </span><span id="L-3"><a href="#L-3"><span class="linenos"> 3</span></a><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-4"><a href="#L-4"><span class="linenos"> 4</span></a>
 </span><span id="L-5"><a href="#L-5"><span class="linenos"> 5</span></a><span class="k">class</span> <span class="nc">Dog</span><span class="p">:</span>
-</span><span id="L-6"><a href="#L-6"><span class="linenos"> 6</span></a>    <span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
+</span><span id="L-6"><a href="#L-6"><span class="linenos"> 6</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
 </span><span id="L-7"><a href="#L-7"><span class="linenos"> 7</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-8"><a href="#L-8"><span class="linenos"> 8</span></a>    <span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
+</span><span id="L-8"><a href="#L-8"><span class="linenos"> 8</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
 </span><span id="L-9"><a href="#L-9"><span class="linenos"> 9</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
-</span><span id="L-10"><a href="#L-10"><span class="linenos">10</span></a>    <span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
+</span><span id="L-10"><a href="#L-10"><span class="linenos">10</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
 </span><span id="L-11"><a href="#L-11"><span class="linenos">11</span></a>
 </span><span id="L-12"><a href="#L-12"><span class="linenos">12</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-13"><a href="#L-13"><span class="linenos">13</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="L-13"><a href="#L-13"><span class="linenos">13</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="L-14"><a href="#L-14"><span class="linenos">14</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="L-15"><a href="#L-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span><span id="L-16"><a href="#L-16"><span class="linenos">16</span></a>
 </span><span id="L-17"><a href="#L-17"><span class="linenos">17</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="L-18"><a href="#L-18"><span class="linenos">18</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="L-18"><a href="#L-18"><span class="linenos">18</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -98,19 +98,19 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog-6"><a href="#Dog-6"><span class="linenos"> 6</span></a><span class="k">class</span> <span class="nc">Dog</span><span class="p">:</span>
-</span><span id="Dog-7"><a href="#Dog-7"><span class="linenos"> 7</span></a>    <span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
+</span><span id="Dog-7"><a href="#Dog-7"><span class="linenos"> 7</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
 </span><span id="Dog-8"><a href="#Dog-8"><span class="linenos"> 8</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Dog-9"><a href="#Dog-9"><span class="linenos"> 9</span></a>    <span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
+</span><span id="Dog-9"><a href="#Dog-9"><span class="linenos"> 9</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
 </span><span id="Dog-10"><a href="#Dog-10"><span class="linenos">10</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
-</span><span id="Dog-11"><a href="#Dog-11"><span class="linenos">11</span></a>    <span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
+</span><span id="Dog-11"><a href="#Dog-11"><span class="linenos">11</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
 </span><span id="Dog-12"><a href="#Dog-12"><span class="linenos">12</span></a>
 </span><span id="Dog-13"><a href="#Dog-13"><span class="linenos">13</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Dog-14"><a href="#Dog-14"><span class="linenos">14</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="Dog-14"><a href="#Dog-14"><span class="linenos">14</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="Dog-15"><a href="#Dog-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="Dog-16"><a href="#Dog-16"><span class="linenos">16</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span><span id="Dog-17"><a href="#Dog-17"><span class="linenos">17</span></a>
 </span><span id="Dog-18"><a href="#Dog-18"><span class="linenos">18</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="Dog-19"><a href="#Dog-19"><span class="linenos">19</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="Dog-19"><a href="#Dog-19"><span class="linenos">19</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -129,7 +129,7 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.__init__-13"><a href="#Dog.__init__-13"><span class="linenos">13</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Dog.__init__-14"><a href="#Dog.__init__-14"><span class="linenos">14</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="Dog.__init__-14"><a href="#Dog.__init__-14"><span class="linenos">14</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="Dog.__init__-15"><a href="#Dog.__init__-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="Dog.__init__-16"><a href="#Dog.__init__-16"><span class="linenos">16</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span></pre></div>
@@ -178,7 +178,7 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog.bark"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.bark-18"><a href="#Dog.bark-18"><span class="linenos">18</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="Dog.bark-19"><a href="#Dog.bark-19"><span class="linenos">19</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="Dog.bark-19"><a href="#Dog.bark-19"><span class="linenos">19</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 

--- a/test/testdata/demo_long.html
+++ b/test/testdata/demo_long.html
@@ -279,7 +279,7 @@ which will also show up in the navigation.</p>
 </span><span id="L-63"><a href="#L-63"><span class="linenos"> 63</span></a>
 </span><span id="L-64"><a href="#L-64"><span class="linenos"> 64</span></a>
 </span><span id="L-65"><a href="#L-65"><span class="linenos"> 65</span></a><span class="k">def</span> <span class="nf">a_simple_function</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-66"><a href="#L-66"><span class="linenos"> 66</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-66"><a href="#L-66"><span class="linenos"> 66</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-67"><a href="#L-67"><span class="linenos"> 67</span></a><span class="sd">    This is a basic module-level function.</span>
 </span><span id="L-68"><a href="#L-68"><span class="linenos"> 68</span></a>
 </span><span id="L-69"><a href="#L-69"><span class="linenos"> 69</span></a><span class="sd">    For a more complex example, take a look at `a_complex_function`!</span>
@@ -293,7 +293,7 @@ which will also show up in the navigation.</p>
 </span><span id="L-77"><a href="#L-77"><span class="linenos"> 77</span></a><span class="k">def</span> <span class="nf">a_complex_function</span><span class="p">(</span>
 </span><span id="L-78"><a href="#L-78"><span class="linenos"> 78</span></a>    <span class="n">a</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">b</span><span class="p">:</span> <span class="n">Union</span><span class="p">[</span><span class="s2">&quot;Foo&quot;</span><span class="p">,</span> <span class="nb">str</span><span class="p">],</span> <span class="o">*</span><span class="p">,</span> <span class="n">c</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">T</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>
 </span><span id="L-79"><a href="#L-79"><span class="linenos"> 79</span></a><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Optional</span><span class="p">[</span><span class="n">T</span><span class="p">]:</span>
-</span><span id="L-80"><a href="#L-80"><span class="linenos"> 80</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-80"><a href="#L-80"><span class="linenos"> 80</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-81"><a href="#L-81"><span class="linenos"> 81</span></a><span class="sd">    This is a function with a fairly complex signature,</span>
 </span><span id="L-82"><a href="#L-82"><span class="linenos"> 82</span></a><span class="sd">    involving type annotations with `typing.Union`, a `typing.TypeVar` (~T),</span>
 </span><span id="L-83"><a href="#L-83"><span class="linenos"> 83</span></a><span class="sd">    as well as a keyword-only arguments (*).</span>
@@ -302,7 +302,7 @@ which will also show up in the navigation.</p>
 </span><span id="L-86"><a href="#L-86"><span class="linenos"> 86</span></a>
 </span><span id="L-87"><a href="#L-87"><span class="linenos"> 87</span></a>
 </span><span id="L-88"><a href="#L-88"><span class="linenos"> 88</span></a><span class="k">class</span> <span class="nc">Foo</span><span class="p">:</span>
-</span><span id="L-89"><a href="#L-89"><span class="linenos"> 89</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-89"><a href="#L-89"><span class="linenos"> 89</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-90"><a href="#L-90"><span class="linenos"> 90</span></a><span class="sd">    `Foo` is a basic class without any parent classes (except for the implicit `object` class).</span>
 </span><span id="L-91"><a href="#L-91"><span class="linenos"> 91</span></a>
 </span><span id="L-92"><a href="#L-92"><span class="linenos"> 92</span></a><span class="sd">    You will see in the definition of `Bar` that docstrings are inherited by default.</span>
@@ -311,62 +311,62 @@ which will also show up in the navigation.</p>
 </span><span id="L-95"><a href="#L-95"><span class="linenos"> 95</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-96"><a href="#L-96"><span class="linenos"> 96</span></a>
 </span><span id="L-97"><a href="#L-97"><span class="linenos"> 97</span></a>    <span class="n">an_attribute</span><span class="p">:</span> <span class="n">Union</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="n">List</span><span class="p">[</span><span class="s2">&quot;int&quot;</span><span class="p">]]</span>
-</span><span id="L-98"><a href="#L-98"><span class="linenos"> 98</span></a>    <span class="sd">&quot;&quot;&quot;A regular attribute with type annotations&quot;&quot;&quot;</span>
+</span><span id="L-98"><a href="#L-98"><span class="linenos"> 98</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A regular attribute with type annotations&quot;&quot;&quot;</span>
 </span><span id="L-99"><a href="#L-99"><span class="linenos"> 99</span></a>
 </span><span id="L-100"><a href="#L-100"><span class="linenos">100</span></a>    <span class="n">a_class_attribute</span><span class="p">:</span> <span class="n">ClassVar</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="s2">&quot;lots of foo!&quot;</span>
-</span><span id="L-101"><a href="#L-101"><span class="linenos">101</span></a>    <span class="sd">&quot;&quot;&quot;An attribute with a ClassVar annotation.&quot;&quot;&quot;</span>
+</span><span id="L-101"><a href="#L-101"><span class="linenos">101</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An attribute with a ClassVar annotation.&quot;&quot;&quot;</span>
 </span><span id="L-102"><a href="#L-102"><span class="linenos">102</span></a>
 </span><span id="L-103"><a href="#L-103"><span class="linenos">103</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
-</span><span id="L-104"><a href="#L-104"><span class="linenos">104</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-104"><a href="#L-104"><span class="linenos">104</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-105"><a href="#L-105"><span class="linenos">105</span></a><span class="sd">        The constructor is currently always listed first as this feels most natural.&quot;&quot;&quot;</span>
 </span><span id="L-106"><a href="#L-106"><span class="linenos">106</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">a_constructor_only_attribute</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">42</span>
-</span><span id="L-107"><a href="#L-107"><span class="linenos">107</span></a>        <span class="sd">&quot;&quot;&quot;This attribute is defined in the constructor only, but still picked up by pdoc&#39;s AST traversal.&quot;&quot;&quot;</span>
+</span><span id="L-107"><a href="#L-107"><span class="linenos">107</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This attribute is defined in the constructor only, but still picked up by pdoc&#39;s AST traversal.&quot;&quot;&quot;</span>
 </span><span id="L-108"><a href="#L-108"><span class="linenos">108</span></a>
 </span><span id="L-109"><a href="#L-109"><span class="linenos">109</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">undocumented_constructor_attribute</span> <span class="o">=</span> <span class="mi">42</span>
 </span><span id="L-110"><a href="#L-110"><span class="linenos">110</span></a>        <span class="n">a_complex_function</span><span class="p">(</span><span class="s2">&quot;a&quot;</span><span class="p">,</span> <span class="s2">&quot;Foo&quot;</span><span class="p">)</span>
 </span><span id="L-111"><a href="#L-111"><span class="linenos">111</span></a>
 </span><span id="L-112"><a href="#L-112"><span class="linenos">112</span></a>    <span class="k">def</span> <span class="nf">a_regular_function</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s2">&quot;Foo&quot;</span><span class="p">:</span>
-</span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a>        <span class="sd">&quot;&quot;&quot;This is a regular method, returning the object itself.&quot;&quot;&quot;</span>
+</span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is a regular method, returning the object itself.&quot;&quot;&quot;</span>
 </span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a>        <span class="k">return</span> <span class="bp">self</span>
 </span><span id="L-115"><a href="#L-115"><span class="linenos">115</span></a>
 </span><span id="L-116"><a href="#L-116"><span class="linenos">116</span></a>    <span class="nd">@property</span>
 </span><span id="L-117"><a href="#L-117"><span class="linenos">117</span></a>    <span class="k">def</span> <span class="nf">a_property</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-118"><a href="#L-118"><span class="linenos">118</span></a>        <span class="sd">&quot;&quot;&quot;This is a `@property` attribute. pdoc will display it as a variable.&quot;&quot;&quot;</span>
+</span><span id="L-118"><a href="#L-118"><span class="linenos">118</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is a `@property` attribute. pdoc will display it as a variable.&quot;&quot;&quot;</span>
 </span><span id="L-119"><a href="#L-119"><span class="linenos">119</span></a>        <span class="k">return</span> <span class="s2">&quot;true foo&quot;</span>
 </span><span id="L-120"><a href="#L-120"><span class="linenos">120</span></a>
 </span><span id="L-121"><a href="#L-121"><span class="linenos">121</span></a>    <span class="nd">@cached_property</span>
 </span><span id="L-122"><a href="#L-122"><span class="linenos">122</span></a>    <span class="k">def</span> <span class="nf">a_cached_property</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-123"><a href="#L-123"><span class="linenos">123</span></a>        <span class="sd">&quot;&quot;&quot;This is a `@functools.cached_property` attribute. pdoc will display it as a variable as well.&quot;&quot;&quot;</span>
+</span><span id="L-123"><a href="#L-123"><span class="linenos">123</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is a `@functools.cached_property` attribute. pdoc will display it as a variable as well.&quot;&quot;&quot;</span>
 </span><span id="L-124"><a href="#L-124"><span class="linenos">124</span></a>        <span class="k">return</span> <span class="s2">&quot;true foo&quot;</span>
 </span><span id="L-125"><a href="#L-125"><span class="linenos">125</span></a>
 </span><span id="L-126"><a href="#L-126"><span class="linenos">126</span></a>    <span class="nd">@cache</span>
 </span><span id="L-127"><a href="#L-127"><span class="linenos">127</span></a>    <span class="k">def</span> <span class="nf">a_cached_function</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-128"><a href="#L-128"><span class="linenos">128</span></a>        <span class="sd">&quot;&quot;&quot;This is method with `@cache` decoration.&quot;&quot;&quot;</span>
+</span><span id="L-128"><a href="#L-128"><span class="linenos">128</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is method with `@cache` decoration.&quot;&quot;&quot;</span>
 </span><span id="L-129"><a href="#L-129"><span class="linenos">129</span></a>        <span class="k">return</span> <span class="s2">&quot;true foo&quot;</span>
 </span><span id="L-130"><a href="#L-130"><span class="linenos">130</span></a>
 </span><span id="L-131"><a href="#L-131"><span class="linenos">131</span></a>    <span class="nd">@classmethod</span>
 </span><span id="L-132"><a href="#L-132"><span class="linenos">132</span></a>    <span class="k">def</span> <span class="nf">a_class_method</span><span class="p">(</span><span class="bp">cls</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="L-133"><a href="#L-133"><span class="linenos">133</span></a>        <span class="sd">&quot;&quot;&quot;This is what a `@classmethod` looks like.&quot;&quot;&quot;</span>
+</span><span id="L-133"><a href="#L-133"><span class="linenos">133</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is what a `@classmethod` looks like.&quot;&quot;&quot;</span>
 </span><span id="L-134"><a href="#L-134"><span class="linenos">134</span></a>        <span class="k">return</span> <span class="mi">24</span>
 </span><span id="L-135"><a href="#L-135"><span class="linenos">135</span></a>
 </span><span id="L-136"><a href="#L-136"><span class="linenos">136</span></a>    <span class="nd">@classmethod</span>  <span class="c1"># type: ignore</span>
 </span><span id="L-137"><a href="#L-137"><span class="linenos">137</span></a>    <span class="nd">@property</span>
 </span><span id="L-138"><a href="#L-138"><span class="linenos">138</span></a>    <span class="k">def</span> <span class="nf">a_class_property</span><span class="p">(</span><span class="bp">cls</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="L-139"><a href="#L-139"><span class="linenos">139</span></a>        <span class="sd">&quot;&quot;&quot;This is what a `@classmethod @property` looks like.&quot;&quot;&quot;</span>
+</span><span id="L-139"><a href="#L-139"><span class="linenos">139</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is what a `@classmethod @property` looks like.&quot;&quot;&quot;</span>
 </span><span id="L-140"><a href="#L-140"><span class="linenos">140</span></a>        <span class="k">return</span> <span class="mi">24</span>
 </span><span id="L-141"><a href="#L-141"><span class="linenos">141</span></a>
 </span><span id="L-142"><a href="#L-142"><span class="linenos">142</span></a>    <span class="nd">@staticmethod</span>
 </span><span id="L-143"><a href="#L-143"><span class="linenos">143</span></a>    <span class="k">def</span> <span class="nf">a_static_method</span><span class="p">():</span>
-</span><span id="L-144"><a href="#L-144"><span class="linenos">144</span></a>        <span class="sd">&quot;&quot;&quot;This is what a `@staticmethod` looks like.&quot;&quot;&quot;</span>
+</span><span id="L-144"><a href="#L-144"><span class="linenos">144</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is what a `@staticmethod` looks like.&quot;&quot;&quot;</span>
 </span><span id="L-145"><a href="#L-145"><span class="linenos">145</span></a>        <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Hello World&quot;</span><span class="p">)</span>
 </span><span id="L-146"><a href="#L-146"><span class="linenos">146</span></a>
 </span><span id="L-147"><a href="#L-147"><span class="linenos">147</span></a>
 </span><span id="L-148"><a href="#L-148"><span class="linenos">148</span></a><span class="k">class</span> <span class="nc">Bar</span><span class="p">(</span><span class="n">Foo</span><span class="p">):</span>
 </span><span id="L-149"><a href="#L-149"><span class="linenos">149</span></a>    <span class="n">bar</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-150"><a href="#L-150"><span class="linenos">150</span></a>    <span class="sd">&quot;&quot;&quot;A new attribute defined on this subclass.&quot;&quot;&quot;</span>
+</span><span id="L-150"><a href="#L-150"><span class="linenos">150</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A new attribute defined on this subclass.&quot;&quot;&quot;</span>
 </span><span id="L-151"><a href="#L-151"><span class="linenos">151</span></a>
 </span><span id="L-152"><a href="#L-152"><span class="linenos">152</span></a>    <span class="k">class</span> <span class="nc">Baz</span><span class="p">:</span>
-</span><span id="L-153"><a href="#L-153"><span class="linenos">153</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-153"><a href="#L-153"><span class="linenos">153</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-154"><a href="#L-154"><span class="linenos">154</span></a><span class="sd">        This class is an attribute of `Bar`.</span>
 </span><span id="L-155"><a href="#L-155"><span class="linenos">155</span></a><span class="sd">        To not create overwhelmingly complex trees, pdoc flattens the class hierarchy in the documentation</span>
 </span><span id="L-156"><a href="#L-156"><span class="linenos">156</span></a><span class="sd">        (but not in the navigation).</span>
@@ -378,12 +378,12 @@ which will also show up in the navigation.</p>
 </span><span id="L-162"><a href="#L-162"><span class="linenos">162</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="L-163"><a href="#L-163"><span class="linenos">163</span></a>
 </span><span id="L-164"><a href="#L-164"><span class="linenos">164</span></a>        <span class="k">def</span> <span class="nf">wat</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-165"><a href="#L-165"><span class="linenos">165</span></a>            <span class="sd">&quot;&quot;&quot;A regular method. Above, you see what happens if a class has no constructor defined and</span>
+</span><span id="L-165"><a href="#L-165"><span class="linenos">165</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;A regular method. Above, you see what happens if a class has no constructor defined and</span>
 </span><span id="L-166"><a href="#L-166"><span class="linenos">166</span></a><span class="sd">            no constructor docstring.&quot;&quot;&quot;</span>
 </span><span id="L-167"><a href="#L-167"><span class="linenos">167</span></a>
 </span><span id="L-168"><a href="#L-168"><span class="linenos">168</span></a>
 </span><span id="L-169"><a href="#L-169"><span class="linenos">169</span></a><span class="k">async</span> <span class="k">def</span> <span class="nf">i_am_async</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="L-170"><a href="#L-170"><span class="linenos">170</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-170"><a href="#L-170"><span class="linenos">170</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-171"><a href="#L-171"><span class="linenos">171</span></a><span class="sd">    This is an example of an async function.</span>
 </span><span id="L-172"><a href="#L-172"><span class="linenos">172</span></a>
 </span><span id="L-173"><a href="#L-173"><span class="linenos">173</span></a><span class="sd">    - Knock, knock</span>
@@ -395,7 +395,7 @@ which will also show up in the navigation.</p>
 </span><span id="L-179"><a href="#L-179"><span class="linenos">179</span></a>
 </span><span id="L-180"><a href="#L-180"><span class="linenos">180</span></a><span class="nd">@cache</span>
 </span><span id="L-181"><a href="#L-181"><span class="linenos">181</span></a><span class="k">def</span> <span class="nf">fib</span><span class="p">(</span><span class="n">n</span><span class="p">):</span>
-</span><span id="L-182"><a href="#L-182"><span class="linenos">182</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-182"><a href="#L-182"><span class="linenos">182</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-183"><a href="#L-183"><span class="linenos">183</span></a><span class="sd">    This is an example of decorated function. Decorators are included in the documentation as well.</span>
 </span><span id="L-184"><a href="#L-184"><span class="linenos">184</span></a><span class="sd">    This is often useful when documenting web APIs, for example.</span>
 </span><span id="L-185"><a href="#L-185"><span class="linenos">185</span></a><span class="sd">    &quot;&quot;&quot;</span>
@@ -405,7 +405,7 @@ which will also show up in the navigation.</p>
 </span><span id="L-189"><a href="#L-189"><span class="linenos">189</span></a>
 </span><span id="L-190"><a href="#L-190"><span class="linenos">190</span></a>
 </span><span id="L-191"><a href="#L-191"><span class="linenos">191</span></a><span class="k">def</span> <span class="nf">security</span><span class="p">(</span><span class="n">test</span><span class="o">=</span><span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="p">):</span>
-</span><span id="L-192"><a href="#L-192"><span class="linenos">192</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-192"><a href="#L-192"><span class="linenos">192</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-193"><a href="#L-193"><span class="linenos">193</span></a><span class="sd">    Default values are generally rendered using repr(),</span>
 </span><span id="L-194"><a href="#L-194"><span class="linenos">194</span></a><span class="sd">    but some special cases -- like os.environ -- are overridden to avoid leaking sensitive data.</span>
 </span><span id="L-195"><a href="#L-195"><span class="linenos">195</span></a><span class="sd">    &quot;&quot;&quot;</span>
@@ -413,7 +413,7 @@ which will also show up in the navigation.</p>
 </span><span id="L-197"><a href="#L-197"><span class="linenos">197</span></a>
 </span><span id="L-198"><a href="#L-198"><span class="linenos">198</span></a>
 </span><span id="L-199"><a href="#L-199"><span class="linenos">199</span></a><span class="k">class</span> <span class="nc">DoubleInherit</span><span class="p">(</span><span class="n">Foo</span><span class="p">,</span> <span class="n">Bar</span><span class="o">.</span><span class="n">Baz</span><span class="p">,</span> <span class="n">abc</span><span class="o">.</span><span class="n">ABC</span><span class="p">):</span>
-</span><span id="L-200"><a href="#L-200"><span class="linenos">200</span></a>    <span class="sd">&quot;&quot;&quot;This is an example of a class that inherits from multiple parent classes.&quot;&quot;&quot;</span>
+</span><span id="L-200"><a href="#L-200"><span class="linenos">200</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This is an example of a class that inherits from multiple parent classes.&quot;&quot;&quot;</span>
 </span><span id="L-201"><a href="#L-201"><span class="linenos">201</span></a>
 </span><span id="L-202"><a href="#L-202"><span class="linenos">202</span></a>
 </span><span id="L-203"><a href="#L-203"><span class="linenos">203</span></a><span class="n">CONST_B</span> <span class="o">=</span> <span class="s2">&quot;yes&quot;</span>
@@ -424,14 +424,14 @@ which will also show up in the navigation.</p>
 </span><span id="L-208"><a href="#L-208"><span class="linenos">208</span></a>
 </span><span id="L-209"><a href="#L-209"><span class="linenos">209</span></a><span class="nd">@dataclass</span>
 </span><span id="L-210"><a href="#L-210"><span class="linenos">210</span></a><span class="k">class</span> <span class="nc">DataDemo</span><span class="p">:</span>
-</span><span id="L-211"><a href="#L-211"><span class="linenos">211</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-211"><a href="#L-211"><span class="linenos">211</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-212"><a href="#L-212"><span class="linenos">212</span></a><span class="sd">    This is an example for a dataclass.</span>
 </span><span id="L-213"><a href="#L-213"><span class="linenos">213</span></a>
 </span><span id="L-214"><a href="#L-214"><span class="linenos">214</span></a><span class="sd">    As usual, you can link to individual properties: `DataDemo.a`.</span>
 </span><span id="L-215"><a href="#L-215"><span class="linenos">215</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-216"><a href="#L-216"><span class="linenos">216</span></a>
 </span><span id="L-217"><a href="#L-217"><span class="linenos">217</span></a>    <span class="n">a</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="L-218"><a href="#L-218"><span class="linenos">218</span></a>    <span class="sd">&quot;&quot;&quot;Again, we can document individual properties with docstrings.&quot;&quot;&quot;</span>
+</span><span id="L-218"><a href="#L-218"><span class="linenos">218</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Again, we can document individual properties with docstrings.&quot;&quot;&quot;</span>
 </span><span id="L-219"><a href="#L-219"><span class="linenos">219</span></a>    <span class="n">a2</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span>
 </span><span id="L-220"><a href="#L-220"><span class="linenos">220</span></a>    <span class="c1"># This property has a type annotation but is not documented.</span>
 </span><span id="L-221"><a href="#L-221"><span class="linenos">221</span></a>    <span class="n">a3</span> <span class="o">=</span> <span class="s2">&quot;a3&quot;</span>
@@ -439,31 +439,31 @@ which will also show up in the navigation.</p>
 </span><span id="L-223"><a href="#L-223"><span class="linenos">223</span></a>    <span class="n">a4</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;a4&quot;</span>
 </span><span id="L-224"><a href="#L-224"><span class="linenos">224</span></a>    <span class="c1"># This property has a type annotation and a default value but is not documented.</span>
 </span><span id="L-225"><a href="#L-225"><span class="linenos">225</span></a>    <span class="n">b</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="n">field</span><span class="p">(</span><span class="nb">repr</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
-</span><span id="L-226"><a href="#L-226"><span class="linenos">226</span></a>    <span class="sd">&quot;&quot;&quot;This property is assigned to `dataclasses.field()`, which works just as well.&quot;&quot;&quot;</span>
+</span><span id="L-226"><a href="#L-226"><span class="linenos">226</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This property is assigned to `dataclasses.field()`, which works just as well.&quot;&quot;&quot;</span>
 </span><span id="L-227"><a href="#L-227"><span class="linenos">227</span></a>
 </span><span id="L-228"><a href="#L-228"><span class="linenos">228</span></a>
 </span><span id="L-229"><a href="#L-229"><span class="linenos">229</span></a><span class="nd">@dataclass</span>
 </span><span id="L-230"><a href="#L-230"><span class="linenos">230</span></a><span class="k">class</span> <span class="nc">DataDemoExtended</span><span class="p">(</span><span class="n">DataDemo</span><span class="p">):</span>
 </span><span id="L-231"><a href="#L-231"><span class="linenos">231</span></a>    <span class="n">c</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;42&quot;</span>
-</span><span id="L-232"><a href="#L-232"><span class="linenos">232</span></a>    <span class="sd">&quot;&quot;&quot;A new attribute.&quot;&quot;&quot;</span>
+</span><span id="L-232"><a href="#L-232"><span class="linenos">232</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A new attribute.&quot;&quot;&quot;</span>
 </span><span id="L-233"><a href="#L-233"><span class="linenos">233</span></a>
 </span><span id="L-234"><a href="#L-234"><span class="linenos">234</span></a>
 </span><span id="L-235"><a href="#L-235"><span class="linenos">235</span></a><span class="k">class</span> <span class="nc">EnumDemo</span><span class="p">(</span><span class="n">enum</span><span class="o">.</span><span class="n">Enum</span><span class="p">):</span>
-</span><span id="L-236"><a href="#L-236"><span class="linenos">236</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-236"><a href="#L-236"><span class="linenos">236</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-237"><a href="#L-237"><span class="linenos">237</span></a><span class="sd">    This is an example of an Enum.</span>
 </span><span id="L-238"><a href="#L-238"><span class="linenos">238</span></a>
 </span><span id="L-239"><a href="#L-239"><span class="linenos">239</span></a><span class="sd">    As usual, you can link to individual properties: `GREEN`.</span>
 </span><span id="L-240"><a href="#L-240"><span class="linenos">240</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-241"><a href="#L-241"><span class="linenos">241</span></a>
 </span><span id="L-242"><a href="#L-242"><span class="linenos">242</span></a>    <span class="n">RED</span> <span class="o">=</span> <span class="mi">1</span>
-</span><span id="L-243"><a href="#L-243"><span class="linenos">243</span></a>    <span class="sd">&quot;&quot;&quot;I am the red.&quot;&quot;&quot;</span>
+</span><span id="L-243"><a href="#L-243"><span class="linenos">243</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;I am the red.&quot;&quot;&quot;</span>
 </span><span id="L-244"><a href="#L-244"><span class="linenos">244</span></a>    <span class="n">GREEN</span> <span class="o">=</span> <span class="mi">2</span>
-</span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a>    <span class="sd">&quot;&quot;&quot;I am green.&quot;&quot;&quot;</span>
+</span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;I am green.&quot;&quot;&quot;</span>
 </span><span id="L-246"><a href="#L-246"><span class="linenos">246</span></a>    <span class="n">BLUE</span> <span class="o">=</span> <span class="n">enum</span><span class="o">.</span><span class="n">auto</span><span class="p">()</span>
 </span><span id="L-247"><a href="#L-247"><span class="linenos">247</span></a>
 </span><span id="L-248"><a href="#L-248"><span class="linenos">248</span></a>
 </span><span id="L-249"><a href="#L-249"><span class="linenos">249</span></a><span class="k">def</span> <span class="nf">embed_image</span><span class="p">():</span>
-</span><span id="L-250"><a href="#L-250"><span class="linenos">250</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-250"><a href="#L-250"><span class="linenos">250</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-251"><a href="#L-251"><span class="linenos">251</span></a><span class="sd">    This docstring includes an embedded image:</span>
 </span><span id="L-252"><a href="#L-252"><span class="linenos">252</span></a>
 </span><span id="L-253"><a href="#L-253"><span class="linenos">253</span></a><span class="sd">    ```</span>
@@ -475,7 +475,7 @@ which will also show up in the navigation.</p>
 </span><span id="L-259"><a href="#L-259"><span class="linenos">259</span></a>
 </span><span id="L-260"><a href="#L-260"><span class="linenos">260</span></a>
 </span><span id="L-261"><a href="#L-261"><span class="linenos">261</span></a><span class="k">def</span> <span class="nf">admonitions</span><span class="p">():</span>
-</span><span id="L-262"><a href="#L-262"><span class="linenos">262</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-262"><a href="#L-262"><span class="linenos">262</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-263"><a href="#L-263"><span class="linenos">263</span></a><span class="sd">    pdoc also supports basic reStructuredText admonitions:</span>
 </span><span id="L-264"><a href="#L-264"><span class="linenos">264</span></a>
 </span><span id="L-265"><a href="#L-265"><span class="linenos">265</span></a><span class="sd">    ```</span>
@@ -498,13 +498,19 @@ which will also show up in the navigation.</p>
 
             </section>
                 <section id="FOO_CONSTANT">
-                    <div class="attr variable">
-            <span class="name">FOO_CONSTANT</span><span class="annotation">: int</span><span class="default_value"> = 42</span>
-
+                            <input id="FOO_CONSTANT-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">FOO_CONSTANT</span><span class="annotation">: int</span>
         
+
+                <label class="view-source-button" for="FOO_CONSTANT-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#FOO_CONSTANT"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="FOO_CONSTANT-1"><a href="#FOO_CONSTANT-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="mi">42</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A happy constant. ✨ <br />
 pdoc documents constants with their type annotation and default value.</p>
 </div>
@@ -547,7 +553,7 @@ automatically.</p>
     </div>
     <a class="headerlink" href="#a_simple_function"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="a_simple_function-66"><a href="#a_simple_function-66"><span class="linenos">66</span></a><span class="k">def</span> <span class="nf">a_simple_function</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="a_simple_function-67"><a href="#a_simple_function-67"><span class="linenos">67</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="a_simple_function-67"><a href="#a_simple_function-67"><span class="linenos">67</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="a_simple_function-68"><a href="#a_simple_function-68"><span class="linenos">68</span></a><span class="sd">    This is a basic module-level function.</span>
 </span><span id="a_simple_function-69"><a href="#a_simple_function-69"><span class="linenos">69</span></a>
 </span><span id="a_simple_function-70"><a href="#a_simple_function-70"><span class="linenos">70</span></a><span class="sd">    For a more complex example, take a look at `a_complex_function`!</span>
@@ -577,7 +583,7 @@ automatically.</p>
             <div class="pdoc-code codehilite"><pre><span></span><span id="a_complex_function-78"><a href="#a_complex_function-78"><span class="linenos">78</span></a><span class="k">def</span> <span class="nf">a_complex_function</span><span class="p">(</span>
 </span><span id="a_complex_function-79"><a href="#a_complex_function-79"><span class="linenos">79</span></a>    <span class="n">a</span><span class="p">:</span> <span class="nb">str</span><span class="p">,</span> <span class="n">b</span><span class="p">:</span> <span class="n">Union</span><span class="p">[</span><span class="s2">&quot;Foo&quot;</span><span class="p">,</span> <span class="nb">str</span><span class="p">],</span> <span class="o">*</span><span class="p">,</span> <span class="n">c</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">T</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>
 </span><span id="a_complex_function-80"><a href="#a_complex_function-80"><span class="linenos">80</span></a><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Optional</span><span class="p">[</span><span class="n">T</span><span class="p">]:</span>
-</span><span id="a_complex_function-81"><a href="#a_complex_function-81"><span class="linenos">81</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="a_complex_function-81"><a href="#a_complex_function-81"><span class="linenos">81</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="a_complex_function-82"><a href="#a_complex_function-82"><span class="linenos">82</span></a><span class="sd">    This is a function with a fairly complex signature,</span>
 </span><span id="a_complex_function-83"><a href="#a_complex_function-83"><span class="linenos">83</span></a><span class="sd">    involving type annotations with `typing.Union`, a `typing.TypeVar` (~T),</span>
 </span><span id="a_complex_function-84"><a href="#a_complex_function-84"><span class="linenos">84</span></a><span class="sd">    as well as a keyword-only arguments (*).</span>
@@ -605,7 +611,7 @@ as well as a keyword-only arguments (*).</p>
     </div>
     <a class="headerlink" href="#Foo"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Foo-89"><a href="#Foo-89"><span class="linenos"> 89</span></a><span class="k">class</span> <span class="nc">Foo</span><span class="p">:</span>
-</span><span id="Foo-90"><a href="#Foo-90"><span class="linenos"> 90</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Foo-90"><a href="#Foo-90"><span class="linenos"> 90</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Foo-91"><a href="#Foo-91"><span class="linenos"> 91</span></a><span class="sd">    `Foo` is a basic class without any parent classes (except for the implicit `object` class).</span>
 </span><span id="Foo-92"><a href="#Foo-92"><span class="linenos"> 92</span></a>
 </span><span id="Foo-93"><a href="#Foo-93"><span class="linenos"> 93</span></a><span class="sd">    You will see in the definition of `Bar` that docstrings are inherited by default.</span>
@@ -614,53 +620,53 @@ as well as a keyword-only arguments (*).</p>
 </span><span id="Foo-96"><a href="#Foo-96"><span class="linenos"> 96</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="Foo-97"><a href="#Foo-97"><span class="linenos"> 97</span></a>
 </span><span id="Foo-98"><a href="#Foo-98"><span class="linenos"> 98</span></a>    <span class="n">an_attribute</span><span class="p">:</span> <span class="n">Union</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="n">List</span><span class="p">[</span><span class="s2">&quot;int&quot;</span><span class="p">]]</span>
-</span><span id="Foo-99"><a href="#Foo-99"><span class="linenos"> 99</span></a>    <span class="sd">&quot;&quot;&quot;A regular attribute with type annotations&quot;&quot;&quot;</span>
+</span><span id="Foo-99"><a href="#Foo-99"><span class="linenos"> 99</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A regular attribute with type annotations&quot;&quot;&quot;</span>
 </span><span id="Foo-100"><a href="#Foo-100"><span class="linenos">100</span></a>
 </span><span id="Foo-101"><a href="#Foo-101"><span class="linenos">101</span></a>    <span class="n">a_class_attribute</span><span class="p">:</span> <span class="n">ClassVar</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="s2">&quot;lots of foo!&quot;</span>
-</span><span id="Foo-102"><a href="#Foo-102"><span class="linenos">102</span></a>    <span class="sd">&quot;&quot;&quot;An attribute with a ClassVar annotation.&quot;&quot;&quot;</span>
+</span><span id="Foo-102"><a href="#Foo-102"><span class="linenos">102</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An attribute with a ClassVar annotation.&quot;&quot;&quot;</span>
 </span><span id="Foo-103"><a href="#Foo-103"><span class="linenos">103</span></a>
 </span><span id="Foo-104"><a href="#Foo-104"><span class="linenos">104</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
-</span><span id="Foo-105"><a href="#Foo-105"><span class="linenos">105</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Foo-105"><a href="#Foo-105"><span class="linenos">105</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Foo-106"><a href="#Foo-106"><span class="linenos">106</span></a><span class="sd">        The constructor is currently always listed first as this feels most natural.&quot;&quot;&quot;</span>
 </span><span id="Foo-107"><a href="#Foo-107"><span class="linenos">107</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">a_constructor_only_attribute</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">42</span>
-</span><span id="Foo-108"><a href="#Foo-108"><span class="linenos">108</span></a>        <span class="sd">&quot;&quot;&quot;This attribute is defined in the constructor only, but still picked up by pdoc&#39;s AST traversal.&quot;&quot;&quot;</span>
+</span><span id="Foo-108"><a href="#Foo-108"><span class="linenos">108</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This attribute is defined in the constructor only, but still picked up by pdoc&#39;s AST traversal.&quot;&quot;&quot;</span>
 </span><span id="Foo-109"><a href="#Foo-109"><span class="linenos">109</span></a>
 </span><span id="Foo-110"><a href="#Foo-110"><span class="linenos">110</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">undocumented_constructor_attribute</span> <span class="o">=</span> <span class="mi">42</span>
 </span><span id="Foo-111"><a href="#Foo-111"><span class="linenos">111</span></a>        <span class="n">a_complex_function</span><span class="p">(</span><span class="s2">&quot;a&quot;</span><span class="p">,</span> <span class="s2">&quot;Foo&quot;</span><span class="p">)</span>
 </span><span id="Foo-112"><a href="#Foo-112"><span class="linenos">112</span></a>
 </span><span id="Foo-113"><a href="#Foo-113"><span class="linenos">113</span></a>    <span class="k">def</span> <span class="nf">a_regular_function</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s2">&quot;Foo&quot;</span><span class="p">:</span>
-</span><span id="Foo-114"><a href="#Foo-114"><span class="linenos">114</span></a>        <span class="sd">&quot;&quot;&quot;This is a regular method, returning the object itself.&quot;&quot;&quot;</span>
+</span><span id="Foo-114"><a href="#Foo-114"><span class="linenos">114</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is a regular method, returning the object itself.&quot;&quot;&quot;</span>
 </span><span id="Foo-115"><a href="#Foo-115"><span class="linenos">115</span></a>        <span class="k">return</span> <span class="bp">self</span>
 </span><span id="Foo-116"><a href="#Foo-116"><span class="linenos">116</span></a>
 </span><span id="Foo-117"><a href="#Foo-117"><span class="linenos">117</span></a>    <span class="nd">@property</span>
 </span><span id="Foo-118"><a href="#Foo-118"><span class="linenos">118</span></a>    <span class="k">def</span> <span class="nf">a_property</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Foo-119"><a href="#Foo-119"><span class="linenos">119</span></a>        <span class="sd">&quot;&quot;&quot;This is a `@property` attribute. pdoc will display it as a variable.&quot;&quot;&quot;</span>
+</span><span id="Foo-119"><a href="#Foo-119"><span class="linenos">119</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is a `@property` attribute. pdoc will display it as a variable.&quot;&quot;&quot;</span>
 </span><span id="Foo-120"><a href="#Foo-120"><span class="linenos">120</span></a>        <span class="k">return</span> <span class="s2">&quot;true foo&quot;</span>
 </span><span id="Foo-121"><a href="#Foo-121"><span class="linenos">121</span></a>
 </span><span id="Foo-122"><a href="#Foo-122"><span class="linenos">122</span></a>    <span class="nd">@cached_property</span>
 </span><span id="Foo-123"><a href="#Foo-123"><span class="linenos">123</span></a>    <span class="k">def</span> <span class="nf">a_cached_property</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Foo-124"><a href="#Foo-124"><span class="linenos">124</span></a>        <span class="sd">&quot;&quot;&quot;This is a `@functools.cached_property` attribute. pdoc will display it as a variable as well.&quot;&quot;&quot;</span>
+</span><span id="Foo-124"><a href="#Foo-124"><span class="linenos">124</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is a `@functools.cached_property` attribute. pdoc will display it as a variable as well.&quot;&quot;&quot;</span>
 </span><span id="Foo-125"><a href="#Foo-125"><span class="linenos">125</span></a>        <span class="k">return</span> <span class="s2">&quot;true foo&quot;</span>
 </span><span id="Foo-126"><a href="#Foo-126"><span class="linenos">126</span></a>
 </span><span id="Foo-127"><a href="#Foo-127"><span class="linenos">127</span></a>    <span class="nd">@cache</span>
 </span><span id="Foo-128"><a href="#Foo-128"><span class="linenos">128</span></a>    <span class="k">def</span> <span class="nf">a_cached_function</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Foo-129"><a href="#Foo-129"><span class="linenos">129</span></a>        <span class="sd">&quot;&quot;&quot;This is method with `@cache` decoration.&quot;&quot;&quot;</span>
+</span><span id="Foo-129"><a href="#Foo-129"><span class="linenos">129</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is method with `@cache` decoration.&quot;&quot;&quot;</span>
 </span><span id="Foo-130"><a href="#Foo-130"><span class="linenos">130</span></a>        <span class="k">return</span> <span class="s2">&quot;true foo&quot;</span>
 </span><span id="Foo-131"><a href="#Foo-131"><span class="linenos">131</span></a>
 </span><span id="Foo-132"><a href="#Foo-132"><span class="linenos">132</span></a>    <span class="nd">@classmethod</span>
 </span><span id="Foo-133"><a href="#Foo-133"><span class="linenos">133</span></a>    <span class="k">def</span> <span class="nf">a_class_method</span><span class="p">(</span><span class="bp">cls</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="Foo-134"><a href="#Foo-134"><span class="linenos">134</span></a>        <span class="sd">&quot;&quot;&quot;This is what a `@classmethod` looks like.&quot;&quot;&quot;</span>
+</span><span id="Foo-134"><a href="#Foo-134"><span class="linenos">134</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is what a `@classmethod` looks like.&quot;&quot;&quot;</span>
 </span><span id="Foo-135"><a href="#Foo-135"><span class="linenos">135</span></a>        <span class="k">return</span> <span class="mi">24</span>
 </span><span id="Foo-136"><a href="#Foo-136"><span class="linenos">136</span></a>
 </span><span id="Foo-137"><a href="#Foo-137"><span class="linenos">137</span></a>    <span class="nd">@classmethod</span>  <span class="c1"># type: ignore</span>
 </span><span id="Foo-138"><a href="#Foo-138"><span class="linenos">138</span></a>    <span class="nd">@property</span>
 </span><span id="Foo-139"><a href="#Foo-139"><span class="linenos">139</span></a>    <span class="k">def</span> <span class="nf">a_class_property</span><span class="p">(</span><span class="bp">cls</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="Foo-140"><a href="#Foo-140"><span class="linenos">140</span></a>        <span class="sd">&quot;&quot;&quot;This is what a `@classmethod @property` looks like.&quot;&quot;&quot;</span>
+</span><span id="Foo-140"><a href="#Foo-140"><span class="linenos">140</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is what a `@classmethod @property` looks like.&quot;&quot;&quot;</span>
 </span><span id="Foo-141"><a href="#Foo-141"><span class="linenos">141</span></a>        <span class="k">return</span> <span class="mi">24</span>
 </span><span id="Foo-142"><a href="#Foo-142"><span class="linenos">142</span></a>
 </span><span id="Foo-143"><a href="#Foo-143"><span class="linenos">143</span></a>    <span class="nd">@staticmethod</span>
 </span><span id="Foo-144"><a href="#Foo-144"><span class="linenos">144</span></a>    <span class="k">def</span> <span class="nf">a_static_method</span><span class="p">():</span>
-</span><span id="Foo-145"><a href="#Foo-145"><span class="linenos">145</span></a>        <span class="sd">&quot;&quot;&quot;This is what a `@staticmethod` looks like.&quot;&quot;&quot;</span>
+</span><span id="Foo-145"><a href="#Foo-145"><span class="linenos">145</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is what a `@staticmethod` looks like.&quot;&quot;&quot;</span>
 </span><span id="Foo-146"><a href="#Foo-146"><span class="linenos">146</span></a>        <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Hello World&quot;</span><span class="p">)</span>
 </span></pre></div>
 
@@ -684,10 +690,10 @@ as well as a keyword-only arguments (*).</p>
     </div>
     <a class="headerlink" href="#Foo.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.__init__-104"><a href="#Foo.__init__-104"><span class="linenos">104</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
-</span><span id="Foo.__init__-105"><a href="#Foo.__init__-105"><span class="linenos">105</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Foo.__init__-105"><a href="#Foo.__init__-105"><span class="linenos">105</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Foo.__init__-106"><a href="#Foo.__init__-106"><span class="linenos">106</span></a><span class="sd">        The constructor is currently always listed first as this feels most natural.&quot;&quot;&quot;</span>
 </span><span id="Foo.__init__-107"><a href="#Foo.__init__-107"><span class="linenos">107</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">a_constructor_only_attribute</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">42</span>
-</span><span id="Foo.__init__-108"><a href="#Foo.__init__-108"><span class="linenos">108</span></a>        <span class="sd">&quot;&quot;&quot;This attribute is defined in the constructor only, but still picked up by pdoc&#39;s AST traversal.&quot;&quot;&quot;</span>
+</span><span id="Foo.__init__-108"><a href="#Foo.__init__-108"><span class="linenos">108</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This attribute is defined in the constructor only, but still picked up by pdoc&#39;s AST traversal.&quot;&quot;&quot;</span>
 </span><span id="Foo.__init__-109"><a href="#Foo.__init__-109"><span class="linenos">109</span></a>
 </span><span id="Foo.__init__-110"><a href="#Foo.__init__-110"><span class="linenos">110</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">undocumented_constructor_attribute</span> <span class="o">=</span> <span class="mi">42</span>
 </span><span id="Foo.__init__-111"><a href="#Foo.__init__-111"><span class="linenos">111</span></a>        <span class="n">a_complex_function</span><span class="p">(</span><span class="s2">&quot;a&quot;</span><span class="p">,</span> <span class="s2">&quot;Foo&quot;</span><span class="p">)</span>
@@ -713,13 +719,19 @@ as well as a keyword-only arguments (*).</p>
 
                             </div>
                             <div id="Foo.a_class_attribute" class="classattr">
-                                <div class="attr variable">
-            <span class="name">a_class_attribute</span><span class="annotation">: ClassVar[str]</span><span class="default_value"> = &#39;lots of foo!&#39;</span>
-
+                                        <input id="Foo.a_class_attribute-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">a_class_attribute</span><span class="annotation">: ClassVar[str]</span>
         
+
+                <label class="view-source-button" for="Foo.a_class_attribute-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Foo.a_class_attribute"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.a_class_attribute-1"><a href="#Foo.a_class_attribute-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="s1">&#39;lots of foo!&#39;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>An attribute with a ClassVar annotation.</p>
 </div>
 
@@ -750,7 +762,7 @@ as well as a keyword-only arguments (*).</p>
     </div>
     <a class="headerlink" href="#Foo.a_regular_function"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.a_regular_function-113"><a href="#Foo.a_regular_function-113"><span class="linenos">113</span></a>    <span class="k">def</span> <span class="nf">a_regular_function</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="s2">&quot;Foo&quot;</span><span class="p">:</span>
-</span><span id="Foo.a_regular_function-114"><a href="#Foo.a_regular_function-114"><span class="linenos">114</span></a>        <span class="sd">&quot;&quot;&quot;This is a regular method, returning the object itself.&quot;&quot;&quot;</span>
+</span><span id="Foo.a_regular_function-114"><a href="#Foo.a_regular_function-114"><span class="linenos">114</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is a regular method, returning the object itself.&quot;&quot;&quot;</span>
 </span><span id="Foo.a_regular_function-115"><a href="#Foo.a_regular_function-115"><span class="linenos">115</span></a>        <span class="k">return</span> <span class="bp">self</span>
 </span></pre></div>
 
@@ -800,7 +812,7 @@ as well as a keyword-only arguments (*).</p>
     <a class="headerlink" href="#Foo.a_cached_function"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.a_cached_function-127"><a href="#Foo.a_cached_function-127"><span class="linenos">127</span></a>    <span class="nd">@cache</span>
 </span><span id="Foo.a_cached_function-128"><a href="#Foo.a_cached_function-128"><span class="linenos">128</span></a>    <span class="k">def</span> <span class="nf">a_cached_function</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Foo.a_cached_function-129"><a href="#Foo.a_cached_function-129"><span class="linenos">129</span></a>        <span class="sd">&quot;&quot;&quot;This is method with `@cache` decoration.&quot;&quot;&quot;</span>
+</span><span id="Foo.a_cached_function-129"><a href="#Foo.a_cached_function-129"><span class="linenos">129</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is method with `@cache` decoration.&quot;&quot;&quot;</span>
 </span><span id="Foo.a_cached_function-130"><a href="#Foo.a_cached_function-130"><span class="linenos">130</span></a>        <span class="k">return</span> <span class="s2">&quot;true foo&quot;</span>
 </span></pre></div>
 
@@ -824,7 +836,7 @@ as well as a keyword-only arguments (*).</p>
     <a class="headerlink" href="#Foo.a_class_method"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.a_class_method-132"><a href="#Foo.a_class_method-132"><span class="linenos">132</span></a>    <span class="nd">@classmethod</span>
 </span><span id="Foo.a_class_method-133"><a href="#Foo.a_class_method-133"><span class="linenos">133</span></a>    <span class="k">def</span> <span class="nf">a_class_method</span><span class="p">(</span><span class="bp">cls</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="Foo.a_class_method-134"><a href="#Foo.a_class_method-134"><span class="linenos">134</span></a>        <span class="sd">&quot;&quot;&quot;This is what a `@classmethod` looks like.&quot;&quot;&quot;</span>
+</span><span id="Foo.a_class_method-134"><a href="#Foo.a_class_method-134"><span class="linenos">134</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is what a `@classmethod` looks like.&quot;&quot;&quot;</span>
 </span><span id="Foo.a_class_method-135"><a href="#Foo.a_class_method-135"><span class="linenos">135</span></a>        <span class="k">return</span> <span class="mi">24</span>
 </span></pre></div>
 
@@ -861,7 +873,7 @@ as well as a keyword-only arguments (*).</p>
     <a class="headerlink" href="#Foo.a_static_method"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.a_static_method-143"><a href="#Foo.a_static_method-143"><span class="linenos">143</span></a>    <span class="nd">@staticmethod</span>
 </span><span id="Foo.a_static_method-144"><a href="#Foo.a_static_method-144"><span class="linenos">144</span></a>    <span class="k">def</span> <span class="nf">a_static_method</span><span class="p">():</span>
-</span><span id="Foo.a_static_method-145"><a href="#Foo.a_static_method-145"><span class="linenos">145</span></a>        <span class="sd">&quot;&quot;&quot;This is what a `@staticmethod` looks like.&quot;&quot;&quot;</span>
+</span><span id="Foo.a_static_method-145"><a href="#Foo.a_static_method-145"><span class="linenos">145</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is what a `@staticmethod` looks like.&quot;&quot;&quot;</span>
 </span><span id="Foo.a_static_method-146"><a href="#Foo.a_static_method-146"><span class="linenos">146</span></a>        <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Hello World&quot;</span><span class="p">)</span>
 </span></pre></div>
 
@@ -885,10 +897,10 @@ as well as a keyword-only arguments (*).</p>
     <a class="headerlink" href="#Bar"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Bar-149"><a href="#Bar-149"><span class="linenos">149</span></a><span class="k">class</span> <span class="nc">Bar</span><span class="p">(</span><span class="n">Foo</span><span class="p">):</span>
 </span><span id="Bar-150"><a href="#Bar-150"><span class="linenos">150</span></a>    <span class="n">bar</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Bar-151"><a href="#Bar-151"><span class="linenos">151</span></a>    <span class="sd">&quot;&quot;&quot;A new attribute defined on this subclass.&quot;&quot;&quot;</span>
+</span><span id="Bar-151"><a href="#Bar-151"><span class="linenos">151</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A new attribute defined on this subclass.&quot;&quot;&quot;</span>
 </span><span id="Bar-152"><a href="#Bar-152"><span class="linenos">152</span></a>
 </span><span id="Bar-153"><a href="#Bar-153"><span class="linenos">153</span></a>    <span class="k">class</span> <span class="nc">Baz</span><span class="p">:</span>
-</span><span id="Bar-154"><a href="#Bar-154"><span class="linenos">154</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Bar-154"><a href="#Bar-154"><span class="linenos">154</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Bar-155"><a href="#Bar-155"><span class="linenos">155</span></a><span class="sd">        This class is an attribute of `Bar`.</span>
 </span><span id="Bar-156"><a href="#Bar-156"><span class="linenos">156</span></a><span class="sd">        To not create overwhelmingly complex trees, pdoc flattens the class hierarchy in the documentation</span>
 </span><span id="Bar-157"><a href="#Bar-157"><span class="linenos">157</span></a><span class="sd">        (but not in the navigation).</span>
@@ -900,7 +912,7 @@ as well as a keyword-only arguments (*).</p>
 </span><span id="Bar-163"><a href="#Bar-163"><span class="linenos">163</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Bar-164"><a href="#Bar-164"><span class="linenos">164</span></a>
 </span><span id="Bar-165"><a href="#Bar-165"><span class="linenos">165</span></a>        <span class="k">def</span> <span class="nf">wat</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Bar-166"><a href="#Bar-166"><span class="linenos">166</span></a>            <span class="sd">&quot;&quot;&quot;A regular method. Above, you see what happens if a class has no constructor defined and</span>
+</span><span id="Bar-166"><a href="#Bar-166"><span class="linenos">166</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;A regular method. Above, you see what happens if a class has no constructor defined and</span>
 </span><span id="Bar-167"><a href="#Bar-167"><span class="linenos">167</span></a><span class="sd">            no constructor docstring.&quot;&quot;&quot;</span>
 </span></pre></div>
 
@@ -958,7 +970,7 @@ as well as a keyword-only arguments (*).</p>
     </div>
     <a class="headerlink" href="#Bar.Baz"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Bar.Baz-153"><a href="#Bar.Baz-153"><span class="linenos">153</span></a>    <span class="k">class</span> <span class="nc">Baz</span><span class="p">:</span>
-</span><span id="Bar.Baz-154"><a href="#Bar.Baz-154"><span class="linenos">154</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Bar.Baz-154"><a href="#Bar.Baz-154"><span class="linenos">154</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Bar.Baz-155"><a href="#Bar.Baz-155"><span class="linenos">155</span></a><span class="sd">        This class is an attribute of `Bar`.</span>
 </span><span id="Bar.Baz-156"><a href="#Bar.Baz-156"><span class="linenos">156</span></a><span class="sd">        To not create overwhelmingly complex trees, pdoc flattens the class hierarchy in the documentation</span>
 </span><span id="Bar.Baz-157"><a href="#Bar.Baz-157"><span class="linenos">157</span></a><span class="sd">        (but not in the navigation).</span>
@@ -970,7 +982,7 @@ as well as a keyword-only arguments (*).</p>
 </span><span id="Bar.Baz-163"><a href="#Bar.Baz-163"><span class="linenos">163</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Bar.Baz-164"><a href="#Bar.Baz-164"><span class="linenos">164</span></a>
 </span><span id="Bar.Baz-165"><a href="#Bar.Baz-165"><span class="linenos">165</span></a>        <span class="k">def</span> <span class="nf">wat</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Bar.Baz-166"><a href="#Bar.Baz-166"><span class="linenos">166</span></a>            <span class="sd">&quot;&quot;&quot;A regular method. Above, you see what happens if a class has no constructor defined and</span>
+</span><span id="Bar.Baz-166"><a href="#Bar.Baz-166"><span class="linenos">166</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;A regular method. Above, you see what happens if a class has no constructor defined and</span>
 </span><span id="Bar.Baz-167"><a href="#Bar.Baz-167"><span class="linenos">167</span></a><span class="sd">            no constructor docstring.&quot;&quot;&quot;</span>
 </span></pre></div>
 
@@ -1010,7 +1022,7 @@ Think about moving stuff in a new package instead!</p>
     </div>
     <a class="headerlink" href="#Bar.Baz.wat"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Bar.Baz.wat-165"><a href="#Bar.Baz.wat-165"><span class="linenos">165</span></a>        <span class="k">def</span> <span class="nf">wat</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Bar.Baz.wat-166"><a href="#Bar.Baz.wat-166"><span class="linenos">166</span></a>            <span class="sd">&quot;&quot;&quot;A regular method. Above, you see what happens if a class has no constructor defined and</span>
+</span><span id="Bar.Baz.wat-166"><a href="#Bar.Baz.wat-166"><span class="linenos">166</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;A regular method. Above, you see what happens if a class has no constructor defined and</span>
 </span><span id="Bar.Baz.wat-167"><a href="#Bar.Baz.wat-167"><span class="linenos">167</span></a><span class="sd">            no constructor docstring.&quot;&quot;&quot;</span>
 </span></pre></div>
 
@@ -1034,7 +1046,7 @@ no constructor docstring.</p>
     </div>
     <a class="headerlink" href="#i_am_async"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="i_am_async-170"><a href="#i_am_async-170"><span class="linenos">170</span></a><span class="k">async</span> <span class="k">def</span> <span class="nf">i_am_async</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="i_am_async-171"><a href="#i_am_async-171"><span class="linenos">171</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="i_am_async-171"><a href="#i_am_async-171"><span class="linenos">171</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="i_am_async-172"><a href="#i_am_async-172"><span class="linenos">172</span></a><span class="sd">    This is an example of an async function.</span>
 </span><span id="i_am_async-173"><a href="#i_am_async-173"><span class="linenos">173</span></a>
 </span><span id="i_am_async-174"><a href="#i_am_async-174"><span class="linenos">174</span></a><span class="sd">    - Knock, knock</span>
@@ -1070,7 +1082,7 @@ no constructor docstring.</p>
     <a class="headerlink" href="#fib"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="fib-181"><a href="#fib-181"><span class="linenos">181</span></a><span class="nd">@cache</span>
 </span><span id="fib-182"><a href="#fib-182"><span class="linenos">182</span></a><span class="k">def</span> <span class="nf">fib</span><span class="p">(</span><span class="n">n</span><span class="p">):</span>
-</span><span id="fib-183"><a href="#fib-183"><span class="linenos">183</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="fib-183"><a href="#fib-183"><span class="linenos">183</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="fib-184"><a href="#fib-184"><span class="linenos">184</span></a><span class="sd">    This is an example of decorated function. Decorators are included in the documentation as well.</span>
 </span><span id="fib-185"><a href="#fib-185"><span class="linenos">185</span></a><span class="sd">    This is often useful when documenting web APIs, for example.</span>
 </span><span id="fib-186"><a href="#fib-186"><span class="linenos">186</span></a><span class="sd">    &quot;&quot;&quot;</span>
@@ -1098,7 +1110,7 @@ This is often useful when documenting web APIs, for example.</p>
     </div>
     <a class="headerlink" href="#security"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="security-192"><a href="#security-192"><span class="linenos">192</span></a><span class="k">def</span> <span class="nf">security</span><span class="p">(</span><span class="n">test</span><span class="o">=</span><span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="p">):</span>
-</span><span id="security-193"><a href="#security-193"><span class="linenos">193</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="security-193"><a href="#security-193"><span class="linenos">193</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="security-194"><a href="#security-194"><span class="linenos">194</span></a><span class="sd">    Default values are generally rendered using repr(),</span>
 </span><span id="security-195"><a href="#security-195"><span class="linenos">195</span></a><span class="sd">    but some special cases -- like os.environ -- are overridden to avoid leaking sensitive data.</span>
 </span><span id="security-196"><a href="#security-196"><span class="linenos">196</span></a><span class="sd">    &quot;&quot;&quot;</span>
@@ -1124,7 +1136,7 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
     </div>
     <a class="headerlink" href="#DoubleInherit"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="DoubleInherit-200"><a href="#DoubleInherit-200"><span class="linenos">200</span></a><span class="k">class</span> <span class="nc">DoubleInherit</span><span class="p">(</span><span class="n">Foo</span><span class="p">,</span> <span class="n">Bar</span><span class="o">.</span><span class="n">Baz</span><span class="p">,</span> <span class="n">abc</span><span class="o">.</span><span class="n">ABC</span><span class="p">):</span>
-</span><span id="DoubleInherit-201"><a href="#DoubleInherit-201"><span class="linenos">201</span></a>    <span class="sd">&quot;&quot;&quot;This is an example of a class that inherits from multiple parent classes.&quot;&quot;&quot;</span>
+</span><span id="DoubleInherit-201"><a href="#DoubleInherit-201"><span class="linenos">201</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This is an example of a class that inherits from multiple parent classes.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1157,13 +1169,19 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
                             </div>
                 </section>
                 <section id="CONST_B">
-                    <div class="attr variable">
-            <span class="name">CONST_B</span><span class="default_value"> = &#39;yes&#39;</span>
-
+                            <input id="CONST_B-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">CONST_B</span>
         
+
+                <label class="view-source-button" for="CONST_B-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#CONST_B"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="CONST_B-1"><a href="#CONST_B-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="s1">&#39;yes&#39;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A constant without type annotation</p>
 </div>
 
@@ -1183,14 +1201,14 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
     <a class="headerlink" href="#DataDemo"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="DataDemo-210"><a href="#DataDemo-210"><span class="linenos">210</span></a><span class="nd">@dataclass</span>
 </span><span id="DataDemo-211"><a href="#DataDemo-211"><span class="linenos">211</span></a><span class="k">class</span> <span class="nc">DataDemo</span><span class="p">:</span>
-</span><span id="DataDemo-212"><a href="#DataDemo-212"><span class="linenos">212</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="DataDemo-212"><a href="#DataDemo-212"><span class="linenos">212</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="DataDemo-213"><a href="#DataDemo-213"><span class="linenos">213</span></a><span class="sd">    This is an example for a dataclass.</span>
 </span><span id="DataDemo-214"><a href="#DataDemo-214"><span class="linenos">214</span></a>
 </span><span id="DataDemo-215"><a href="#DataDemo-215"><span class="linenos">215</span></a><span class="sd">    As usual, you can link to individual properties: `DataDemo.a`.</span>
 </span><span id="DataDemo-216"><a href="#DataDemo-216"><span class="linenos">216</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="DataDemo-217"><a href="#DataDemo-217"><span class="linenos">217</span></a>
 </span><span id="DataDemo-218"><a href="#DataDemo-218"><span class="linenos">218</span></a>    <span class="n">a</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="DataDemo-219"><a href="#DataDemo-219"><span class="linenos">219</span></a>    <span class="sd">&quot;&quot;&quot;Again, we can document individual properties with docstrings.&quot;&quot;&quot;</span>
+</span><span id="DataDemo-219"><a href="#DataDemo-219"><span class="linenos">219</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Again, we can document individual properties with docstrings.&quot;&quot;&quot;</span>
 </span><span id="DataDemo-220"><a href="#DataDemo-220"><span class="linenos">220</span></a>    <span class="n">a2</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span>
 </span><span id="DataDemo-221"><a href="#DataDemo-221"><span class="linenos">221</span></a>    <span class="c1"># This property has a type annotation but is not documented.</span>
 </span><span id="DataDemo-222"><a href="#DataDemo-222"><span class="linenos">222</span></a>    <span class="n">a3</span> <span class="o">=</span> <span class="s2">&quot;a3&quot;</span>
@@ -1198,7 +1216,7 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
 </span><span id="DataDemo-224"><a href="#DataDemo-224"><span class="linenos">224</span></a>    <span class="n">a4</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;a4&quot;</span>
 </span><span id="DataDemo-225"><a href="#DataDemo-225"><span class="linenos">225</span></a>    <span class="c1"># This property has a type annotation and a default value but is not documented.</span>
 </span><span id="DataDemo-226"><a href="#DataDemo-226"><span class="linenos">226</span></a>    <span class="n">b</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="n">field</span><span class="p">(</span><span class="nb">repr</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
-</span><span id="DataDemo-227"><a href="#DataDemo-227"><span class="linenos">227</span></a>    <span class="sd">&quot;&quot;&quot;This property is assigned to `dataclasses.field()`, which works just as well.&quot;&quot;&quot;</span>
+</span><span id="DataDemo-227"><a href="#DataDemo-227"><span class="linenos">227</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This property is assigned to `dataclasses.field()`, which works just as well.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1234,13 +1252,19 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
 
                             </div>
                             <div id="DataDemo.b" class="classattr">
-                                <div class="attr variable">
-            <span class="name">b</span><span class="annotation">: bool</span><span class="default_value"> = True</span>
-
+                                        <input id="DataDemo.b-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">b</span><span class="annotation">: bool</span>
         
+
+                <label class="view-source-button" for="DataDemo.b-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#DataDemo.b"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="DataDemo.b-1"><a href="#DataDemo.b-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="kc">True</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>This property is assigned to <code>dataclasses.field()</code>, which works just as well.</p>
 </div>
 
@@ -1262,7 +1286,7 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
             <div class="pdoc-code codehilite"><pre><span></span><span id="DataDemoExtended-230"><a href="#DataDemoExtended-230"><span class="linenos">230</span></a><span class="nd">@dataclass</span>
 </span><span id="DataDemoExtended-231"><a href="#DataDemoExtended-231"><span class="linenos">231</span></a><span class="k">class</span> <span class="nc">DataDemoExtended</span><span class="p">(</span><span class="n">DataDemo</span><span class="p">):</span>
 </span><span id="DataDemoExtended-232"><a href="#DataDemoExtended-232"><span class="linenos">232</span></a>    <span class="n">c</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;42&quot;</span>
-</span><span id="DataDemoExtended-233"><a href="#DataDemoExtended-233"><span class="linenos">233</span></a>    <span class="sd">&quot;&quot;&quot;A new attribute.&quot;&quot;&quot;</span>
+</span><span id="DataDemoExtended-233"><a href="#DataDemoExtended-233"><span class="linenos">233</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A new attribute.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1281,13 +1305,19 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
 
                             </div>
                             <div id="DataDemoExtended.c" class="classattr">
-                                <div class="attr variable">
-            <span class="name">c</span><span class="annotation">: str</span><span class="default_value"> = &#39;42&#39;</span>
-
+                                        <input id="DataDemoExtended.c-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">c</span><span class="annotation">: str</span>
         
+
+                <label class="view-source-button" for="DataDemoExtended.c-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#DataDemoExtended.c"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="DataDemoExtended.c-1"><a href="#DataDemoExtended.c-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="s1">&#39;42&#39;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A new attribute.</p>
 </div>
 
@@ -1316,16 +1346,16 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
     </div>
     <a class="headerlink" href="#EnumDemo"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="EnumDemo-236"><a href="#EnumDemo-236"><span class="linenos">236</span></a><span class="k">class</span> <span class="nc">EnumDemo</span><span class="p">(</span><span class="n">enum</span><span class="o">.</span><span class="n">Enum</span><span class="p">):</span>
-</span><span id="EnumDemo-237"><a href="#EnumDemo-237"><span class="linenos">237</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="EnumDemo-237"><a href="#EnumDemo-237"><span class="linenos">237</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="EnumDemo-238"><a href="#EnumDemo-238"><span class="linenos">238</span></a><span class="sd">    This is an example of an Enum.</span>
 </span><span id="EnumDemo-239"><a href="#EnumDemo-239"><span class="linenos">239</span></a>
 </span><span id="EnumDemo-240"><a href="#EnumDemo-240"><span class="linenos">240</span></a><span class="sd">    As usual, you can link to individual properties: `GREEN`.</span>
 </span><span id="EnumDemo-241"><a href="#EnumDemo-241"><span class="linenos">241</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="EnumDemo-242"><a href="#EnumDemo-242"><span class="linenos">242</span></a>
 </span><span id="EnumDemo-243"><a href="#EnumDemo-243"><span class="linenos">243</span></a>    <span class="n">RED</span> <span class="o">=</span> <span class="mi">1</span>
-</span><span id="EnumDemo-244"><a href="#EnumDemo-244"><span class="linenos">244</span></a>    <span class="sd">&quot;&quot;&quot;I am the red.&quot;&quot;&quot;</span>
+</span><span id="EnumDemo-244"><a href="#EnumDemo-244"><span class="linenos">244</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;I am the red.&quot;&quot;&quot;</span>
 </span><span id="EnumDemo-245"><a href="#EnumDemo-245"><span class="linenos">245</span></a>    <span class="n">GREEN</span> <span class="o">=</span> <span class="mi">2</span>
-</span><span id="EnumDemo-246"><a href="#EnumDemo-246"><span class="linenos">246</span></a>    <span class="sd">&quot;&quot;&quot;I am green.&quot;&quot;&quot;</span>
+</span><span id="EnumDemo-246"><a href="#EnumDemo-246"><span class="linenos">246</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;I am green.&quot;&quot;&quot;</span>
 </span><span id="EnumDemo-247"><a href="#EnumDemo-247"><span class="linenos">247</span></a>    <span class="n">BLUE</span> <span class="o">=</span> <span class="n">enum</span><span class="o">.</span><span class="n">auto</span><span class="p">()</span>
 </span></pre></div>
 
@@ -1337,39 +1367,57 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
 
 
                             <div id="EnumDemo.RED" class="classattr">
-                                <div class="attr variable">
-            <span class="name">RED</span><span class="default_value"> = &lt;<a href="#EnumDemo.RED">EnumDemo.RED</a>: 1&gt;</span>
-
+                                        <input id="EnumDemo.RED-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">RED</span>
         
+
+                <label class="view-source-button" for="EnumDemo.RED-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumDemo.RED"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumDemo.RED-1"><a href="#EnumDemo.RED-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="o">&lt;</span><span class="n">EnumDemo</span><span class="o">.</span><span class="n">RED</span><span class="p">:</span> <span class="mi">1</span><span class="o">&gt;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>I am the red.</p>
 </div>
 
 
                             </div>
                             <div id="EnumDemo.GREEN" class="classattr">
-                                <div class="attr variable">
-            <span class="name">GREEN</span><span class="default_value"> = &lt;<a href="#EnumDemo.GREEN">EnumDemo.GREEN</a>: 2&gt;</span>
-
+                                        <input id="EnumDemo.GREEN-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">GREEN</span>
         
+
+                <label class="view-source-button" for="EnumDemo.GREEN-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumDemo.GREEN"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumDemo.GREEN-1"><a href="#EnumDemo.GREEN-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="o">&lt;</span><span class="n">EnumDemo</span><span class="o">.</span><span class="n">GREEN</span><span class="p">:</span> <span class="mi">2</span><span class="o">&gt;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>I am green.</p>
 </div>
 
 
                             </div>
                             <div id="EnumDemo.BLUE" class="classattr">
-                                <div class="attr variable">
-            <span class="name">BLUE</span><span class="default_value"> = &lt;<a href="#EnumDemo.BLUE">EnumDemo.BLUE</a>: 3&gt;</span>
-
+                                        <input id="EnumDemo.BLUE-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">BLUE</span>
         
+
+                <label class="view-source-button" for="EnumDemo.BLUE-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumDemo.BLUE"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumDemo.BLUE-1"><a href="#EnumDemo.BLUE-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="o">&lt;</span><span class="n">EnumDemo</span><span class="o">.</span><span class="n">BLUE</span><span class="p">:</span> <span class="mi">3</span><span class="o">&gt;</span>
+</span></pre></div>
+
+
     
 
                             </div>
@@ -1396,7 +1444,7 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
     </div>
     <a class="headerlink" href="#embed_image"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="embed_image-250"><a href="#embed_image-250"><span class="linenos">250</span></a><span class="k">def</span> <span class="nf">embed_image</span><span class="p">():</span>
-</span><span id="embed_image-251"><a href="#embed_image-251"><span class="linenos">251</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="embed_image-251"><a href="#embed_image-251"><span class="linenos">251</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="embed_image-252"><a href="#embed_image-252"><span class="linenos">252</span></a><span class="sd">    This docstring includes an embedded image:</span>
 </span><span id="embed_image-253"><a href="#embed_image-253"><span class="linenos">253</span></a>
 </span><span id="embed_image-254"><a href="#embed_image-254"><span class="linenos">254</span></a><span class="sd">    ```</span>
@@ -1430,7 +1478,7 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
     </div>
     <a class="headerlink" href="#admonitions"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="admonitions-262"><a href="#admonitions-262"><span class="linenos">262</span></a><span class="k">def</span> <span class="nf">admonitions</span><span class="p">():</span>
-</span><span id="admonitions-263"><a href="#admonitions-263"><span class="linenos">263</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="admonitions-263"><a href="#admonitions-263"><span class="linenos">263</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="admonitions-264"><a href="#admonitions-264"><span class="linenos">264</span></a><span class="sd">    pdoc also supports basic reStructuredText admonitions:</span>
 </span><span id="admonitions-265"><a href="#admonitions-265"><span class="linenos">265</span></a>
 </span><span id="admonitions-266"><a href="#admonitions-266"><span class="linenos">266</span></a><span class="sd">    ```</span>

--- a/test/testdata/demopackage.html
+++ b/test/testdata/demopackage.html
@@ -131,10 +131,10 @@ demopackage    </h1>
     </div>
     <a class="headerlink" href="#Test"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Test-5"><a href="#Test-5"><span class="linenos">5</span></a><span class="k">class</span> <span class="nc">Test</span><span class="p">:</span>
-</span><span id="Test-6"><a href="#Test-6"><span class="linenos">6</span></a>    <span class="sd">&quot;&quot;&quot;The Test class from _child_d.&quot;&quot;&quot;</span>
+</span><span id="Test-6"><a href="#Test-6"><span class="linenos">6</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The Test class from _child_d.&quot;&quot;&quot;</span>
 </span><span id="Test-7"><a href="#Test-7"><span class="linenos">7</span></a>
 </span><span id="Test-8"><a href="#Test-8"><span class="linenos">8</span></a>    <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="Test-9"><a href="#Test-9"><span class="linenos">9</span></a>        <span class="sd">&quot;&quot;&quot;Do foo.&quot;&quot;&quot;</span>
+</span><span id="Test-9"><a href="#Test-9"><span class="linenos">9</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Do foo.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -166,7 +166,7 @@ demopackage    </h1>
     </div>
     <a class="headerlink" href="#Test.foo"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Test.foo-8"><a href="#Test.foo-8"><span class="linenos">8</span></a>    <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">a</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="Test.foo-9"><a href="#Test.foo-9"><span class="linenos">9</span></a>        <span class="sd">&quot;&quot;&quot;Do foo.&quot;&quot;&quot;</span>
+</span><span id="Test.foo-9"><a href="#Test.foo-9"><span class="linenos">9</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Do foo.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -188,10 +188,10 @@ demopackage    </h1>
     </div>
     <a class="headerlink" href="#B"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="B-8"><a href="#B-8"><span class="linenos"> 8</span></a><span class="k">class</span> <span class="nc">B</span><span class="p">:</span>
-</span><span id="B-9"><a href="#B-9"><span class="linenos"> 9</span></a>    <span class="sd">&quot;&quot;&quot;This class is defined in .child_b.&quot;&quot;&quot;</span>
+</span><span id="B-9"><a href="#B-9"><span class="linenos"> 9</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This class is defined in .child_b.&quot;&quot;&quot;</span>
 </span><span id="B-10"><a href="#B-10"><span class="linenos">10</span></a>
 </span><span id="B-11"><a href="#B-11"><span class="linenos">11</span></a>    <span class="n">b_type</span><span class="p">:</span> <span class="n">typing</span><span class="o">.</span><span class="n">Type</span><span class="p">[</span><span class="n">B</span><span class="p">]</span>
-</span><span id="B-12"><a href="#B-12"><span class="linenos">12</span></a>    <span class="sd">&quot;&quot;&quot;we have a self-referential attribute here&quot;&quot;&quot;</span>
+</span><span id="B-12"><a href="#B-12"><span class="linenos">12</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;we have a self-referential attribute here&quot;&quot;&quot;</span>
 </span><span id="B-13"><a href="#B-13"><span class="linenos">13</span></a>
 </span><span id="B-14"><a href="#B-14"><span class="linenos">14</span></a>    <span class="k">def</span> <span class="nf">b</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
 </span><span id="B-15"><a href="#B-15"><span class="linenos">15</span></a>        <span class="k">return</span> <span class="mi">1</span>
@@ -259,7 +259,7 @@ demopackage    </h1>
     </div>
     <a class="headerlink" href="#C"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="C-6"><a href="#C-6"><span class="linenos"> 6</span></a><span class="k">class</span> <span class="nc">C</span><span class="p">(</span><span class="n">child_b</span><span class="o">.</span><span class="n">B</span><span class="p">):</span>
-</span><span id="C-7"><a href="#C-7"><span class="linenos"> 7</span></a>    <span class="sd">&quot;&quot;&quot;This class is defined in .child_c and inherits from .child_b.B&quot;&quot;&quot;</span>
+</span><span id="C-7"><a href="#C-7"><span class="linenos"> 7</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This class is defined in .child_c and inherits from .child_b.B&quot;&quot;&quot;</span>
 </span><span id="C-8"><a href="#C-8"><span class="linenos"> 8</span></a>
 </span><span id="C-9"><a href="#C-9"><span class="linenos"> 9</span></a>    <span class="k">def</span> <span class="nf">c</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
 </span><span id="C-10"><a href="#C-10"><span class="linenos">10</span></a>        <span class="k">return</span> <span class="mi">2</span>

--- a/test/testdata/demopackage_dir.html
+++ b/test/testdata/demopackage_dir.html
@@ -666,10 +666,10 @@ demopackage    </h1>
     </div>
     <a class=&quot;headerlink&quot; href=&quot;#Test&quot;></a>
             <div class=&quot;pdoc-code codehilite&quot;><pre><span></span><span id=&quot;Test-5&quot;><a href=&quot;#Test-5&quot;><span class=&quot;linenos&quot;>5</span></a><span class=&quot;k&quot;>class</span> <span class=&quot;nc&quot;>Test</span><span class=&quot;p&quot;>:</span>
-</span><span id=&quot;Test-6&quot;><a href=&quot;#Test-6&quot;><span class=&quot;linenos&quot;>6</span></a>    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;The Test class from _child_d.&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;Test-6&quot;><a href=&quot;#Test-6&quot;><span class=&quot;linenos&quot;>6</span></a><span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;The Test class from _child_d.&amp;quot;&amp;quot;&amp;quot;</span>
 </span><span id=&quot;Test-7&quot;><a href=&quot;#Test-7&quot;><span class=&quot;linenos&quot;>7</span></a>
 </span><span id=&quot;Test-8&quot;><a href=&quot;#Test-8&quot;><span class=&quot;linenos&quot;>8</span></a>    <span class=&quot;k&quot;>def</span> <span class=&quot;nf&quot;>foo</span><span class=&quot;p&quot;>(</span><span class=&quot;bp&quot;>self</span><span class=&quot;p&quot;>,</span> <span class=&quot;n&quot;>a</span><span class=&quot;p&quot;>:</span> <span class=&quot;nb&quot;>int</span><span class=&quot;p&quot;>):</span>
-</span><span id=&quot;Test-9&quot;><a href=&quot;#Test-9&quot;><span class=&quot;linenos&quot;>9</span></a>        <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;Do foo.&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;Test-9&quot;><a href=&quot;#Test-9&quot;><span class=&quot;linenos&quot;>9</span></a><span class=&quot;w&quot;>        </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;Do foo.&amp;quot;&amp;quot;&amp;quot;</span>
 </span></pre></div>
 
 
@@ -701,7 +701,7 @@ demopackage    </h1>
     </div>
     <a class=&quot;headerlink&quot; href=&quot;#Test.foo&quot;></a>
             <div class=&quot;pdoc-code codehilite&quot;><pre><span></span><span id=&quot;Test.foo-8&quot;><a href=&quot;#Test.foo-8&quot;><span class=&quot;linenos&quot;>8</span></a>    <span class=&quot;k&quot;>def</span> <span class=&quot;nf&quot;>foo</span><span class=&quot;p&quot;>(</span><span class=&quot;bp&quot;>self</span><span class=&quot;p&quot;>,</span> <span class=&quot;n&quot;>a</span><span class=&quot;p&quot;>:</span> <span class=&quot;nb&quot;>int</span><span class=&quot;p&quot;>):</span>
-</span><span id=&quot;Test.foo-9&quot;><a href=&quot;#Test.foo-9&quot;><span class=&quot;linenos&quot;>9</span></a>        <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;Do foo.&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;Test.foo-9&quot;><a href=&quot;#Test.foo-9&quot;><span class=&quot;linenos&quot;>9</span></a><span class=&quot;w&quot;>        </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;Do foo.&amp;quot;&amp;quot;&amp;quot;</span>
 </span></pre></div>
 
 
@@ -723,10 +723,10 @@ demopackage    </h1>
     </div>
     <a class=&quot;headerlink&quot; href=&quot;#B&quot;></a>
             <div class=&quot;pdoc-code codehilite&quot;><pre><span></span><span id=&quot;B-8&quot;><a href=&quot;#B-8&quot;><span class=&quot;linenos&quot;> 8</span></a><span class=&quot;k&quot;>class</span> <span class=&quot;nc&quot;>B</span><span class=&quot;p&quot;>:</span>
-</span><span id=&quot;B-9&quot;><a href=&quot;#B-9&quot;><span class=&quot;linenos&quot;> 9</span></a>    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_b.&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;B-9&quot;><a href=&quot;#B-9&quot;><span class=&quot;linenos&quot;> 9</span></a><span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_b.&amp;quot;&amp;quot;&amp;quot;</span>
 </span><span id=&quot;B-10&quot;><a href=&quot;#B-10&quot;><span class=&quot;linenos&quot;>10</span></a>
 </span><span id=&quot;B-11&quot;><a href=&quot;#B-11&quot;><span class=&quot;linenos&quot;>11</span></a>    <span class=&quot;n&quot;>b_type</span><span class=&quot;p&quot;>:</span> <span class=&quot;n&quot;>typing</span><span class=&quot;o&quot;>.</span><span class=&quot;n&quot;>Type</span><span class=&quot;p&quot;>[</span><span class=&quot;n&quot;>B</span><span class=&quot;p&quot;>]</span>
-</span><span id=&quot;B-12&quot;><a href=&quot;#B-12&quot;><span class=&quot;linenos&quot;>12</span></a>    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;we have a self-referential attribute here&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;B-12&quot;><a href=&quot;#B-12&quot;><span class=&quot;linenos&quot;>12</span></a><span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;we have a self-referential attribute here&amp;quot;&amp;quot;&amp;quot;</span>
 </span><span id=&quot;B-13&quot;><a href=&quot;#B-13&quot;><span class=&quot;linenos&quot;>13</span></a>
 </span><span id=&quot;B-14&quot;><a href=&quot;#B-14&quot;><span class=&quot;linenos&quot;>14</span></a>    <span class=&quot;k&quot;>def</span> <span class=&quot;nf&quot;>b</span><span class=&quot;p&quot;>(</span><span class=&quot;bp&quot;>self</span><span class=&quot;p&quot;>):</span>
 </span><span id=&quot;B-15&quot;><a href=&quot;#B-15&quot;><span class=&quot;linenos&quot;>15</span></a>        <span class=&quot;k&quot;>return</span> <span class=&quot;mi&quot;>1</span>
@@ -794,7 +794,7 @@ demopackage    </h1>
     </div>
     <a class=&quot;headerlink&quot; href=&quot;#C&quot;></a>
             <div class=&quot;pdoc-code codehilite&quot;><pre><span></span><span id=&quot;C-6&quot;><a href=&quot;#C-6&quot;><span class=&quot;linenos&quot;> 6</span></a><span class=&quot;k&quot;>class</span> <span class=&quot;nc&quot;>C</span><span class=&quot;p&quot;>(</span><span class=&quot;n&quot;>child_b</span><span class=&quot;o&quot;>.</span><span class=&quot;n&quot;>B</span><span class=&quot;p&quot;>):</span>
-</span><span id=&quot;C-7&quot;><a href=&quot;#C-7&quot;><span class=&quot;linenos&quot;> 7</span></a>    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_c and inherits from .child_b.B&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;C-7&quot;><a href=&quot;#C-7&quot;><span class=&quot;linenos&quot;> 7</span></a><span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_c and inherits from .child_b.B&amp;quot;&amp;quot;&amp;quot;</span>
 </span><span id=&quot;C-8&quot;><a href=&quot;#C-8&quot;><span class=&quot;linenos&quot;> 8</span></a>
 </span><span id=&quot;C-9&quot;><a href=&quot;#C-9&quot;><span class=&quot;linenos&quot;> 9</span></a>    <span class=&quot;k&quot;>def</span> <span class=&quot;nf&quot;>c</span><span class=&quot;p&quot;>(</span><span class=&quot;bp&quot;>self</span><span class=&quot;p&quot;>):</span>
 </span><span id=&quot;C-10&quot;><a href=&quot;#C-10&quot;><span class=&quot;linenos&quot;>10</span></a>        <span class=&quot;k&quot;>return</span> <span class=&quot;mi&quot;>2</span>
@@ -1108,7 +1108,7 @@ demopackage    </h1>
 </span><span id=&quot;L-3&quot;><a href=&quot;#L-3&quot;><span class=&quot;linenos&quot;>3</span></a>
 </span><span id=&quot;L-4&quot;><a href=&quot;#L-4&quot;><span class=&quot;linenos&quot;>4</span></a>
 </span><span id=&quot;L-5&quot;><a href=&quot;#L-5&quot;><span class=&quot;linenos&quot;>5</span></a><span class=&quot;k&quot;>class</span> <span class=&quot;nc&quot;>C</span><span class=&quot;p&quot;>(</span><span class=&quot;n&quot;>child_b</span><span class=&quot;o&quot;>.</span><span class=&quot;n&quot;>B</span><span class=&quot;p&quot;>):</span>
-</span><span id=&quot;L-6&quot;><a href=&quot;#L-6&quot;><span class=&quot;linenos&quot;>6</span></a>    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_c and inherits from .child_b.B&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;L-6&quot;><a href=&quot;#L-6&quot;><span class=&quot;linenos&quot;>6</span></a><span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_c and inherits from .child_b.B&amp;quot;&amp;quot;&amp;quot;</span>
 </span><span id=&quot;L-7&quot;><a href=&quot;#L-7&quot;><span class=&quot;linenos&quot;>7</span></a>
 </span><span id=&quot;L-8&quot;><a href=&quot;#L-8&quot;><span class=&quot;linenos&quot;>8</span></a>    <span class=&quot;k&quot;>def</span> <span class=&quot;nf&quot;>c</span><span class=&quot;p&quot;>(</span><span class=&quot;bp&quot;>self</span><span class=&quot;p&quot;>):</span>
 </span><span id=&quot;L-9&quot;><a href=&quot;#L-9&quot;><span class=&quot;linenos&quot;>9</span></a>        <span class=&quot;k&quot;>return</span> <span class=&quot;mi&quot;>2</span>
@@ -1128,7 +1128,7 @@ demopackage    </h1>
     </div>
     <a class=&quot;headerlink&quot; href=&quot;#C&quot;></a>
             <div class=&quot;pdoc-code codehilite&quot;><pre><span></span><span id=&quot;C-6&quot;><a href=&quot;#C-6&quot;><span class=&quot;linenos&quot;> 6</span></a><span class=&quot;k&quot;>class</span> <span class=&quot;nc&quot;>C</span><span class=&quot;p&quot;>(</span><span class=&quot;n&quot;>child_b</span><span class=&quot;o&quot;>.</span><span class=&quot;n&quot;>B</span><span class=&quot;p&quot;>):</span>
-</span><span id=&quot;C-7&quot;><a href=&quot;#C-7&quot;><span class=&quot;linenos&quot;> 7</span></a>    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_c and inherits from .child_b.B&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;C-7&quot;><a href=&quot;#C-7&quot;><span class=&quot;linenos&quot;> 7</span></a><span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_c and inherits from .child_b.B&amp;quot;&amp;quot;&amp;quot;</span>
 </span><span id=&quot;C-8&quot;><a href=&quot;#C-8&quot;><span class=&quot;linenos&quot;> 8</span></a>
 </span><span id=&quot;C-9&quot;><a href=&quot;#C-9&quot;><span class=&quot;linenos&quot;> 9</span></a>    <span class=&quot;k&quot;>def</span> <span class=&quot;nf&quot;>c</span><span class=&quot;p&quot;>(</span><span class=&quot;bp&quot;>self</span><span class=&quot;p&quot;>):</span>
 </span><span id=&quot;C-10&quot;><a href=&quot;#C-10&quot;><span class=&quot;linenos&quot;>10</span></a>        <span class=&quot;k&quot;>return</span> <span class=&quot;mi&quot;>2</span>
@@ -1447,10 +1447,10 @@ demopackage    </h1>
 </span><span id=&quot;L-5&quot;><a href=&quot;#L-5&quot;><span class=&quot;linenos&quot;> 5</span></a>
 </span><span id=&quot;L-6&quot;><a href=&quot;#L-6&quot;><span class=&quot;linenos&quot;> 6</span></a>
 </span><span id=&quot;L-7&quot;><a href=&quot;#L-7&quot;><span class=&quot;linenos&quot;> 7</span></a><span class=&quot;k&quot;>class</span> <span class=&quot;nc&quot;>B</span><span class=&quot;p&quot;>:</span>
-</span><span id=&quot;L-8&quot;><a href=&quot;#L-8&quot;><span class=&quot;linenos&quot;> 8</span></a>    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_b.&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;L-8&quot;><a href=&quot;#L-8&quot;><span class=&quot;linenos&quot;> 8</span></a><span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_b.&amp;quot;&amp;quot;&amp;quot;</span>
 </span><span id=&quot;L-9&quot;><a href=&quot;#L-9&quot;><span class=&quot;linenos&quot;> 9</span></a>
 </span><span id=&quot;L-10&quot;><a href=&quot;#L-10&quot;><span class=&quot;linenos&quot;>10</span></a>    <span class=&quot;n&quot;>b_type</span><span class=&quot;p&quot;>:</span> <span class=&quot;n&quot;>typing</span><span class=&quot;o&quot;>.</span><span class=&quot;n&quot;>Type</span><span class=&quot;p&quot;>[</span><span class=&quot;n&quot;>B</span><span class=&quot;p&quot;>]</span>
-</span><span id=&quot;L-11&quot;><a href=&quot;#L-11&quot;><span class=&quot;linenos&quot;>11</span></a>    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;we have a self-referential attribute here&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;L-11&quot;><a href=&quot;#L-11&quot;><span class=&quot;linenos&quot;>11</span></a><span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;we have a self-referential attribute here&amp;quot;&amp;quot;&amp;quot;</span>
 </span><span id=&quot;L-12&quot;><a href=&quot;#L-12&quot;><span class=&quot;linenos&quot;>12</span></a>
 </span><span id=&quot;L-13&quot;><a href=&quot;#L-13&quot;><span class=&quot;linenos&quot;>13</span></a>    <span class=&quot;k&quot;>def</span> <span class=&quot;nf&quot;>b</span><span class=&quot;p&quot;>(</span><span class=&quot;bp&quot;>self</span><span class=&quot;p&quot;>):</span>
 </span><span id=&quot;L-14&quot;><a href=&quot;#L-14&quot;><span class=&quot;linenos&quot;>14</span></a>        <span class=&quot;k&quot;>return</span> <span class=&quot;mi&quot;>1</span>
@@ -1470,10 +1470,10 @@ demopackage    </h1>
     </div>
     <a class=&quot;headerlink&quot; href=&quot;#B&quot;></a>
             <div class=&quot;pdoc-code codehilite&quot;><pre><span></span><span id=&quot;B-8&quot;><a href=&quot;#B-8&quot;><span class=&quot;linenos&quot;> 8</span></a><span class=&quot;k&quot;>class</span> <span class=&quot;nc&quot;>B</span><span class=&quot;p&quot;>:</span>
-</span><span id=&quot;B-9&quot;><a href=&quot;#B-9&quot;><span class=&quot;linenos&quot;> 9</span></a>    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_b.&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;B-9&quot;><a href=&quot;#B-9&quot;><span class=&quot;linenos&quot;> 9</span></a><span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;This class is defined in .child_b.&amp;quot;&amp;quot;&amp;quot;</span>
 </span><span id=&quot;B-10&quot;><a href=&quot;#B-10&quot;><span class=&quot;linenos&quot;>10</span></a>
 </span><span id=&quot;B-11&quot;><a href=&quot;#B-11&quot;><span class=&quot;linenos&quot;>11</span></a>    <span class=&quot;n&quot;>b_type</span><span class=&quot;p&quot;>:</span> <span class=&quot;n&quot;>typing</span><span class=&quot;o&quot;>.</span><span class=&quot;n&quot;>Type</span><span class=&quot;p&quot;>[</span><span class=&quot;n&quot;>B</span><span class=&quot;p&quot;>]</span>
-</span><span id=&quot;B-12&quot;><a href=&quot;#B-12&quot;><span class=&quot;linenos&quot;>12</span></a>    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;we have a self-referential attribute here&amp;quot;&amp;quot;&amp;quot;</span>
+</span><span id=&quot;B-12&quot;><a href=&quot;#B-12&quot;><span class=&quot;linenos&quot;>12</span></a><span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;we have a self-referential attribute here&amp;quot;&amp;quot;&amp;quot;</span>
 </span><span id=&quot;B-13&quot;><a href=&quot;#B-13&quot;><span class=&quot;linenos&quot;>13</span></a>
 </span><span id=&quot;B-14&quot;><a href=&quot;#B-14&quot;><span class=&quot;linenos&quot;>14</span></a>    <span class=&quot;k&quot;>def</span> <span class=&quot;nf&quot;>b</span><span class=&quot;p&quot;>(</span><span class=&quot;bp&quot;>self</span><span class=&quot;p&quot;>):</span>
 </span><span id=&quot;B-15&quot;><a href=&quot;#B-15&quot;><span class=&quot;linenos&quot;>15</span></a>        <span class=&quot;k&quot;>return</span> <span class=&quot;mi&quot;>1</span>

--- a/test/testdata/example_customtemplate.html
+++ b/test/testdata/example_customtemplate.html
@@ -71,19 +71,19 @@ demo    </h1>
 </span><span id="L-3"><a href="#L-3"><span class="linenos"> 3</span></a><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-4"><a href="#L-4"><span class="linenos"> 4</span></a>
 </span><span id="L-5"><a href="#L-5"><span class="linenos"> 5</span></a><span class="k">class</span> <span class="nc">Dog</span><span class="p">:</span>
-</span><span id="L-6"><a href="#L-6"><span class="linenos"> 6</span></a>    <span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
+</span><span id="L-6"><a href="#L-6"><span class="linenos"> 6</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
 </span><span id="L-7"><a href="#L-7"><span class="linenos"> 7</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-8"><a href="#L-8"><span class="linenos"> 8</span></a>    <span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
+</span><span id="L-8"><a href="#L-8"><span class="linenos"> 8</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
 </span><span id="L-9"><a href="#L-9"><span class="linenos"> 9</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
-</span><span id="L-10"><a href="#L-10"><span class="linenos">10</span></a>    <span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
+</span><span id="L-10"><a href="#L-10"><span class="linenos">10</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
 </span><span id="L-11"><a href="#L-11"><span class="linenos">11</span></a>
 </span><span id="L-12"><a href="#L-12"><span class="linenos">12</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-13"><a href="#L-13"><span class="linenos">13</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="L-13"><a href="#L-13"><span class="linenos">13</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="L-14"><a href="#L-14"><span class="linenos">14</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="L-15"><a href="#L-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span><span id="L-16"><a href="#L-16"><span class="linenos">16</span></a>
 </span><span id="L-17"><a href="#L-17"><span class="linenos">17</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="L-18"><a href="#L-18"><span class="linenos">18</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="L-18"><a href="#L-18"><span class="linenos">18</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -100,19 +100,19 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog-6"><a href="#Dog-6"><span class="linenos"> 6</span></a><span class="k">class</span> <span class="nc">Dog</span><span class="p">:</span>
-</span><span id="Dog-7"><a href="#Dog-7"><span class="linenos"> 7</span></a>    <span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
+</span><span id="Dog-7"><a href="#Dog-7"><span class="linenos"> 7</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
 </span><span id="Dog-8"><a href="#Dog-8"><span class="linenos"> 8</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Dog-9"><a href="#Dog-9"><span class="linenos"> 9</span></a>    <span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
+</span><span id="Dog-9"><a href="#Dog-9"><span class="linenos"> 9</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
 </span><span id="Dog-10"><a href="#Dog-10"><span class="linenos">10</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
-</span><span id="Dog-11"><a href="#Dog-11"><span class="linenos">11</span></a>    <span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
+</span><span id="Dog-11"><a href="#Dog-11"><span class="linenos">11</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
 </span><span id="Dog-12"><a href="#Dog-12"><span class="linenos">12</span></a>
 </span><span id="Dog-13"><a href="#Dog-13"><span class="linenos">13</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Dog-14"><a href="#Dog-14"><span class="linenos">14</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="Dog-14"><a href="#Dog-14"><span class="linenos">14</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="Dog-15"><a href="#Dog-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="Dog-16"><a href="#Dog-16"><span class="linenos">16</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span><span id="Dog-17"><a href="#Dog-17"><span class="linenos">17</span></a>
 </span><span id="Dog-18"><a href="#Dog-18"><span class="linenos">18</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="Dog-19"><a href="#Dog-19"><span class="linenos">19</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="Dog-19"><a href="#Dog-19"><span class="linenos">19</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -131,7 +131,7 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.__init__-13"><a href="#Dog.__init__-13"><span class="linenos">13</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Dog.__init__-14"><a href="#Dog.__init__-14"><span class="linenos">14</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="Dog.__init__-14"><a href="#Dog.__init__-14"><span class="linenos">14</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="Dog.__init__-15"><a href="#Dog.__init__-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="Dog.__init__-16"><a href="#Dog.__init__-16"><span class="linenos">16</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span></pre></div>
@@ -180,7 +180,7 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog.bark"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.bark-18"><a href="#Dog.bark-18"><span class="linenos">18</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="Dog.bark-19"><a href="#Dog.bark-19"><span class="linenos">19</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="Dog.bark-19"><a href="#Dog.bark-19"><span class="linenos">19</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 

--- a/test/testdata/example_darkmode.html
+++ b/test/testdata/example_darkmode.html
@@ -69,19 +69,19 @@ demo    </h1>
 </span><span id="L-3"><a href="#L-3"><span class="linenos"> 3</span></a><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-4"><a href="#L-4"><span class="linenos"> 4</span></a>
 </span><span id="L-5"><a href="#L-5"><span class="linenos"> 5</span></a><span class="k">class</span> <span class="nc">Dog</span><span class="p">:</span>
-</span><span id="L-6"><a href="#L-6"><span class="linenos"> 6</span></a>    <span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
+</span><span id="L-6"><a href="#L-6"><span class="linenos"> 6</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
 </span><span id="L-7"><a href="#L-7"><span class="linenos"> 7</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-8"><a href="#L-8"><span class="linenos"> 8</span></a>    <span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
+</span><span id="L-8"><a href="#L-8"><span class="linenos"> 8</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
 </span><span id="L-9"><a href="#L-9"><span class="linenos"> 9</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
-</span><span id="L-10"><a href="#L-10"><span class="linenos">10</span></a>    <span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
+</span><span id="L-10"><a href="#L-10"><span class="linenos">10</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
 </span><span id="L-11"><a href="#L-11"><span class="linenos">11</span></a>
 </span><span id="L-12"><a href="#L-12"><span class="linenos">12</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-13"><a href="#L-13"><span class="linenos">13</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="L-13"><a href="#L-13"><span class="linenos">13</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="L-14"><a href="#L-14"><span class="linenos">14</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="L-15"><a href="#L-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span><span id="L-16"><a href="#L-16"><span class="linenos">16</span></a>
 </span><span id="L-17"><a href="#L-17"><span class="linenos">17</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="L-18"><a href="#L-18"><span class="linenos">18</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="L-18"><a href="#L-18"><span class="linenos">18</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -98,19 +98,19 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog-6"><a href="#Dog-6"><span class="linenos"> 6</span></a><span class="k">class</span> <span class="nc">Dog</span><span class="p">:</span>
-</span><span id="Dog-7"><a href="#Dog-7"><span class="linenos"> 7</span></a>    <span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
+</span><span id="Dog-7"><a href="#Dog-7"><span class="linenos"> 7</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
 </span><span id="Dog-8"><a href="#Dog-8"><span class="linenos"> 8</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Dog-9"><a href="#Dog-9"><span class="linenos"> 9</span></a>    <span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
+</span><span id="Dog-9"><a href="#Dog-9"><span class="linenos"> 9</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
 </span><span id="Dog-10"><a href="#Dog-10"><span class="linenos">10</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
-</span><span id="Dog-11"><a href="#Dog-11"><span class="linenos">11</span></a>    <span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
+</span><span id="Dog-11"><a href="#Dog-11"><span class="linenos">11</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
 </span><span id="Dog-12"><a href="#Dog-12"><span class="linenos">12</span></a>
 </span><span id="Dog-13"><a href="#Dog-13"><span class="linenos">13</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Dog-14"><a href="#Dog-14"><span class="linenos">14</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="Dog-14"><a href="#Dog-14"><span class="linenos">14</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="Dog-15"><a href="#Dog-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="Dog-16"><a href="#Dog-16"><span class="linenos">16</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span><span id="Dog-17"><a href="#Dog-17"><span class="linenos">17</span></a>
 </span><span id="Dog-18"><a href="#Dog-18"><span class="linenos">18</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="Dog-19"><a href="#Dog-19"><span class="linenos">19</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="Dog-19"><a href="#Dog-19"><span class="linenos">19</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -129,7 +129,7 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.__init__-13"><a href="#Dog.__init__-13"><span class="linenos">13</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Dog.__init__-14"><a href="#Dog.__init__-14"><span class="linenos">14</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="Dog.__init__-14"><a href="#Dog.__init__-14"><span class="linenos">14</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="Dog.__init__-15"><a href="#Dog.__init__-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="Dog.__init__-16"><a href="#Dog.__init__-16"><span class="linenos">16</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span></pre></div>
@@ -178,7 +178,7 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog.bark"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.bark-18"><a href="#Dog.bark-18"><span class="linenos">18</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="Dog.bark-19"><a href="#Dog.bark-19"><span class="linenos">19</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="Dog.bark-19"><a href="#Dog.bark-19"><span class="linenos">19</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 

--- a/test/testdata/example_mkdocs.html
+++ b/test/testdata/example_mkdocs.html
@@ -20,19 +20,19 @@ demo    </h1>
 </span><span id="L-3"><a href="#L-3"><span class="linenos"> 3</span></a><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-4"><a href="#L-4"><span class="linenos"> 4</span></a>
 </span><span id="L-5"><a href="#L-5"><span class="linenos"> 5</span></a><span class="k">class</span> <span class="nc">Dog</span><span class="p">:</span>
-</span><span id="L-6"><a href="#L-6"><span class="linenos"> 6</span></a>    <span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
+</span><span id="L-6"><a href="#L-6"><span class="linenos"> 6</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
 </span><span id="L-7"><a href="#L-7"><span class="linenos"> 7</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-8"><a href="#L-8"><span class="linenos"> 8</span></a>    <span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
+</span><span id="L-8"><a href="#L-8"><span class="linenos"> 8</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
 </span><span id="L-9"><a href="#L-9"><span class="linenos"> 9</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
-</span><span id="L-10"><a href="#L-10"><span class="linenos">10</span></a>    <span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
+</span><span id="L-10"><a href="#L-10"><span class="linenos">10</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
 </span><span id="L-11"><a href="#L-11"><span class="linenos">11</span></a>
 </span><span id="L-12"><a href="#L-12"><span class="linenos">12</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-13"><a href="#L-13"><span class="linenos">13</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="L-13"><a href="#L-13"><span class="linenos">13</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="L-14"><a href="#L-14"><span class="linenos">14</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="L-15"><a href="#L-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span><span id="L-16"><a href="#L-16"><span class="linenos">16</span></a>
 </span><span id="L-17"><a href="#L-17"><span class="linenos">17</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="L-18"><a href="#L-18"><span class="linenos">18</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="L-18"><a href="#L-18"><span class="linenos">18</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -49,19 +49,19 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog-6"><a href="#Dog-6"><span class="linenos"> 6</span></a><span class="k">class</span> <span class="nc">Dog</span><span class="p">:</span>
-</span><span id="Dog-7"><a href="#Dog-7"><span class="linenos"> 7</span></a>    <span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
+</span><span id="Dog-7"><a href="#Dog-7"><span class="linenos"> 7</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;🐕&quot;&quot;&quot;</span>
 </span><span id="Dog-8"><a href="#Dog-8"><span class="linenos"> 8</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="Dog-9"><a href="#Dog-9"><span class="linenos"> 9</span></a>    <span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
+</span><span id="Dog-9"><a href="#Dog-9"><span class="linenos"> 9</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The name of our dog.&quot;&quot;&quot;</span>
 </span><span id="Dog-10"><a href="#Dog-10"><span class="linenos">10</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
-</span><span id="Dog-11"><a href="#Dog-11"><span class="linenos">11</span></a>    <span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
+</span><span id="Dog-11"><a href="#Dog-11"><span class="linenos">11</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The friends of our dog.&quot;&quot;&quot;</span>
 </span><span id="Dog-12"><a href="#Dog-12"><span class="linenos">12</span></a>
 </span><span id="Dog-13"><a href="#Dog-13"><span class="linenos">13</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Dog-14"><a href="#Dog-14"><span class="linenos">14</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="Dog-14"><a href="#Dog-14"><span class="linenos">14</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="Dog-15"><a href="#Dog-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="Dog-16"><a href="#Dog-16"><span class="linenos">16</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span><span id="Dog-17"><a href="#Dog-17"><span class="linenos">17</span></a>
 </span><span id="Dog-18"><a href="#Dog-18"><span class="linenos">18</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="Dog-19"><a href="#Dog-19"><span class="linenos">19</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="Dog-19"><a href="#Dog-19"><span class="linenos">19</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -80,7 +80,7 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.__init__-13"><a href="#Dog.__init__-13"><span class="linenos">13</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Dog.__init__-14"><a href="#Dog.__init__-14"><span class="linenos">14</span></a>        <span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
+</span><span id="Dog.__init__-14"><a href="#Dog.__init__-14"><span class="linenos">14</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Make a Dog without any friends (yet).&quot;&quot;&quot;</span>
 </span><span id="Dog.__init__-15"><a href="#Dog.__init__-15"><span class="linenos">15</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
 </span><span id="Dog.__init__-16"><a href="#Dog.__init__-16"><span class="linenos">16</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">friends</span> <span class="o">=</span> <span class="p">[]</span>
 </span></pre></div>
@@ -129,7 +129,7 @@ demo    </h1>
     </div>
     <a class="headerlink" href="#Dog.bark"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.bark-18"><a href="#Dog.bark-18"><span class="linenos">18</span></a>    <span class="k">def</span> <span class="nf">bark</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">):</span>
-</span><span id="Dog.bark-19"><a href="#Dog.bark-19"><span class="linenos">19</span></a>        <span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
+</span><span id="Dog.bark-19"><a href="#Dog.bark-19"><span class="linenos">19</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;*woof*&quot;&quot;&quot;</span>
 </span></pre></div>
 
 

--- a/test/testdata/flavors_google.html
+++ b/test/testdata/flavors_google.html
@@ -221,7 +221,7 @@ with it.</p></li>
 </span><span id="L-56"><a href="#L-56"><span class="linenos"> 56</span></a>
 </span><span id="L-57"><a href="#L-57"><span class="linenos"> 57</span></a>
 </span><span id="L-58"><a href="#L-58"><span class="linenos"> 58</span></a><span class="k">def</span> <span class="nf">function_with_types_in_docstring</span><span class="p">(</span><span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">):</span>
-</span><span id="L-59"><a href="#L-59"><span class="linenos"> 59</span></a>    <span class="sd">&quot;&quot;&quot;Example function with types documented in the docstring.</span>
+</span><span id="L-59"><a href="#L-59"><span class="linenos"> 59</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Example function with types documented in the docstring.</span>
 </span><span id="L-60"><a href="#L-60"><span class="linenos"> 60</span></a>
 </span><span id="L-61"><a href="#L-61"><span class="linenos"> 61</span></a><span class="sd">    `PEP 484`_ type annotations are supported. If attribute, parameter, and</span>
 </span><span id="L-62"><a href="#L-62"><span class="linenos"> 62</span></a><span class="sd">    return types are annotated according to `PEP 484`_, they do not need to be</span>
@@ -241,7 +241,7 @@ with it.</p></li>
 </span><span id="L-76"><a href="#L-76"><span class="linenos"> 76</span></a>
 </span><span id="L-77"><a href="#L-77"><span class="linenos"> 77</span></a>
 </span><span id="L-78"><a href="#L-78"><span class="linenos"> 78</span></a><span class="k">def</span> <span class="nf">function_with_pep484_type_annotations</span><span class="p">(</span><span class="n">param1</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">param2</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-</span><span id="L-79"><a href="#L-79"><span class="linenos"> 79</span></a>    <span class="sd">&quot;&quot;&quot;Example function with PEP 484 type annotations.</span>
+</span><span id="L-79"><a href="#L-79"><span class="linenos"> 79</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Example function with PEP 484 type annotations.</span>
 </span><span id="L-80"><a href="#L-80"><span class="linenos"> 80</span></a>
 </span><span id="L-81"><a href="#L-81"><span class="linenos"> 81</span></a><span class="sd">    Args:</span>
 </span><span id="L-82"><a href="#L-82"><span class="linenos"> 82</span></a><span class="sd">        param1: The first parameter.</span>
@@ -255,7 +255,7 @@ with it.</p></li>
 </span><span id="L-90"><a href="#L-90"><span class="linenos"> 90</span></a>
 </span><span id="L-91"><a href="#L-91"><span class="linenos"> 91</span></a>
 </span><span id="L-92"><a href="#L-92"><span class="linenos"> 92</span></a><span class="k">def</span> <span class="nf">module_level_function</span><span class="p">(</span><span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-</span><span id="L-93"><a href="#L-93"><span class="linenos"> 93</span></a>    <span class="sd">&quot;&quot;&quot;This is an example of a module level function.</span>
+</span><span id="L-93"><a href="#L-93"><span class="linenos"> 93</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This is an example of a module level function.</span>
 </span><span id="L-94"><a href="#L-94"><span class="linenos"> 94</span></a>
 </span><span id="L-95"><a href="#L-95"><span class="linenos"> 95</span></a><span class="sd">    Function parameters should be documented in the ``Args`` section. The name</span>
 </span><span id="L-96"><a href="#L-96"><span class="linenos"> 96</span></a><span class="sd">    of each parameter is required. The type and description of each parameter</span>
@@ -309,7 +309,7 @@ with it.</p></li>
 </span><span id="L-144"><a href="#L-144"><span class="linenos">144</span></a>
 </span><span id="L-145"><a href="#L-145"><span class="linenos">145</span></a>
 </span><span id="L-146"><a href="#L-146"><span class="linenos">146</span></a><span class="k">def</span> <span class="nf">example_generator</span><span class="p">(</span><span class="n">n</span><span class="p">):</span>
-</span><span id="L-147"><a href="#L-147"><span class="linenos">147</span></a>    <span class="sd">&quot;&quot;&quot;Generators have a ``Yields`` section instead of a ``Returns`` section.</span>
+</span><span id="L-147"><a href="#L-147"><span class="linenos">147</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Generators have a ``Yields`` section instead of a ``Returns`` section.</span>
 </span><span id="L-148"><a href="#L-148"><span class="linenos">148</span></a>
 </span><span id="L-149"><a href="#L-149"><span class="linenos">149</span></a><span class="sd">    Args:</span>
 </span><span id="L-150"><a href="#L-150"><span class="linenos">150</span></a><span class="sd">        n (int): The upper limit of the range to generate, from 0 to `n` - 1.</span>
@@ -330,7 +330,7 @@ with it.</p></li>
 </span><span id="L-165"><a href="#L-165"><span class="linenos">165</span></a>
 </span><span id="L-166"><a href="#L-166"><span class="linenos">166</span></a>
 </span><span id="L-167"><a href="#L-167"><span class="linenos">167</span></a><span class="k">class</span> <span class="nc">ExampleError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-</span><span id="L-168"><a href="#L-168"><span class="linenos">168</span></a>    <span class="sd">&quot;&quot;&quot;Exceptions are documented in the same way as classes.</span>
+</span><span id="L-168"><a href="#L-168"><span class="linenos">168</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Exceptions are documented in the same way as classes.</span>
 </span><span id="L-169"><a href="#L-169"><span class="linenos">169</span></a>
 </span><span id="L-170"><a href="#L-170"><span class="linenos">170</span></a><span class="sd">    The __init__ method may be documented in either the class level</span>
 </span><span id="L-171"><a href="#L-171"><span class="linenos">171</span></a><span class="sd">    docstring, or as a docstring on the __init__ method itself.</span>
@@ -356,11 +356,11 @@ with it.</p></li>
 </span><span id="L-191"><a href="#L-191"><span class="linenos">191</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">code</span> <span class="o">=</span> <span class="n">code</span>
 </span><span id="L-192"><a href="#L-192"><span class="linenos">192</span></a>
 </span><span id="L-193"><a href="#L-193"><span class="linenos">193</span></a>    <span class="k">def</span> <span class="nf">add_note</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">note</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-194"><a href="#L-194"><span class="linenos">194</span></a>        <span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
+</span><span id="L-194"><a href="#L-194"><span class="linenos">194</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
 </span><span id="L-195"><a href="#L-195"><span class="linenos">195</span></a>
 </span><span id="L-196"><a href="#L-196"><span class="linenos">196</span></a>
 </span><span id="L-197"><a href="#L-197"><span class="linenos">197</span></a><span class="k">class</span> <span class="nc">ExampleClass</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="L-198"><a href="#L-198"><span class="linenos">198</span></a>    <span class="sd">&quot;&quot;&quot;The summary line for a class docstring should fit on one line.</span>
+</span><span id="L-198"><a href="#L-198"><span class="linenos">198</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The summary line for a class docstring should fit on one line.</span>
 </span><span id="L-199"><a href="#L-199"><span class="linenos">199</span></a>
 </span><span id="L-200"><a href="#L-200"><span class="linenos">200</span></a><span class="sd">    If the class has public attributes, they may be documented here</span>
 </span><span id="L-201"><a href="#L-201"><span class="linenos">201</span></a><span class="sd">    in an ``Attributes`` section and follow the same formatting as a</span>
@@ -377,7 +377,7 @@ with it.</p></li>
 </span><span id="L-212"><a href="#L-212"><span class="linenos">212</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-213"><a href="#L-213"><span class="linenos">213</span></a>
 </span><span id="L-214"><a href="#L-214"><span class="linenos">214</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">,</span> <span class="n">param3</span><span class="p">):</span>
-</span><span id="L-215"><a href="#L-215"><span class="linenos">215</span></a>        <span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
+</span><span id="L-215"><a href="#L-215"><span class="linenos">215</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
 </span><span id="L-216"><a href="#L-216"><span class="linenos">216</span></a>
 </span><span id="L-217"><a href="#L-217"><span class="linenos">217</span></a><span class="sd">        The __init__ method may be documented in either the class level</span>
 </span><span id="L-218"><a href="#L-218"><span class="linenos">218</span></a><span class="sd">        docstring, or as a docstring on the __init__ method itself.</span>
@@ -403,16 +403,16 @@ with it.</p></li>
 </span><span id="L-238"><a href="#L-238"><span class="linenos">238</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr4</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;attr4&#39;</span><span class="p">]</span>
 </span><span id="L-239"><a href="#L-239"><span class="linenos">239</span></a>
 </span><span id="L-240"><a href="#L-240"><span class="linenos">240</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr5</span> <span class="o">=</span> <span class="kc">None</span>
-</span><span id="L-241"><a href="#L-241"><span class="linenos">241</span></a>        <span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
+</span><span id="L-241"><a href="#L-241"><span class="linenos">241</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
 </span><span id="L-242"><a href="#L-242"><span class="linenos">242</span></a>
 </span><span id="L-243"><a href="#L-243"><span class="linenos">243</span></a>    <span class="nd">@property</span>
 </span><span id="L-244"><a href="#L-244"><span class="linenos">244</span></a>    <span class="k">def</span> <span class="nf">readonly_property</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a>        <span class="sd">&quot;&quot;&quot;str: Properties should be documented in their getter method.&quot;&quot;&quot;</span>
+</span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;str: Properties should be documented in their getter method.&quot;&quot;&quot;</span>
 </span><span id="L-246"><a href="#L-246"><span class="linenos">246</span></a>        <span class="k">return</span> <span class="s1">&#39;readonly_property&#39;</span>
 </span><span id="L-247"><a href="#L-247"><span class="linenos">247</span></a>
 </span><span id="L-248"><a href="#L-248"><span class="linenos">248</span></a>    <span class="nd">@property</span>
 </span><span id="L-249"><a href="#L-249"><span class="linenos">249</span></a>    <span class="k">def</span> <span class="nf">readwrite_property</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-250"><a href="#L-250"><span class="linenos">250</span></a>        <span class="sd">&quot;&quot;&quot;:obj:`list` of :obj:`str`: Properties with both a getter and setter</span>
+</span><span id="L-250"><a href="#L-250"><span class="linenos">250</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;:obj:`list` of :obj:`str`: Properties with both a getter and setter</span>
 </span><span id="L-251"><a href="#L-251"><span class="linenos">251</span></a><span class="sd">        should only be documented in their getter method.</span>
 </span><span id="L-252"><a href="#L-252"><span class="linenos">252</span></a>
 </span><span id="L-253"><a href="#L-253"><span class="linenos">253</span></a><span class="sd">        If the setter method contains notable behavior, it should be</span>
@@ -425,7 +425,7 @@ with it.</p></li>
 </span><span id="L-260"><a href="#L-260"><span class="linenos">260</span></a>        <span class="n">value</span>
 </span><span id="L-261"><a href="#L-261"><span class="linenos">261</span></a>
 </span><span id="L-262"><a href="#L-262"><span class="linenos">262</span></a>    <span class="k">def</span> <span class="nf">example_method</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">):</span>
-</span><span id="L-263"><a href="#L-263"><span class="linenos">263</span></a>        <span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
+</span><span id="L-263"><a href="#L-263"><span class="linenos">263</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
 </span><span id="L-264"><a href="#L-264"><span class="linenos">264</span></a>
 </span><span id="L-265"><a href="#L-265"><span class="linenos">265</span></a><span class="sd">        Note:</span>
 </span><span id="L-266"><a href="#L-266"><span class="linenos">266</span></a><span class="sd">            Do not include the `self` parameter in the ``Args`` section.</span>
@@ -441,7 +441,7 @@ with it.</p></li>
 </span><span id="L-276"><a href="#L-276"><span class="linenos">276</span></a>        <span class="k">return</span> <span class="kc">True</span>
 </span><span id="L-277"><a href="#L-277"><span class="linenos">277</span></a>
 </span><span id="L-278"><a href="#L-278"><span class="linenos">278</span></a>    <span class="k">def</span> <span class="nf">__special__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-279"><a href="#L-279"><span class="linenos">279</span></a>        <span class="sd">&quot;&quot;&quot;By default special members with docstrings are not included.</span>
+</span><span id="L-279"><a href="#L-279"><span class="linenos">279</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;By default special members with docstrings are not included.</span>
 </span><span id="L-280"><a href="#L-280"><span class="linenos">280</span></a>
 </span><span id="L-281"><a href="#L-281"><span class="linenos">281</span></a><span class="sd">        Special members are any methods or attributes that start with and</span>
 </span><span id="L-282"><a href="#L-282"><span class="linenos">282</span></a><span class="sd">        end with a double underscore. Any special member with a docstring</span>
@@ -460,7 +460,7 @@ with it.</p></li>
 </span><span id="L-295"><a href="#L-295"><span class="linenos">295</span></a>        <span class="k">pass</span>
 </span><span id="L-296"><a href="#L-296"><span class="linenos">296</span></a>
 </span><span id="L-297"><a href="#L-297"><span class="linenos">297</span></a>    <span class="k">def</span> <span class="nf">_private</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-298"><a href="#L-298"><span class="linenos">298</span></a>        <span class="sd">&quot;&quot;&quot;By default private members are not included.</span>
+</span><span id="L-298"><a href="#L-298"><span class="linenos">298</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;By default private members are not included.</span>
 </span><span id="L-299"><a href="#L-299"><span class="linenos">299</span></a>
 </span><span id="L-300"><a href="#L-300"><span class="linenos">300</span></a><span class="sd">        Private members are any methods or attributes that start with an</span>
 </span><span id="L-301"><a href="#L-301"><span class="linenos">301</span></a><span class="sd">        underscore and are *not* special. By default they are not included</span>
@@ -482,7 +482,7 @@ with it.</p></li>
 </span><span id="L-317"><a href="#L-317"><span class="linenos">317</span></a>                          <span class="n">keys</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">],</span>
 </span><span id="L-318"><a href="#L-318"><span class="linenos">318</span></a>                          <span class="n">require_all_keys</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">False</span><span class="p">,</span>
 </span><span id="L-319"><a href="#L-319"><span class="linenos">319</span></a><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Mapping</span><span class="p">[</span><span class="nb">bytes</span><span class="p">,</span> <span class="n">Tuple</span><span class="p">[</span><span class="nb">str</span><span class="p">]]:</span>
-</span><span id="L-320"><a href="#L-320"><span class="linenos">320</span></a>    <span class="sd">&quot;&quot;&quot;Fetches rows from a Smalltable.</span>
+</span><span id="L-320"><a href="#L-320"><span class="linenos">320</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Fetches rows from a Smalltable.</span>
 </span><span id="L-321"><a href="#L-321"><span class="linenos">321</span></a>
 </span><span id="L-322"><a href="#L-322"><span class="linenos">322</span></a><span class="sd">    Retrieves rows pertaining to the given keys from the Table instance</span>
 </span><span id="L-323"><a href="#L-323"><span class="linenos">323</span></a><span class="sd">    represented by table_handle.  String keys will be UTF-8 encoded.</span>
@@ -517,7 +517,7 @@ with it.</p></li>
 </span><span id="L-352"><a href="#L-352"><span class="linenos">352</span></a>                          <span class="n">keys</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">],</span>
 </span><span id="L-353"><a href="#L-353"><span class="linenos">353</span></a>                          <span class="n">require_all_keys</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">False</span><span class="p">,</span>
 </span><span id="L-354"><a href="#L-354"><span class="linenos">354</span></a><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Mapping</span><span class="p">[</span><span class="nb">bytes</span><span class="p">,</span> <span class="n">Tuple</span><span class="p">[</span><span class="nb">str</span><span class="p">]]:</span>
-</span><span id="L-355"><a href="#L-355"><span class="linenos">355</span></a>    <span class="sd">&quot;&quot;&quot;Fetches rows from a Smalltable.</span>
+</span><span id="L-355"><a href="#L-355"><span class="linenos">355</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Fetches rows from a Smalltable.</span>
 </span><span id="L-356"><a href="#L-356"><span class="linenos">356</span></a>
 </span><span id="L-357"><a href="#L-357"><span class="linenos">357</span></a><span class="sd">    Retrieves rows pertaining to the given keys from the Table instance</span>
 </span><span id="L-358"><a href="#L-358"><span class="linenos">358</span></a><span class="sd">    represented by table_handle.  String keys will be UTF-8 encoded.</span>
@@ -552,7 +552,7 @@ with it.</p></li>
 </span><span id="L-387"><a href="#L-387"><span class="linenos">387</span></a>
 </span><span id="L-388"><a href="#L-388"><span class="linenos">388</span></a>
 </span><span id="L-389"><a href="#L-389"><span class="linenos">389</span></a><span class="k">class</span> <span class="nc">SampleClass</span><span class="p">:</span>
-</span><span id="L-390"><a href="#L-390"><span class="linenos">390</span></a>    <span class="sd">&quot;&quot;&quot;Summary of class here.</span>
+</span><span id="L-390"><a href="#L-390"><span class="linenos">390</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Summary of class here.</span>
 </span><span id="L-391"><a href="#L-391"><span class="linenos">391</span></a>
 </span><span id="L-392"><a href="#L-392"><span class="linenos">392</span></a><span class="sd">    Longer class information....</span>
 </span><span id="L-393"><a href="#L-393"><span class="linenos">393</span></a><span class="sd">    Longer class information....</span>
@@ -563,16 +563,16 @@ with it.</p></li>
 </span><span id="L-398"><a href="#L-398"><span class="linenos">398</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-399"><a href="#L-399"><span class="linenos">399</span></a>
 </span><span id="L-400"><a href="#L-400"><span class="linenos">400</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">likes_spam</span><span class="o">=</span><span class="kc">False</span><span class="p">):</span>
-</span><span id="L-401"><a href="#L-401"><span class="linenos">401</span></a>        <span class="sd">&quot;&quot;&quot;Inits SampleClass with blah.&quot;&quot;&quot;</span>
+</span><span id="L-401"><a href="#L-401"><span class="linenos">401</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Inits SampleClass with blah.&quot;&quot;&quot;</span>
 </span><span id="L-402"><a href="#L-402"><span class="linenos">402</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">likes_spam</span> <span class="o">=</span> <span class="n">likes_spam</span>
 </span><span id="L-403"><a href="#L-403"><span class="linenos">403</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">eggs</span> <span class="o">=</span> <span class="mi">0</span>
 </span><span id="L-404"><a href="#L-404"><span class="linenos">404</span></a>
 </span><span id="L-405"><a href="#L-405"><span class="linenos">405</span></a>    <span class="k">def</span> <span class="nf">public_method</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-406"><a href="#L-406"><span class="linenos">406</span></a>        <span class="sd">&quot;&quot;&quot;Performs operation blah.&quot;&quot;&quot;</span>
+</span><span id="L-406"><a href="#L-406"><span class="linenos">406</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Performs operation blah.&quot;&quot;&quot;</span>
 </span><span id="L-407"><a href="#L-407"><span class="linenos">407</span></a>
 </span><span id="L-408"><a href="#L-408"><span class="linenos">408</span></a>
 </span><span id="L-409"><a href="#L-409"><span class="linenos">409</span></a><span class="k">def</span> <span class="nf">invalid_format</span><span class="p">(</span><span class="n">test</span><span class="p">):</span>
-</span><span id="L-410"><a href="#L-410"><span class="linenos">410</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-410"><a href="#L-410"><span class="linenos">410</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-411"><a href="#L-411"><span class="linenos">411</span></a><span class="sd">    In this example, there is no colon after the argument and an empty section.</span>
 </span><span id="L-412"><a href="#L-412"><span class="linenos">412</span></a>
 </span><span id="L-413"><a href="#L-413"><span class="linenos">413</span></a><span class="sd">    Args:</span>
@@ -584,7 +584,7 @@ with it.</p></li>
 </span><span id="L-419"><a href="#L-419"><span class="linenos">419</span></a>
 </span><span id="L-420"><a href="#L-420"><span class="linenos">420</span></a>
 </span><span id="L-421"><a href="#L-421"><span class="linenos">421</span></a><span class="k">def</span> <span class="nf">example_code</span><span class="p">():</span>
-</span><span id="L-422"><a href="#L-422"><span class="linenos">422</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-422"><a href="#L-422"><span class="linenos">422</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-423"><a href="#L-423"><span class="linenos">423</span></a><span class="sd">    Test case for https://github.com/mitmproxy/pdoc/issues/264.</span>
 </span><span id="L-424"><a href="#L-424"><span class="linenos">424</span></a>
 </span><span id="L-425"><a href="#L-425"><span class="linenos">425</span></a><span class="sd">    Example:</span>
@@ -598,7 +598,7 @@ with it.</p></li>
 </span><span id="L-433"><a href="#L-433"><span class="linenos">433</span></a>
 </span><span id="L-434"><a href="#L-434"><span class="linenos">434</span></a>
 </span><span id="L-435"><a href="#L-435"><span class="linenos">435</span></a><span class="k">def</span> <span class="nf">newline_after_args</span><span class="p">(</span><span class="n">test</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-436"><a href="#L-436"><span class="linenos">436</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-436"><a href="#L-436"><span class="linenos">436</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-437"><a href="#L-437"><span class="linenos">437</span></a><span class="sd">    Test case for https://github.com/mitmproxy/pdoc/pull/458.</span>
 </span><span id="L-438"><a href="#L-438"><span class="linenos">438</span></a>
 </span><span id="L-439"><a href="#L-439"><span class="linenos">439</span></a><span class="sd">    Args:</span>
@@ -609,7 +609,7 @@ with it.</p></li>
 </span><span id="L-444"><a href="#L-444"><span class="linenos">444</span></a>
 </span><span id="L-445"><a href="#L-445"><span class="linenos">445</span></a>
 </span><span id="L-446"><a href="#L-446"><span class="linenos">446</span></a><span class="k">def</span> <span class="nf">alternative_section_names</span><span class="p">(</span><span class="n">test</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-447"><a href="#L-447"><span class="linenos">447</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-447"><a href="#L-447"><span class="linenos">447</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-448"><a href="#L-448"><span class="linenos">448</span></a><span class="sd">    In this example, we check whether alternative section names aliased to</span>
 </span><span id="L-449"><a href="#L-449"><span class="linenos">449</span></a><span class="sd">    &#39;Args&#39; are handled properly.</span>
 </span><span id="L-450"><a href="#L-450"><span class="linenos">450</span></a>
@@ -621,13 +621,19 @@ with it.</p></li>
 
             </section>
                 <section id="module_level_variable2">
-                    <div class="attr variable">
-            <span class="name">module_level_variable2</span><span class="default_value"> = 98765</span>
-
+                            <input id="module_level_variable2-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">module_level_variable2</span>
         
+
+                <label class="view-source-button" for="module_level_variable2-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#module_level_variable2"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="module_level_variable2-1"><a href="#module_level_variable2-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="mi">98765</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>int: Module level variable documented inline.</p>
 
 <p>The docstring may span multiple lines. The type may optionally be specified
@@ -648,7 +654,7 @@ on the first line, separated by a colon.</p>
     </div>
     <a class="headerlink" href="#function_with_types_in_docstring"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="function_with_types_in_docstring-59"><a href="#function_with_types_in_docstring-59"><span class="linenos">59</span></a><span class="k">def</span> <span class="nf">function_with_types_in_docstring</span><span class="p">(</span><span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">):</span>
-</span><span id="function_with_types_in_docstring-60"><a href="#function_with_types_in_docstring-60"><span class="linenos">60</span></a>    <span class="sd">&quot;&quot;&quot;Example function with types documented in the docstring.</span>
+</span><span id="function_with_types_in_docstring-60"><a href="#function_with_types_in_docstring-60"><span class="linenos">60</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Example function with types documented in the docstring.</span>
 </span><span id="function_with_types_in_docstring-61"><a href="#function_with_types_in_docstring-61"><span class="linenos">61</span></a>
 </span><span id="function_with_types_in_docstring-62"><a href="#function_with_types_in_docstring-62"><span class="linenos">62</span></a><span class="sd">    `PEP 484`_ type annotations are supported. If attribute, parameter, and</span>
 </span><span id="function_with_types_in_docstring-63"><a href="#function_with_types_in_docstring-63"><span class="linenos">63</span></a><span class="sd">    return types are annotated according to `PEP 484`_, they do not need to be</span>
@@ -702,7 +708,7 @@ included in the docstring:</p>
     </div>
     <a class="headerlink" href="#function_with_pep484_type_annotations"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="function_with_pep484_type_annotations-79"><a href="#function_with_pep484_type_annotations-79"><span class="linenos">79</span></a><span class="k">def</span> <span class="nf">function_with_pep484_type_annotations</span><span class="p">(</span><span class="n">param1</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">param2</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-</span><span id="function_with_pep484_type_annotations-80"><a href="#function_with_pep484_type_annotations-80"><span class="linenos">80</span></a>    <span class="sd">&quot;&quot;&quot;Example function with PEP 484 type annotations.</span>
+</span><span id="function_with_pep484_type_annotations-80"><a href="#function_with_pep484_type_annotations-80"><span class="linenos">80</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Example function with PEP 484 type annotations.</span>
 </span><span id="function_with_pep484_type_annotations-81"><a href="#function_with_pep484_type_annotations-81"><span class="linenos">81</span></a>
 </span><span id="function_with_pep484_type_annotations-82"><a href="#function_with_pep484_type_annotations-82"><span class="linenos">82</span></a><span class="sd">    Args:</span>
 </span><span id="function_with_pep484_type_annotations-83"><a href="#function_with_pep484_type_annotations-83"><span class="linenos">83</span></a><span class="sd">        param1: The first parameter.</span>
@@ -746,7 +752,7 @@ included in the docstring:</p>
     </div>
     <a class="headerlink" href="#module_level_function"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="module_level_function-93"><a href="#module_level_function-93"><span class="linenos"> 93</span></a><span class="k">def</span> <span class="nf">module_level_function</span><span class="p">(</span><span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-</span><span id="module_level_function-94"><a href="#module_level_function-94"><span class="linenos"> 94</span></a>    <span class="sd">&quot;&quot;&quot;This is an example of a module level function.</span>
+</span><span id="module_level_function-94"><a href="#module_level_function-94"><span class="linenos"> 94</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This is an example of a module level function.</span>
 </span><span id="module_level_function-95"><a href="#module_level_function-95"><span class="linenos"> 95</span></a>
 </span><span id="module_level_function-96"><a href="#module_level_function-96"><span class="linenos"> 96</span></a><span class="sd">    Function parameters should be documented in the ``Args`` section. The name</span>
 </span><span id="module_level_function-97"><a href="#module_level_function-97"><span class="linenos"> 97</span></a><span class="sd">    of each parameter is required. The type and description of each parameter</span>
@@ -873,7 +879,7 @@ that are relevant to the interface.</li>
     </div>
     <a class="headerlink" href="#example_generator"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="example_generator-147"><a href="#example_generator-147"><span class="linenos">147</span></a><span class="k">def</span> <span class="nf">example_generator</span><span class="p">(</span><span class="n">n</span><span class="p">):</span>
-</span><span id="example_generator-148"><a href="#example_generator-148"><span class="linenos">148</span></a>    <span class="sd">&quot;&quot;&quot;Generators have a ``Yields`` section instead of a ``Returns`` section.</span>
+</span><span id="example_generator-148"><a href="#example_generator-148"><span class="linenos">148</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Generators have a ``Yields`` section instead of a ``Returns`` section.</span>
 </span><span id="example_generator-149"><a href="#example_generator-149"><span class="linenos">149</span></a>
 </span><span id="example_generator-150"><a href="#example_generator-150"><span class="linenos">150</span></a><span class="sd">    Args:</span>
 </span><span id="example_generator-151"><a href="#example_generator-151"><span class="linenos">151</span></a><span class="sd">        n (int): The upper limit of the range to generate, from 0 to `n` - 1.</span>
@@ -936,7 +942,7 @@ that are relevant to the interface.</li>
     </div>
     <a class="headerlink" href="#ExampleError"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ExampleError-168"><a href="#ExampleError-168"><span class="linenos">168</span></a><span class="k">class</span> <span class="nc">ExampleError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-</span><span id="ExampleError-169"><a href="#ExampleError-169"><span class="linenos">169</span></a>    <span class="sd">&quot;&quot;&quot;Exceptions are documented in the same way as classes.</span>
+</span><span id="ExampleError-169"><a href="#ExampleError-169"><span class="linenos">169</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Exceptions are documented in the same way as classes.</span>
 </span><span id="ExampleError-170"><a href="#ExampleError-170"><span class="linenos">170</span></a>
 </span><span id="ExampleError-171"><a href="#ExampleError-171"><span class="linenos">171</span></a><span class="sd">    The __init__ method may be documented in either the class level</span>
 </span><span id="ExampleError-172"><a href="#ExampleError-172"><span class="linenos">172</span></a><span class="sd">    docstring, or as a docstring on the __init__ method itself.</span>
@@ -962,7 +968,7 @@ that are relevant to the interface.</li>
 </span><span id="ExampleError-192"><a href="#ExampleError-192"><span class="linenos">192</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">code</span> <span class="o">=</span> <span class="n">code</span>
 </span><span id="ExampleError-193"><a href="#ExampleError-193"><span class="linenos">193</span></a>
 </span><span id="ExampleError-194"><a href="#ExampleError-194"><span class="linenos">194</span></a>    <span class="k">def</span> <span class="nf">add_note</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">note</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="ExampleError-195"><a href="#ExampleError-195"><span class="linenos">195</span></a>        <span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
+</span><span id="ExampleError-195"><a href="#ExampleError-195"><span class="linenos">195</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1027,7 +1033,7 @@ convention to document the __init__ method and be consistent with it.</p>
     </div>
     <a class="headerlink" href="#ExampleError.add_note"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ExampleError.add_note-194"><a href="#ExampleError.add_note-194"><span class="linenos">194</span></a>    <span class="k">def</span> <span class="nf">add_note</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">note</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="ExampleError.add_note-195"><a href="#ExampleError.add_note-195"><span class="linenos">195</span></a>        <span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
+</span><span id="ExampleError.add_note-195"><a href="#ExampleError.add_note-195"><span class="linenos">195</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1058,7 +1064,7 @@ convention to document the __init__ method and be consistent with it.</p>
     </div>
     <a class="headerlink" href="#ExampleClass"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ExampleClass-198"><a href="#ExampleClass-198"><span class="linenos">198</span></a><span class="k">class</span> <span class="nc">ExampleClass</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="ExampleClass-199"><a href="#ExampleClass-199"><span class="linenos">199</span></a>    <span class="sd">&quot;&quot;&quot;The summary line for a class docstring should fit on one line.</span>
+</span><span id="ExampleClass-199"><a href="#ExampleClass-199"><span class="linenos">199</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The summary line for a class docstring should fit on one line.</span>
 </span><span id="ExampleClass-200"><a href="#ExampleClass-200"><span class="linenos">200</span></a>
 </span><span id="ExampleClass-201"><a href="#ExampleClass-201"><span class="linenos">201</span></a><span class="sd">    If the class has public attributes, they may be documented here</span>
 </span><span id="ExampleClass-202"><a href="#ExampleClass-202"><span class="linenos">202</span></a><span class="sd">    in an ``Attributes`` section and follow the same formatting as a</span>
@@ -1075,7 +1081,7 @@ convention to document the __init__ method and be consistent with it.</p>
 </span><span id="ExampleClass-213"><a href="#ExampleClass-213"><span class="linenos">213</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="ExampleClass-214"><a href="#ExampleClass-214"><span class="linenos">214</span></a>
 </span><span id="ExampleClass-215"><a href="#ExampleClass-215"><span class="linenos">215</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">,</span> <span class="n">param3</span><span class="p">):</span>
-</span><span id="ExampleClass-216"><a href="#ExampleClass-216"><span class="linenos">216</span></a>        <span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
+</span><span id="ExampleClass-216"><a href="#ExampleClass-216"><span class="linenos">216</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
 </span><span id="ExampleClass-217"><a href="#ExampleClass-217"><span class="linenos">217</span></a>
 </span><span id="ExampleClass-218"><a href="#ExampleClass-218"><span class="linenos">218</span></a><span class="sd">        The __init__ method may be documented in either the class level</span>
 </span><span id="ExampleClass-219"><a href="#ExampleClass-219"><span class="linenos">219</span></a><span class="sd">        docstring, or as a docstring on the __init__ method itself.</span>
@@ -1101,16 +1107,16 @@ convention to document the __init__ method and be consistent with it.</p>
 </span><span id="ExampleClass-239"><a href="#ExampleClass-239"><span class="linenos">239</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr4</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;attr4&#39;</span><span class="p">]</span>
 </span><span id="ExampleClass-240"><a href="#ExampleClass-240"><span class="linenos">240</span></a>
 </span><span id="ExampleClass-241"><a href="#ExampleClass-241"><span class="linenos">241</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr5</span> <span class="o">=</span> <span class="kc">None</span>
-</span><span id="ExampleClass-242"><a href="#ExampleClass-242"><span class="linenos">242</span></a>        <span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
+</span><span id="ExampleClass-242"><a href="#ExampleClass-242"><span class="linenos">242</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
 </span><span id="ExampleClass-243"><a href="#ExampleClass-243"><span class="linenos">243</span></a>
 </span><span id="ExampleClass-244"><a href="#ExampleClass-244"><span class="linenos">244</span></a>    <span class="nd">@property</span>
 </span><span id="ExampleClass-245"><a href="#ExampleClass-245"><span class="linenos">245</span></a>    <span class="k">def</span> <span class="nf">readonly_property</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="ExampleClass-246"><a href="#ExampleClass-246"><span class="linenos">246</span></a>        <span class="sd">&quot;&quot;&quot;str: Properties should be documented in their getter method.&quot;&quot;&quot;</span>
+</span><span id="ExampleClass-246"><a href="#ExampleClass-246"><span class="linenos">246</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;str: Properties should be documented in their getter method.&quot;&quot;&quot;</span>
 </span><span id="ExampleClass-247"><a href="#ExampleClass-247"><span class="linenos">247</span></a>        <span class="k">return</span> <span class="s1">&#39;readonly_property&#39;</span>
 </span><span id="ExampleClass-248"><a href="#ExampleClass-248"><span class="linenos">248</span></a>
 </span><span id="ExampleClass-249"><a href="#ExampleClass-249"><span class="linenos">249</span></a>    <span class="nd">@property</span>
 </span><span id="ExampleClass-250"><a href="#ExampleClass-250"><span class="linenos">250</span></a>    <span class="k">def</span> <span class="nf">readwrite_property</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="ExampleClass-251"><a href="#ExampleClass-251"><span class="linenos">251</span></a>        <span class="sd">&quot;&quot;&quot;:obj:`list` of :obj:`str`: Properties with both a getter and setter</span>
+</span><span id="ExampleClass-251"><a href="#ExampleClass-251"><span class="linenos">251</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;:obj:`list` of :obj:`str`: Properties with both a getter and setter</span>
 </span><span id="ExampleClass-252"><a href="#ExampleClass-252"><span class="linenos">252</span></a><span class="sd">        should only be documented in their getter method.</span>
 </span><span id="ExampleClass-253"><a href="#ExampleClass-253"><span class="linenos">253</span></a>
 </span><span id="ExampleClass-254"><a href="#ExampleClass-254"><span class="linenos">254</span></a><span class="sd">        If the setter method contains notable behavior, it should be</span>
@@ -1123,7 +1129,7 @@ convention to document the __init__ method and be consistent with it.</p>
 </span><span id="ExampleClass-261"><a href="#ExampleClass-261"><span class="linenos">261</span></a>        <span class="n">value</span>
 </span><span id="ExampleClass-262"><a href="#ExampleClass-262"><span class="linenos">262</span></a>
 </span><span id="ExampleClass-263"><a href="#ExampleClass-263"><span class="linenos">263</span></a>    <span class="k">def</span> <span class="nf">example_method</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">):</span>
-</span><span id="ExampleClass-264"><a href="#ExampleClass-264"><span class="linenos">264</span></a>        <span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
+</span><span id="ExampleClass-264"><a href="#ExampleClass-264"><span class="linenos">264</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
 </span><span id="ExampleClass-265"><a href="#ExampleClass-265"><span class="linenos">265</span></a>
 </span><span id="ExampleClass-266"><a href="#ExampleClass-266"><span class="linenos">266</span></a><span class="sd">        Note:</span>
 </span><span id="ExampleClass-267"><a href="#ExampleClass-267"><span class="linenos">267</span></a><span class="sd">            Do not include the `self` parameter in the ``Args`` section.</span>
@@ -1139,7 +1145,7 @@ convention to document the __init__ method and be consistent with it.</p>
 </span><span id="ExampleClass-277"><a href="#ExampleClass-277"><span class="linenos">277</span></a>        <span class="k">return</span> <span class="kc">True</span>
 </span><span id="ExampleClass-278"><a href="#ExampleClass-278"><span class="linenos">278</span></a>
 </span><span id="ExampleClass-279"><a href="#ExampleClass-279"><span class="linenos">279</span></a>    <span class="k">def</span> <span class="nf">__special__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="ExampleClass-280"><a href="#ExampleClass-280"><span class="linenos">280</span></a>        <span class="sd">&quot;&quot;&quot;By default special members with docstrings are not included.</span>
+</span><span id="ExampleClass-280"><a href="#ExampleClass-280"><span class="linenos">280</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;By default special members with docstrings are not included.</span>
 </span><span id="ExampleClass-281"><a href="#ExampleClass-281"><span class="linenos">281</span></a>
 </span><span id="ExampleClass-282"><a href="#ExampleClass-282"><span class="linenos">282</span></a><span class="sd">        Special members are any methods or attributes that start with and</span>
 </span><span id="ExampleClass-283"><a href="#ExampleClass-283"><span class="linenos">283</span></a><span class="sd">        end with a double underscore. Any special member with a docstring</span>
@@ -1158,7 +1164,7 @@ convention to document the __init__ method and be consistent with it.</p>
 </span><span id="ExampleClass-296"><a href="#ExampleClass-296"><span class="linenos">296</span></a>        <span class="k">pass</span>
 </span><span id="ExampleClass-297"><a href="#ExampleClass-297"><span class="linenos">297</span></a>
 </span><span id="ExampleClass-298"><a href="#ExampleClass-298"><span class="linenos">298</span></a>    <span class="k">def</span> <span class="nf">_private</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="ExampleClass-299"><a href="#ExampleClass-299"><span class="linenos">299</span></a>        <span class="sd">&quot;&quot;&quot;By default private members are not included.</span>
+</span><span id="ExampleClass-299"><a href="#ExampleClass-299"><span class="linenos">299</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;By default private members are not included.</span>
 </span><span id="ExampleClass-300"><a href="#ExampleClass-300"><span class="linenos">300</span></a>
 </span><span id="ExampleClass-301"><a href="#ExampleClass-301"><span class="linenos">301</span></a><span class="sd">        Private members are any methods or attributes that start with an</span>
 </span><span id="ExampleClass-302"><a href="#ExampleClass-302"><span class="linenos">302</span></a><span class="sd">        underscore and are *not* special. By default they are not included</span>
@@ -1207,7 +1213,7 @@ in the property's getter method.</p>
     </div>
     <a class="headerlink" href="#ExampleClass.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ExampleClass.__init__-215"><a href="#ExampleClass.__init__-215"><span class="linenos">215</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">,</span> <span class="n">param3</span><span class="p">):</span>
-</span><span id="ExampleClass.__init__-216"><a href="#ExampleClass.__init__-216"><span class="linenos">216</span></a>        <span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
+</span><span id="ExampleClass.__init__-216"><a href="#ExampleClass.__init__-216"><span class="linenos">216</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
 </span><span id="ExampleClass.__init__-217"><a href="#ExampleClass.__init__-217"><span class="linenos">217</span></a>
 </span><span id="ExampleClass.__init__-218"><a href="#ExampleClass.__init__-218"><span class="linenos">218</span></a><span class="sd">        The __init__ method may be documented in either the class level</span>
 </span><span id="ExampleClass.__init__-219"><a href="#ExampleClass.__init__-219"><span class="linenos">219</span></a><span class="sd">        docstring, or as a docstring on the __init__ method itself.</span>
@@ -1233,7 +1239,7 @@ in the property's getter method.</p>
 </span><span id="ExampleClass.__init__-239"><a href="#ExampleClass.__init__-239"><span class="linenos">239</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr4</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;attr4&#39;</span><span class="p">]</span>
 </span><span id="ExampleClass.__init__-240"><a href="#ExampleClass.__init__-240"><span class="linenos">240</span></a>
 </span><span id="ExampleClass.__init__-241"><a href="#ExampleClass.__init__-241"><span class="linenos">241</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr5</span> <span class="o">=</span> <span class="kc">None</span>
-</span><span id="ExampleClass.__init__-242"><a href="#ExampleClass.__init__-242"><span class="linenos">242</span></a>        <span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
+</span><span id="ExampleClass.__init__-242"><a href="#ExampleClass.__init__-242"><span class="linenos">242</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1318,7 +1324,7 @@ mentioned here.</p>
     </div>
     <a class="headerlink" href="#ExampleClass.example_method"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ExampleClass.example_method-263"><a href="#ExampleClass.example_method-263"><span class="linenos">263</span></a>    <span class="k">def</span> <span class="nf">example_method</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">):</span>
-</span><span id="ExampleClass.example_method-264"><a href="#ExampleClass.example_method-264"><span class="linenos">264</span></a>        <span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
+</span><span id="ExampleClass.example_method-264"><a href="#ExampleClass.example_method-264"><span class="linenos">264</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
 </span><span id="ExampleClass.example_method-265"><a href="#ExampleClass.example_method-265"><span class="linenos">265</span></a>
 </span><span id="ExampleClass.example_method-266"><a href="#ExampleClass.example_method-266"><span class="linenos">266</span></a><span class="sd">        Note:</span>
 </span><span id="ExampleClass.example_method-267"><a href="#ExampleClass.example_method-267"><span class="linenos">267</span></a><span class="sd">            Do not include the `self` parameter in the ``Args`` section.</span>
@@ -1375,7 +1381,7 @@ mentioned here.</p>
 </span><span id="fetch_smalltable_rows-318"><a href="#fetch_smalltable_rows-318"><span class="linenos">318</span></a>                          <span class="n">keys</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">],</span>
 </span><span id="fetch_smalltable_rows-319"><a href="#fetch_smalltable_rows-319"><span class="linenos">319</span></a>                          <span class="n">require_all_keys</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">False</span><span class="p">,</span>
 </span><span id="fetch_smalltable_rows-320"><a href="#fetch_smalltable_rows-320"><span class="linenos">320</span></a><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Mapping</span><span class="p">[</span><span class="nb">bytes</span><span class="p">,</span> <span class="n">Tuple</span><span class="p">[</span><span class="nb">str</span><span class="p">]]:</span>
-</span><span id="fetch_smalltable_rows-321"><a href="#fetch_smalltable_rows-321"><span class="linenos">321</span></a>    <span class="sd">&quot;&quot;&quot;Fetches rows from a Smalltable.</span>
+</span><span id="fetch_smalltable_rows-321"><a href="#fetch_smalltable_rows-321"><span class="linenos">321</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Fetches rows from a Smalltable.</span>
 </span><span id="fetch_smalltable_rows-322"><a href="#fetch_smalltable_rows-322"><span class="linenos">322</span></a>
 </span><span id="fetch_smalltable_rows-323"><a href="#fetch_smalltable_rows-323"><span class="linenos">323</span></a><span class="sd">    Retrieves rows pertaining to the given keys from the Table instance</span>
 </span><span id="fetch_smalltable_rows-324"><a href="#fetch_smalltable_rows-324"><span class="linenos">324</span></a><span class="sd">    represented by table_handle.  String keys will be UTF-8 encoded.</span>
@@ -1462,7 +1468,7 @@ rows with values set for all keys will be returned.</li>
 </span><span id="fetch_smalltable_rows2-353"><a href="#fetch_smalltable_rows2-353"><span class="linenos">353</span></a>                          <span class="n">keys</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">],</span>
 </span><span id="fetch_smalltable_rows2-354"><a href="#fetch_smalltable_rows2-354"><span class="linenos">354</span></a>                          <span class="n">require_all_keys</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">False</span><span class="p">,</span>
 </span><span id="fetch_smalltable_rows2-355"><a href="#fetch_smalltable_rows2-355"><span class="linenos">355</span></a><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Mapping</span><span class="p">[</span><span class="nb">bytes</span><span class="p">,</span> <span class="n">Tuple</span><span class="p">[</span><span class="nb">str</span><span class="p">]]:</span>
-</span><span id="fetch_smalltable_rows2-356"><a href="#fetch_smalltable_rows2-356"><span class="linenos">356</span></a>    <span class="sd">&quot;&quot;&quot;Fetches rows from a Smalltable.</span>
+</span><span id="fetch_smalltable_rows2-356"><a href="#fetch_smalltable_rows2-356"><span class="linenos">356</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Fetches rows from a Smalltable.</span>
 </span><span id="fetch_smalltable_rows2-357"><a href="#fetch_smalltable_rows2-357"><span class="linenos">357</span></a>
 </span><span id="fetch_smalltable_rows2-358"><a href="#fetch_smalltable_rows2-358"><span class="linenos">358</span></a><span class="sd">    Retrieves rows pertaining to the given keys from the Table instance</span>
 </span><span id="fetch_smalltable_rows2-359"><a href="#fetch_smalltable_rows2-359"><span class="linenos">359</span></a><span class="sd">    represented by table_handle.  String keys will be UTF-8 encoded.</span>
@@ -1549,7 +1555,7 @@ for all keys will be returned.</li>
     </div>
     <a class="headerlink" href="#SampleClass"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="SampleClass-390"><a href="#SampleClass-390"><span class="linenos">390</span></a><span class="k">class</span> <span class="nc">SampleClass</span><span class="p">:</span>
-</span><span id="SampleClass-391"><a href="#SampleClass-391"><span class="linenos">391</span></a>    <span class="sd">&quot;&quot;&quot;Summary of class here.</span>
+</span><span id="SampleClass-391"><a href="#SampleClass-391"><span class="linenos">391</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Summary of class here.</span>
 </span><span id="SampleClass-392"><a href="#SampleClass-392"><span class="linenos">392</span></a>
 </span><span id="SampleClass-393"><a href="#SampleClass-393"><span class="linenos">393</span></a><span class="sd">    Longer class information....</span>
 </span><span id="SampleClass-394"><a href="#SampleClass-394"><span class="linenos">394</span></a><span class="sd">    Longer class information....</span>
@@ -1560,12 +1566,12 @@ for all keys will be returned.</li>
 </span><span id="SampleClass-399"><a href="#SampleClass-399"><span class="linenos">399</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="SampleClass-400"><a href="#SampleClass-400"><span class="linenos">400</span></a>
 </span><span id="SampleClass-401"><a href="#SampleClass-401"><span class="linenos">401</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">likes_spam</span><span class="o">=</span><span class="kc">False</span><span class="p">):</span>
-</span><span id="SampleClass-402"><a href="#SampleClass-402"><span class="linenos">402</span></a>        <span class="sd">&quot;&quot;&quot;Inits SampleClass with blah.&quot;&quot;&quot;</span>
+</span><span id="SampleClass-402"><a href="#SampleClass-402"><span class="linenos">402</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Inits SampleClass with blah.&quot;&quot;&quot;</span>
 </span><span id="SampleClass-403"><a href="#SampleClass-403"><span class="linenos">403</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">likes_spam</span> <span class="o">=</span> <span class="n">likes_spam</span>
 </span><span id="SampleClass-404"><a href="#SampleClass-404"><span class="linenos">404</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">eggs</span> <span class="o">=</span> <span class="mi">0</span>
 </span><span id="SampleClass-405"><a href="#SampleClass-405"><span class="linenos">405</span></a>
 </span><span id="SampleClass-406"><a href="#SampleClass-406"><span class="linenos">406</span></a>    <span class="k">def</span> <span class="nf">public_method</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="SampleClass-407"><a href="#SampleClass-407"><span class="linenos">407</span></a>        <span class="sd">&quot;&quot;&quot;Performs operation blah.&quot;&quot;&quot;</span>
+</span><span id="SampleClass-407"><a href="#SampleClass-407"><span class="linenos">407</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Performs operation blah.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1594,7 +1600,7 @@ Longer class information....</p>
     </div>
     <a class="headerlink" href="#SampleClass.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="SampleClass.__init__-401"><a href="#SampleClass.__init__-401"><span class="linenos">401</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">likes_spam</span><span class="o">=</span><span class="kc">False</span><span class="p">):</span>
-</span><span id="SampleClass.__init__-402"><a href="#SampleClass.__init__-402"><span class="linenos">402</span></a>        <span class="sd">&quot;&quot;&quot;Inits SampleClass with blah.&quot;&quot;&quot;</span>
+</span><span id="SampleClass.__init__-402"><a href="#SampleClass.__init__-402"><span class="linenos">402</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Inits SampleClass with blah.&quot;&quot;&quot;</span>
 </span><span id="SampleClass.__init__-403"><a href="#SampleClass.__init__-403"><span class="linenos">403</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">likes_spam</span> <span class="o">=</span> <span class="n">likes_spam</span>
 </span><span id="SampleClass.__init__-404"><a href="#SampleClass.__init__-404"><span class="linenos">404</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">eggs</span> <span class="o">=</span> <span class="mi">0</span>
 </span></pre></div>
@@ -1617,7 +1623,7 @@ Longer class information....</p>
     </div>
     <a class="headerlink" href="#SampleClass.public_method"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="SampleClass.public_method-406"><a href="#SampleClass.public_method-406"><span class="linenos">406</span></a>    <span class="k">def</span> <span class="nf">public_method</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="SampleClass.public_method-407"><a href="#SampleClass.public_method-407"><span class="linenos">407</span></a>        <span class="sd">&quot;&quot;&quot;Performs operation blah.&quot;&quot;&quot;</span>
+</span><span id="SampleClass.public_method-407"><a href="#SampleClass.public_method-407"><span class="linenos">407</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Performs operation blah.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1639,7 +1645,7 @@ Longer class information....</p>
     </div>
     <a class="headerlink" href="#invalid_format"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="invalid_format-410"><a href="#invalid_format-410"><span class="linenos">410</span></a><span class="k">def</span> <span class="nf">invalid_format</span><span class="p">(</span><span class="n">test</span><span class="p">):</span>
-</span><span id="invalid_format-411"><a href="#invalid_format-411"><span class="linenos">411</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="invalid_format-411"><a href="#invalid_format-411"><span class="linenos">411</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="invalid_format-412"><a href="#invalid_format-412"><span class="linenos">412</span></a><span class="sd">    In this example, there is no colon after the argument and an empty section.</span>
 </span><span id="invalid_format-413"><a href="#invalid_format-413"><span class="linenos">413</span></a>
 </span><span id="invalid_format-414"><a href="#invalid_format-414"><span class="linenos">414</span></a><span class="sd">    Args:</span>
@@ -1677,7 +1683,7 @@ there is a colon missing in the previous line</li>
     </div>
     <a class="headerlink" href="#example_code"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="example_code-422"><a href="#example_code-422"><span class="linenos">422</span></a><span class="k">def</span> <span class="nf">example_code</span><span class="p">():</span>
-</span><span id="example_code-423"><a href="#example_code-423"><span class="linenos">423</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="example_code-423"><a href="#example_code-423"><span class="linenos">423</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="example_code-424"><a href="#example_code-424"><span class="linenos">424</span></a><span class="sd">    Test case for https://github.com/mitmproxy/pdoc/issues/264.</span>
 </span><span id="example_code-425"><a href="#example_code-425"><span class="linenos">425</span></a>
 </span><span id="example_code-426"><a href="#example_code-426"><span class="linenos">426</span></a><span class="sd">    Example:</span>
@@ -1719,7 +1725,7 @@ there is a colon missing in the previous line</li>
     </div>
     <a class="headerlink" href="#newline_after_args"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="newline_after_args-436"><a href="#newline_after_args-436"><span class="linenos">436</span></a><span class="k">def</span> <span class="nf">newline_after_args</span><span class="p">(</span><span class="n">test</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="newline_after_args-437"><a href="#newline_after_args-437"><span class="linenos">437</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="newline_after_args-437"><a href="#newline_after_args-437"><span class="linenos">437</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="newline_after_args-438"><a href="#newline_after_args-438"><span class="linenos">438</span></a><span class="sd">    Test case for https://github.com/mitmproxy/pdoc/pull/458.</span>
 </span><span id="newline_after_args-439"><a href="#newline_after_args-439"><span class="linenos">439</span></a>
 </span><span id="newline_after_args-440"><a href="#newline_after_args-440"><span class="linenos">440</span></a><span class="sd">    Args:</span>
@@ -1754,7 +1760,7 @@ there is unexpected whitespace before test.</li>
     </div>
     <a class="headerlink" href="#alternative_section_names"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="alternative_section_names-447"><a href="#alternative_section_names-447"><span class="linenos">447</span></a><span class="k">def</span> <span class="nf">alternative_section_names</span><span class="p">(</span><span class="n">test</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="alternative_section_names-448"><a href="#alternative_section_names-448"><span class="linenos">448</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="alternative_section_names-448"><a href="#alternative_section_names-448"><span class="linenos">448</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="alternative_section_names-449"><a href="#alternative_section_names-449"><span class="linenos">449</span></a><span class="sd">    In this example, we check whether alternative section names aliased to</span>
 </span><span id="alternative_section_names-450"><a href="#alternative_section_names-450"><span class="linenos">450</span></a><span class="sd">    &#39;Args&#39; are handled properly.</span>
 </span><span id="alternative_section_names-451"><a href="#alternative_section_names-451"><span class="linenos">451</span></a>

--- a/test/testdata/flavors_numpy.html
+++ b/test/testdata/flavors_numpy.html
@@ -203,7 +203,7 @@ with it.</p></li>
 </span><span id="L-64"><a href="#L-64"><span class="linenos"> 64</span></a>
 </span><span id="L-65"><a href="#L-65"><span class="linenos"> 65</span></a>
 </span><span id="L-66"><a href="#L-66"><span class="linenos"> 66</span></a><span class="k">def</span> <span class="nf">function_with_types_in_docstring</span><span class="p">(</span><span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">):</span>
-</span><span id="L-67"><a href="#L-67"><span class="linenos"> 67</span></a>    <span class="sd">&quot;&quot;&quot;Example function with types documented in the docstring.</span>
+</span><span id="L-67"><a href="#L-67"><span class="linenos"> 67</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Example function with types documented in the docstring.</span>
 </span><span id="L-68"><a href="#L-68"><span class="linenos"> 68</span></a>
 </span><span id="L-69"><a href="#L-69"><span class="linenos"> 69</span></a><span class="sd">    `PEP 484`_ type annotations are supported. If attribute, parameter, and</span>
 </span><span id="L-70"><a href="#L-70"><span class="linenos"> 70</span></a><span class="sd">    return types are annotated according to `PEP 484`_, they do not need to be</span>
@@ -228,7 +228,7 @@ with it.</p></li>
 </span><span id="L-89"><a href="#L-89"><span class="linenos"> 89</span></a>
 </span><span id="L-90"><a href="#L-90"><span class="linenos"> 90</span></a>
 </span><span id="L-91"><a href="#L-91"><span class="linenos"> 91</span></a><span class="k">def</span> <span class="nf">function_with_pep484_type_annotations</span><span class="p">(</span><span class="n">param1</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">param2</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-</span><span id="L-92"><a href="#L-92"><span class="linenos"> 92</span></a>    <span class="sd">&quot;&quot;&quot;Example function with PEP 484 type annotations.</span>
+</span><span id="L-92"><a href="#L-92"><span class="linenos"> 92</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Example function with PEP 484 type annotations.</span>
 </span><span id="L-93"><a href="#L-93"><span class="linenos"> 93</span></a>
 </span><span id="L-94"><a href="#L-94"><span class="linenos"> 94</span></a><span class="sd">    The return type must be duplicated in the docstring to comply</span>
 </span><span id="L-95"><a href="#L-95"><span class="linenos"> 95</span></a><span class="sd">    with the NumPy docstring style.</span>
@@ -250,7 +250,7 @@ with it.</p></li>
 </span><span id="L-111"><a href="#L-111"><span class="linenos">111</span></a>
 </span><span id="L-112"><a href="#L-112"><span class="linenos">112</span></a>
 </span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a><span class="k">def</span> <span class="nf">module_level_function</span><span class="p">(</span><span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-</span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a>    <span class="sd">&quot;&quot;&quot;This is an example of a module level function.</span>
+</span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This is an example of a module level function.</span>
 </span><span id="L-115"><a href="#L-115"><span class="linenos">115</span></a>
 </span><span id="L-116"><a href="#L-116"><span class="linenos">116</span></a><span class="sd">    Function parameters should be documented in the ``Parameters`` section.</span>
 </span><span id="L-117"><a href="#L-117"><span class="linenos">117</span></a><span class="sd">    The name of each parameter is required. The type and description of each</span>
@@ -314,7 +314,7 @@ with it.</p></li>
 </span><span id="L-175"><a href="#L-175"><span class="linenos">175</span></a>
 </span><span id="L-176"><a href="#L-176"><span class="linenos">176</span></a>
 </span><span id="L-177"><a href="#L-177"><span class="linenos">177</span></a><span class="k">def</span> <span class="nf">example_generator</span><span class="p">(</span><span class="n">n</span><span class="p">):</span>
-</span><span id="L-178"><a href="#L-178"><span class="linenos">178</span></a>    <span class="sd">&quot;&quot;&quot;Generators have a ``Yields`` section instead of a ``Returns`` section.</span>
+</span><span id="L-178"><a href="#L-178"><span class="linenos">178</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Generators have a ``Yields`` section instead of a ``Returns`` section.</span>
 </span><span id="L-179"><a href="#L-179"><span class="linenos">179</span></a>
 </span><span id="L-180"><a href="#L-180"><span class="linenos">180</span></a><span class="sd">    Parameters</span>
 </span><span id="L-181"><a href="#L-181"><span class="linenos">181</span></a><span class="sd">    ----------</span>
@@ -340,7 +340,7 @@ with it.</p></li>
 </span><span id="L-201"><a href="#L-201"><span class="linenos">201</span></a>
 </span><span id="L-202"><a href="#L-202"><span class="linenos">202</span></a>
 </span><span id="L-203"><a href="#L-203"><span class="linenos">203</span></a><span class="k">class</span> <span class="nc">ExampleError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-</span><span id="L-204"><a href="#L-204"><span class="linenos">204</span></a>    <span class="sd">&quot;&quot;&quot;Exceptions are documented in the same way as classes.</span>
+</span><span id="L-204"><a href="#L-204"><span class="linenos">204</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Exceptions are documented in the same way as classes.</span>
 </span><span id="L-205"><a href="#L-205"><span class="linenos">205</span></a>
 </span><span id="L-206"><a href="#L-206"><span class="linenos">206</span></a><span class="sd">    The __init__ method may be documented in either the class level</span>
 </span><span id="L-207"><a href="#L-207"><span class="linenos">207</span></a><span class="sd">    docstring, or as a docstring on the __init__ method itself.</span>
@@ -373,11 +373,11 @@ with it.</p></li>
 </span><span id="L-234"><a href="#L-234"><span class="linenos">234</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">code</span> <span class="o">=</span> <span class="n">code</span>
 </span><span id="L-235"><a href="#L-235"><span class="linenos">235</span></a>
 </span><span id="L-236"><a href="#L-236"><span class="linenos">236</span></a>    <span class="k">def</span> <span class="nf">add_note</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">note</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-237"><a href="#L-237"><span class="linenos">237</span></a>        <span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
+</span><span id="L-237"><a href="#L-237"><span class="linenos">237</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
 </span><span id="L-238"><a href="#L-238"><span class="linenos">238</span></a>
 </span><span id="L-239"><a href="#L-239"><span class="linenos">239</span></a>
 </span><span id="L-240"><a href="#L-240"><span class="linenos">240</span></a><span class="k">class</span> <span class="nc">ExampleClass</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="L-241"><a href="#L-241"><span class="linenos">241</span></a>    <span class="sd">&quot;&quot;&quot;The summary line for a class docstring should fit on one line.</span>
+</span><span id="L-241"><a href="#L-241"><span class="linenos">241</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The summary line for a class docstring should fit on one line.</span>
 </span><span id="L-242"><a href="#L-242"><span class="linenos">242</span></a>
 </span><span id="L-243"><a href="#L-243"><span class="linenos">243</span></a><span class="sd">    If the class has public attributes, they may be documented here</span>
 </span><span id="L-244"><a href="#L-244"><span class="linenos">244</span></a><span class="sd">    in an ``Attributes`` section and follow the same formatting as a</span>
@@ -397,7 +397,7 @@ with it.</p></li>
 </span><span id="L-258"><a href="#L-258"><span class="linenos">258</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-259"><a href="#L-259"><span class="linenos">259</span></a>
 </span><span id="L-260"><a href="#L-260"><span class="linenos">260</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">,</span> <span class="n">param3</span><span class="p">):</span>
-</span><span id="L-261"><a href="#L-261"><span class="linenos">261</span></a>        <span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
+</span><span id="L-261"><a href="#L-261"><span class="linenos">261</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
 </span><span id="L-262"><a href="#L-262"><span class="linenos">262</span></a>
 </span><span id="L-263"><a href="#L-263"><span class="linenos">263</span></a><span class="sd">        The __init__ method may be documented in either the class level</span>
 </span><span id="L-264"><a href="#L-264"><span class="linenos">264</span></a><span class="sd">        docstring, or as a docstring on the __init__ method itself.</span>
@@ -428,16 +428,16 @@ with it.</p></li>
 </span><span id="L-289"><a href="#L-289"><span class="linenos">289</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr4</span> <span class="o">=</span> <span class="p">[</span><span class="s2">&quot;attr4&quot;</span><span class="p">]</span>
 </span><span id="L-290"><a href="#L-290"><span class="linenos">290</span></a>
 </span><span id="L-291"><a href="#L-291"><span class="linenos">291</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr5</span> <span class="o">=</span> <span class="kc">None</span>
-</span><span id="L-292"><a href="#L-292"><span class="linenos">292</span></a>        <span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
+</span><span id="L-292"><a href="#L-292"><span class="linenos">292</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
 </span><span id="L-293"><a href="#L-293"><span class="linenos">293</span></a>
 </span><span id="L-294"><a href="#L-294"><span class="linenos">294</span></a>    <span class="nd">@property</span>
 </span><span id="L-295"><a href="#L-295"><span class="linenos">295</span></a>    <span class="k">def</span> <span class="nf">readonly_property</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-296"><a href="#L-296"><span class="linenos">296</span></a>        <span class="sd">&quot;&quot;&quot;str: Properties should be documented in their getter method.&quot;&quot;&quot;</span>
+</span><span id="L-296"><a href="#L-296"><span class="linenos">296</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;str: Properties should be documented in their getter method.&quot;&quot;&quot;</span>
 </span><span id="L-297"><a href="#L-297"><span class="linenos">297</span></a>        <span class="k">return</span> <span class="s2">&quot;readonly_property&quot;</span>
 </span><span id="L-298"><a href="#L-298"><span class="linenos">298</span></a>
 </span><span id="L-299"><a href="#L-299"><span class="linenos">299</span></a>    <span class="nd">@property</span>
 </span><span id="L-300"><a href="#L-300"><span class="linenos">300</span></a>    <span class="k">def</span> <span class="nf">readwrite_property</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-301"><a href="#L-301"><span class="linenos">301</span></a>        <span class="sd">&quot;&quot;&quot;:obj:`list` of :obj:`str`: Properties with both a getter and setter</span>
+</span><span id="L-301"><a href="#L-301"><span class="linenos">301</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;:obj:`list` of :obj:`str`: Properties with both a getter and setter</span>
 </span><span id="L-302"><a href="#L-302"><span class="linenos">302</span></a><span class="sd">        should only be documented in their getter method.</span>
 </span><span id="L-303"><a href="#L-303"><span class="linenos">303</span></a>
 </span><span id="L-304"><a href="#L-304"><span class="linenos">304</span></a><span class="sd">        If the setter method contains notable behavior, it should be</span>
@@ -450,7 +450,7 @@ with it.</p></li>
 </span><span id="L-311"><a href="#L-311"><span class="linenos">311</span></a>        <span class="n">value</span>
 </span><span id="L-312"><a href="#L-312"><span class="linenos">312</span></a>
 </span><span id="L-313"><a href="#L-313"><span class="linenos">313</span></a>    <span class="k">def</span> <span class="nf">example_method</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">):</span>
-</span><span id="L-314"><a href="#L-314"><span class="linenos">314</span></a>        <span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
+</span><span id="L-314"><a href="#L-314"><span class="linenos">314</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
 </span><span id="L-315"><a href="#L-315"><span class="linenos">315</span></a>
 </span><span id="L-316"><a href="#L-316"><span class="linenos">316</span></a><span class="sd">        Note</span>
 </span><span id="L-317"><a href="#L-317"><span class="linenos">317</span></a><span class="sd">        ----</span>
@@ -472,7 +472,7 @@ with it.</p></li>
 </span><span id="L-333"><a href="#L-333"><span class="linenos">333</span></a>        <span class="k">return</span> <span class="kc">True</span>
 </span><span id="L-334"><a href="#L-334"><span class="linenos">334</span></a>
 </span><span id="L-335"><a href="#L-335"><span class="linenos">335</span></a>    <span class="k">def</span> <span class="nf">__special__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-336"><a href="#L-336"><span class="linenos">336</span></a>        <span class="sd">&quot;&quot;&quot;By default special members with docstrings are not included.</span>
+</span><span id="L-336"><a href="#L-336"><span class="linenos">336</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;By default special members with docstrings are not included.</span>
 </span><span id="L-337"><a href="#L-337"><span class="linenos">337</span></a>
 </span><span id="L-338"><a href="#L-338"><span class="linenos">338</span></a><span class="sd">        Special members are any methods or attributes that start with and</span>
 </span><span id="L-339"><a href="#L-339"><span class="linenos">339</span></a><span class="sd">        end with a double underscore. Any special member with a docstring</span>
@@ -491,7 +491,7 @@ with it.</p></li>
 </span><span id="L-352"><a href="#L-352"><span class="linenos">352</span></a>        <span class="k">pass</span>
 </span><span id="L-353"><a href="#L-353"><span class="linenos">353</span></a>
 </span><span id="L-354"><a href="#L-354"><span class="linenos">354</span></a>    <span class="k">def</span> <span class="nf">_private</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-355"><a href="#L-355"><span class="linenos">355</span></a>        <span class="sd">&quot;&quot;&quot;By default private members are not included.</span>
+</span><span id="L-355"><a href="#L-355"><span class="linenos">355</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;By default private members are not included.</span>
 </span><span id="L-356"><a href="#L-356"><span class="linenos">356</span></a>
 </span><span id="L-357"><a href="#L-357"><span class="linenos">357</span></a><span class="sd">        Private members are any methods or attributes that start with an</span>
 </span><span id="L-358"><a href="#L-358"><span class="linenos">358</span></a><span class="sd">        underscore and are *not* special. By default they are not included</span>
@@ -510,7 +510,7 @@ with it.</p></li>
 </span><span id="L-371"><a href="#L-371"><span class="linenos">371</span></a>
 </span><span id="L-372"><a href="#L-372"><span class="linenos">372</span></a>
 </span><span id="L-373"><a href="#L-373"><span class="linenos">373</span></a><span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="n">var1</span><span class="p">,</span> <span class="n">var2</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="n">long_var_name</span><span class="o">=</span><span class="s1">&#39;hi&#39;</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-</span><span id="L-374"><a href="#L-374"><span class="linenos">374</span></a>    <span class="sa">r</span><span class="sd">&quot;&quot;&quot;Summarize the function in one line.</span>
+</span><span id="L-374"><a href="#L-374"><span class="linenos">374</span></a><span class="w">    </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;Summarize the function in one line.</span>
 </span><span id="L-375"><a href="#L-375"><span class="linenos">375</span></a>
 </span><span id="L-376"><a href="#L-376"><span class="linenos">376</span></a><span class="sd">    Several sentences providing an extended description. Refer to</span>
 </span><span id="L-377"><a href="#L-377"><span class="linenos">377</span></a><span class="sd">    variables using back-ticks, e.g. `var`.</span>
@@ -604,7 +604,7 @@ with it.</p></li>
 </span><span id="L-465"><a href="#L-465"><span class="linenos">465</span></a>
 </span><span id="L-466"><a href="#L-466"><span class="linenos">466</span></a>
 </span><span id="L-467"><a href="#L-467"><span class="linenos">467</span></a><span class="k">def</span> <span class="nf">invalid_format</span><span class="p">(</span><span class="n">test</span><span class="p">):</span>
-</span><span id="L-468"><a href="#L-468"><span class="linenos">468</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-468"><a href="#L-468"><span class="linenos">468</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-469"><a href="#L-469"><span class="linenos">469</span></a><span class="sd">    In this example, there is no description for the test argument</span>
 </span><span id="L-470"><a href="#L-470"><span class="linenos">470</span></a>
 </span><span id="L-471"><a href="#L-471"><span class="linenos">471</span></a><span class="sd">    Parameters</span>
@@ -617,13 +617,19 @@ with it.</p></li>
 
             </section>
                 <section id="module_level_variable2">
-                    <div class="attr variable">
-            <span class="name">module_level_variable2</span><span class="default_value"> = 98765</span>
-
+                            <input id="module_level_variable2-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">module_level_variable2</span>
         
+
+                <label class="view-source-button" for="module_level_variable2-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#module_level_variable2"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="module_level_variable2-1"><a href="#module_level_variable2-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="mi">98765</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>int: Module level variable documented inline.</p>
 
 <p>The docstring may span multiple lines. The type may optionally be specified
@@ -644,7 +650,7 @@ on the first line, separated by a colon.</p>
     </div>
     <a class="headerlink" href="#function_with_types_in_docstring"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="function_with_types_in_docstring-67"><a href="#function_with_types_in_docstring-67"><span class="linenos">67</span></a><span class="k">def</span> <span class="nf">function_with_types_in_docstring</span><span class="p">(</span><span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">):</span>
-</span><span id="function_with_types_in_docstring-68"><a href="#function_with_types_in_docstring-68"><span class="linenos">68</span></a>    <span class="sd">&quot;&quot;&quot;Example function with types documented in the docstring.</span>
+</span><span id="function_with_types_in_docstring-68"><a href="#function_with_types_in_docstring-68"><span class="linenos">68</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Example function with types documented in the docstring.</span>
 </span><span id="function_with_types_in_docstring-69"><a href="#function_with_types_in_docstring-69"><span class="linenos">69</span></a>
 </span><span id="function_with_types_in_docstring-70"><a href="#function_with_types_in_docstring-70"><span class="linenos">70</span></a><span class="sd">    `PEP 484`_ type annotations are supported. If attribute, parameter, and</span>
 </span><span id="function_with_types_in_docstring-71"><a href="#function_with_types_in_docstring-71"><span class="linenos">71</span></a><span class="sd">    return types are annotated according to `PEP 484`_, they do not need to be</span>
@@ -705,7 +711,7 @@ The second parameter.</li>
     </div>
     <a class="headerlink" href="#function_with_pep484_type_annotations"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="function_with_pep484_type_annotations-92"><a href="#function_with_pep484_type_annotations-92"><span class="linenos"> 92</span></a><span class="k">def</span> <span class="nf">function_with_pep484_type_annotations</span><span class="p">(</span><span class="n">param1</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">param2</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-</span><span id="function_with_pep484_type_annotations-93"><a href="#function_with_pep484_type_annotations-93"><span class="linenos"> 93</span></a>    <span class="sd">&quot;&quot;&quot;Example function with PEP 484 type annotations.</span>
+</span><span id="function_with_pep484_type_annotations-93"><a href="#function_with_pep484_type_annotations-93"><span class="linenos"> 93</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Example function with PEP 484 type annotations.</span>
 </span><span id="function_with_pep484_type_annotations-94"><a href="#function_with_pep484_type_annotations-94"><span class="linenos"> 94</span></a>
 </span><span id="function_with_pep484_type_annotations-95"><a href="#function_with_pep484_type_annotations-95"><span class="linenos"> 95</span></a><span class="sd">    The return type must be duplicated in the docstring to comply</span>
 </span><span id="function_with_pep484_type_annotations-96"><a href="#function_with_pep484_type_annotations-96"><span class="linenos"> 96</span></a><span class="sd">    with the NumPy docstring style.</span>
@@ -760,7 +766,7 @@ with the NumPy docstring style.</p>
     </div>
     <a class="headerlink" href="#module_level_function"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="module_level_function-114"><a href="#module_level_function-114"><span class="linenos">114</span></a><span class="k">def</span> <span class="nf">module_level_function</span><span class="p">(</span><span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-</span><span id="module_level_function-115"><a href="#module_level_function-115"><span class="linenos">115</span></a>    <span class="sd">&quot;&quot;&quot;This is an example of a module level function.</span>
+</span><span id="module_level_function-115"><a href="#module_level_function-115"><span class="linenos">115</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This is an example of a module level function.</span>
 </span><span id="module_level_function-116"><a href="#module_level_function-116"><span class="linenos">116</span></a>
 </span><span id="module_level_function-117"><a href="#module_level_function-117"><span class="linenos">117</span></a><span class="sd">    Function parameters should be documented in the ``Parameters`` section.</span>
 </span><span id="module_level_function-118"><a href="#module_level_function-118"><span class="linenos">118</span></a><span class="sd">    The name of each parameter is required. The type and description of each</span>
@@ -899,7 +905,7 @@ that are relevant to the interface.</li>
     </div>
     <a class="headerlink" href="#example_generator"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="example_generator-178"><a href="#example_generator-178"><span class="linenos">178</span></a><span class="k">def</span> <span class="nf">example_generator</span><span class="p">(</span><span class="n">n</span><span class="p">):</span>
-</span><span id="example_generator-179"><a href="#example_generator-179"><span class="linenos">179</span></a>    <span class="sd">&quot;&quot;&quot;Generators have a ``Yields`` section instead of a ``Returns`` section.</span>
+</span><span id="example_generator-179"><a href="#example_generator-179"><span class="linenos">179</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Generators have a ``Yields`` section instead of a ``Returns`` section.</span>
 </span><span id="example_generator-180"><a href="#example_generator-180"><span class="linenos">180</span></a>
 </span><span id="example_generator-181"><a href="#example_generator-181"><span class="linenos">181</span></a><span class="sd">    Parameters</span>
 </span><span id="example_generator-182"><a href="#example_generator-182"><span class="linenos">182</span></a><span class="sd">    ----------</span>
@@ -966,7 +972,7 @@ to use the function.</p>
     </div>
     <a class="headerlink" href="#ExampleError"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ExampleError-204"><a href="#ExampleError-204"><span class="linenos">204</span></a><span class="k">class</span> <span class="nc">ExampleError</span><span class="p">(</span><span class="ne">Exception</span><span class="p">):</span>
-</span><span id="ExampleError-205"><a href="#ExampleError-205"><span class="linenos">205</span></a>    <span class="sd">&quot;&quot;&quot;Exceptions are documented in the same way as classes.</span>
+</span><span id="ExampleError-205"><a href="#ExampleError-205"><span class="linenos">205</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Exceptions are documented in the same way as classes.</span>
 </span><span id="ExampleError-206"><a href="#ExampleError-206"><span class="linenos">206</span></a>
 </span><span id="ExampleError-207"><a href="#ExampleError-207"><span class="linenos">207</span></a><span class="sd">    The __init__ method may be documented in either the class level</span>
 </span><span id="ExampleError-208"><a href="#ExampleError-208"><span class="linenos">208</span></a><span class="sd">    docstring, or as a docstring on the __init__ method itself.</span>
@@ -999,7 +1005,7 @@ to use the function.</p>
 </span><span id="ExampleError-235"><a href="#ExampleError-235"><span class="linenos">235</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">code</span> <span class="o">=</span> <span class="n">code</span>
 </span><span id="ExampleError-236"><a href="#ExampleError-236"><span class="linenos">236</span></a>
 </span><span id="ExampleError-237"><a href="#ExampleError-237"><span class="linenos">237</span></a>    <span class="k">def</span> <span class="nf">add_note</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">note</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="ExampleError-238"><a href="#ExampleError-238"><span class="linenos">238</span></a>        <span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
+</span><span id="ExampleError-238"><a href="#ExampleError-238"><span class="linenos">238</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1066,7 +1072,7 @@ Numeric error code.</li>
     </div>
     <a class="headerlink" href="#ExampleError.add_note"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ExampleError.add_note-237"><a href="#ExampleError.add_note-237"><span class="linenos">237</span></a>    <span class="k">def</span> <span class="nf">add_note</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">note</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="ExampleError.add_note-238"><a href="#ExampleError.add_note-238"><span class="linenos">238</span></a>        <span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
+</span><span id="ExampleError.add_note-238"><a href="#ExampleError.add_note-238"><span class="linenos">238</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This method is present on Python 3.11+ and manually added here so that snapshots are consistent.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1097,7 +1103,7 @@ Numeric error code.</li>
     </div>
     <a class="headerlink" href="#ExampleClass"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ExampleClass-241"><a href="#ExampleClass-241"><span class="linenos">241</span></a><span class="k">class</span> <span class="nc">ExampleClass</span><span class="p">(</span><span class="nb">object</span><span class="p">):</span>
-</span><span id="ExampleClass-242"><a href="#ExampleClass-242"><span class="linenos">242</span></a>    <span class="sd">&quot;&quot;&quot;The summary line for a class docstring should fit on one line.</span>
+</span><span id="ExampleClass-242"><a href="#ExampleClass-242"><span class="linenos">242</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The summary line for a class docstring should fit on one line.</span>
 </span><span id="ExampleClass-243"><a href="#ExampleClass-243"><span class="linenos">243</span></a>
 </span><span id="ExampleClass-244"><a href="#ExampleClass-244"><span class="linenos">244</span></a><span class="sd">    If the class has public attributes, they may be documented here</span>
 </span><span id="ExampleClass-245"><a href="#ExampleClass-245"><span class="linenos">245</span></a><span class="sd">    in an ``Attributes`` section and follow the same formatting as a</span>
@@ -1117,7 +1123,7 @@ Numeric error code.</li>
 </span><span id="ExampleClass-259"><a href="#ExampleClass-259"><span class="linenos">259</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="ExampleClass-260"><a href="#ExampleClass-260"><span class="linenos">260</span></a>
 </span><span id="ExampleClass-261"><a href="#ExampleClass-261"><span class="linenos">261</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">,</span> <span class="n">param3</span><span class="p">):</span>
-</span><span id="ExampleClass-262"><a href="#ExampleClass-262"><span class="linenos">262</span></a>        <span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
+</span><span id="ExampleClass-262"><a href="#ExampleClass-262"><span class="linenos">262</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
 </span><span id="ExampleClass-263"><a href="#ExampleClass-263"><span class="linenos">263</span></a>
 </span><span id="ExampleClass-264"><a href="#ExampleClass-264"><span class="linenos">264</span></a><span class="sd">        The __init__ method may be documented in either the class level</span>
 </span><span id="ExampleClass-265"><a href="#ExampleClass-265"><span class="linenos">265</span></a><span class="sd">        docstring, or as a docstring on the __init__ method itself.</span>
@@ -1148,16 +1154,16 @@ Numeric error code.</li>
 </span><span id="ExampleClass-290"><a href="#ExampleClass-290"><span class="linenos">290</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr4</span> <span class="o">=</span> <span class="p">[</span><span class="s2">&quot;attr4&quot;</span><span class="p">]</span>
 </span><span id="ExampleClass-291"><a href="#ExampleClass-291"><span class="linenos">291</span></a>
 </span><span id="ExampleClass-292"><a href="#ExampleClass-292"><span class="linenos">292</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr5</span> <span class="o">=</span> <span class="kc">None</span>
-</span><span id="ExampleClass-293"><a href="#ExampleClass-293"><span class="linenos">293</span></a>        <span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
+</span><span id="ExampleClass-293"><a href="#ExampleClass-293"><span class="linenos">293</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
 </span><span id="ExampleClass-294"><a href="#ExampleClass-294"><span class="linenos">294</span></a>
 </span><span id="ExampleClass-295"><a href="#ExampleClass-295"><span class="linenos">295</span></a>    <span class="nd">@property</span>
 </span><span id="ExampleClass-296"><a href="#ExampleClass-296"><span class="linenos">296</span></a>    <span class="k">def</span> <span class="nf">readonly_property</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="ExampleClass-297"><a href="#ExampleClass-297"><span class="linenos">297</span></a>        <span class="sd">&quot;&quot;&quot;str: Properties should be documented in their getter method.&quot;&quot;&quot;</span>
+</span><span id="ExampleClass-297"><a href="#ExampleClass-297"><span class="linenos">297</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;str: Properties should be documented in their getter method.&quot;&quot;&quot;</span>
 </span><span id="ExampleClass-298"><a href="#ExampleClass-298"><span class="linenos">298</span></a>        <span class="k">return</span> <span class="s2">&quot;readonly_property&quot;</span>
 </span><span id="ExampleClass-299"><a href="#ExampleClass-299"><span class="linenos">299</span></a>
 </span><span id="ExampleClass-300"><a href="#ExampleClass-300"><span class="linenos">300</span></a>    <span class="nd">@property</span>
 </span><span id="ExampleClass-301"><a href="#ExampleClass-301"><span class="linenos">301</span></a>    <span class="k">def</span> <span class="nf">readwrite_property</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="ExampleClass-302"><a href="#ExampleClass-302"><span class="linenos">302</span></a>        <span class="sd">&quot;&quot;&quot;:obj:`list` of :obj:`str`: Properties with both a getter and setter</span>
+</span><span id="ExampleClass-302"><a href="#ExampleClass-302"><span class="linenos">302</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;:obj:`list` of :obj:`str`: Properties with both a getter and setter</span>
 </span><span id="ExampleClass-303"><a href="#ExampleClass-303"><span class="linenos">303</span></a><span class="sd">        should only be documented in their getter method.</span>
 </span><span id="ExampleClass-304"><a href="#ExampleClass-304"><span class="linenos">304</span></a>
 </span><span id="ExampleClass-305"><a href="#ExampleClass-305"><span class="linenos">305</span></a><span class="sd">        If the setter method contains notable behavior, it should be</span>
@@ -1170,7 +1176,7 @@ Numeric error code.</li>
 </span><span id="ExampleClass-312"><a href="#ExampleClass-312"><span class="linenos">312</span></a>        <span class="n">value</span>
 </span><span id="ExampleClass-313"><a href="#ExampleClass-313"><span class="linenos">313</span></a>
 </span><span id="ExampleClass-314"><a href="#ExampleClass-314"><span class="linenos">314</span></a>    <span class="k">def</span> <span class="nf">example_method</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">):</span>
-</span><span id="ExampleClass-315"><a href="#ExampleClass-315"><span class="linenos">315</span></a>        <span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
+</span><span id="ExampleClass-315"><a href="#ExampleClass-315"><span class="linenos">315</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
 </span><span id="ExampleClass-316"><a href="#ExampleClass-316"><span class="linenos">316</span></a>
 </span><span id="ExampleClass-317"><a href="#ExampleClass-317"><span class="linenos">317</span></a><span class="sd">        Note</span>
 </span><span id="ExampleClass-318"><a href="#ExampleClass-318"><span class="linenos">318</span></a><span class="sd">        ----</span>
@@ -1192,7 +1198,7 @@ Numeric error code.</li>
 </span><span id="ExampleClass-334"><a href="#ExampleClass-334"><span class="linenos">334</span></a>        <span class="k">return</span> <span class="kc">True</span>
 </span><span id="ExampleClass-335"><a href="#ExampleClass-335"><span class="linenos">335</span></a>
 </span><span id="ExampleClass-336"><a href="#ExampleClass-336"><span class="linenos">336</span></a>    <span class="k">def</span> <span class="nf">__special__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="ExampleClass-337"><a href="#ExampleClass-337"><span class="linenos">337</span></a>        <span class="sd">&quot;&quot;&quot;By default special members with docstrings are not included.</span>
+</span><span id="ExampleClass-337"><a href="#ExampleClass-337"><span class="linenos">337</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;By default special members with docstrings are not included.</span>
 </span><span id="ExampleClass-338"><a href="#ExampleClass-338"><span class="linenos">338</span></a>
 </span><span id="ExampleClass-339"><a href="#ExampleClass-339"><span class="linenos">339</span></a><span class="sd">        Special members are any methods or attributes that start with and</span>
 </span><span id="ExampleClass-340"><a href="#ExampleClass-340"><span class="linenos">340</span></a><span class="sd">        end with a double underscore. Any special member with a docstring</span>
@@ -1211,7 +1217,7 @@ Numeric error code.</li>
 </span><span id="ExampleClass-353"><a href="#ExampleClass-353"><span class="linenos">353</span></a>        <span class="k">pass</span>
 </span><span id="ExampleClass-354"><a href="#ExampleClass-354"><span class="linenos">354</span></a>
 </span><span id="ExampleClass-355"><a href="#ExampleClass-355"><span class="linenos">355</span></a>    <span class="k">def</span> <span class="nf">_private</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="ExampleClass-356"><a href="#ExampleClass-356"><span class="linenos">356</span></a>        <span class="sd">&quot;&quot;&quot;By default private members are not included.</span>
+</span><span id="ExampleClass-356"><a href="#ExampleClass-356"><span class="linenos">356</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;By default private members are not included.</span>
 </span><span id="ExampleClass-357"><a href="#ExampleClass-357"><span class="linenos">357</span></a>
 </span><span id="ExampleClass-358"><a href="#ExampleClass-358"><span class="linenos">358</span></a><span class="sd">        Private members are any methods or attributes that start with an</span>
 </span><span id="ExampleClass-359"><a href="#ExampleClass-359"><span class="linenos">359</span></a><span class="sd">        underscore and are *not* special. By default they are not included</span>
@@ -1262,7 +1268,7 @@ Description of <code>attr2</code>.</li>
     </div>
     <a class="headerlink" href="#ExampleClass.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ExampleClass.__init__-261"><a href="#ExampleClass.__init__-261"><span class="linenos">261</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">,</span> <span class="n">param3</span><span class="p">):</span>
-</span><span id="ExampleClass.__init__-262"><a href="#ExampleClass.__init__-262"><span class="linenos">262</span></a>        <span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
+</span><span id="ExampleClass.__init__-262"><a href="#ExampleClass.__init__-262"><span class="linenos">262</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Example of docstring on the __init__ method.</span>
 </span><span id="ExampleClass.__init__-263"><a href="#ExampleClass.__init__-263"><span class="linenos">263</span></a>
 </span><span id="ExampleClass.__init__-264"><a href="#ExampleClass.__init__-264"><span class="linenos">264</span></a><span class="sd">        The __init__ method may be documented in either the class level</span>
 </span><span id="ExampleClass.__init__-265"><a href="#ExampleClass.__init__-265"><span class="linenos">265</span></a><span class="sd">        docstring, or as a docstring on the __init__ method itself.</span>
@@ -1293,7 +1299,7 @@ Description of <code>attr2</code>.</li>
 </span><span id="ExampleClass.__init__-290"><a href="#ExampleClass.__init__-290"><span class="linenos">290</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr4</span> <span class="o">=</span> <span class="p">[</span><span class="s2">&quot;attr4&quot;</span><span class="p">]</span>
 </span><span id="ExampleClass.__init__-291"><a href="#ExampleClass.__init__-291"><span class="linenos">291</span></a>
 </span><span id="ExampleClass.__init__-292"><a href="#ExampleClass.__init__-292"><span class="linenos">292</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">attr5</span> <span class="o">=</span> <span class="kc">None</span>
-</span><span id="ExampleClass.__init__-293"><a href="#ExampleClass.__init__-293"><span class="linenos">293</span></a>        <span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
+</span><span id="ExampleClass.__init__-293"><a href="#ExampleClass.__init__-293"><span class="linenos">293</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;str: Docstring *after* attribute, with type specified.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1379,7 +1385,7 @@ mentioned here.</p>
     </div>
     <a class="headerlink" href="#ExampleClass.example_method"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ExampleClass.example_method-314"><a href="#ExampleClass.example_method-314"><span class="linenos">314</span></a>    <span class="k">def</span> <span class="nf">example_method</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">param1</span><span class="p">,</span> <span class="n">param2</span><span class="p">):</span>
-</span><span id="ExampleClass.example_method-315"><a href="#ExampleClass.example_method-315"><span class="linenos">315</span></a>        <span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
+</span><span id="ExampleClass.example_method-315"><a href="#ExampleClass.example_method-315"><span class="linenos">315</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Class methods are similar to regular functions.</span>
 </span><span id="ExampleClass.example_method-316"><a href="#ExampleClass.example_method-316"><span class="linenos">316</span></a>
 </span><span id="ExampleClass.example_method-317"><a href="#ExampleClass.example_method-317"><span class="linenos">317</span></a><span class="sd">        Note</span>
 </span><span id="ExampleClass.example_method-318"><a href="#ExampleClass.example_method-318"><span class="linenos">318</span></a><span class="sd">        ----</span>
@@ -1437,7 +1443,7 @@ mentioned here.</p>
     </div>
     <a class="headerlink" href="#foo"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="foo-374"><a href="#foo-374"><span class="linenos">374</span></a><span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="n">var1</span><span class="p">,</span> <span class="n">var2</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="n">long_var_name</span><span class="o">=</span><span class="s1">&#39;hi&#39;</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-</span><span id="foo-375"><a href="#foo-375"><span class="linenos">375</span></a>    <span class="sa">r</span><span class="sd">&quot;&quot;&quot;Summarize the function in one line.</span>
+</span><span id="foo-375"><a href="#foo-375"><span class="linenos">375</span></a><span class="w">    </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;Summarize the function in one line.</span>
 </span><span id="foo-376"><a href="#foo-376"><span class="linenos">376</span></a>
 </span><span id="foo-377"><a href="#foo-377"><span class="linenos">377</span></a><span class="sd">    Several sentences providing an extended description. Refer to</span>
 </span><span id="foo-378"><a href="#foo-378"><span class="linenos">378</span></a><span class="sd">    variables using back-ticks, e.g. `var`.</span>
@@ -1648,7 +1654,7 @@ pp. 585-588, 1996.&#160;<a href="#fnref-1" class="footnoteBackLink" title="Jump 
     </div>
     <a class="headerlink" href="#invalid_format"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="invalid_format-468"><a href="#invalid_format-468"><span class="linenos">468</span></a><span class="k">def</span> <span class="nf">invalid_format</span><span class="p">(</span><span class="n">test</span><span class="p">):</span>
-</span><span id="invalid_format-469"><a href="#invalid_format-469"><span class="linenos">469</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="invalid_format-469"><a href="#invalid_format-469"><span class="linenos">469</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="invalid_format-470"><a href="#invalid_format-470"><span class="linenos">470</span></a><span class="sd">    In this example, there is no description for the test argument</span>
 </span><span id="invalid_format-471"><a href="#invalid_format-471"><span class="linenos">471</span></a>
 </span><span id="invalid_format-472"><a href="#invalid_format-472"><span class="linenos">472</span></a><span class="sd">    Parameters</span>

--- a/test/testdata/flavors_rst.html
+++ b/test/testdata/flavors_rst.html
@@ -93,7 +93,7 @@ flavors_rst    </h1>
 </span><span id="L-2"><a href="#L-2"><span class="linenos">  2</span></a>
 </span><span id="L-3"><a href="#L-3"><span class="linenos">  3</span></a>
 </span><span id="L-4"><a href="#L-4"><span class="linenos">  4</span></a><span class="k">def</span> <span class="nf">links</span><span class="p">():</span>
-</span><span id="L-5"><a href="#L-5"><span class="linenos">  5</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-5"><a href="#L-5"><span class="linenos">  5</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-6"><a href="#L-6"><span class="linenos">  6</span></a><span class="sd">    For type hints, read `PEP 484`_.</span>
 </span><span id="L-7"><a href="#L-7"><span class="linenos">  7</span></a><span class="sd">    See the `Python home page &lt;http://www.python.org&gt;`_ for info.</span>
 </span><span id="L-8"><a href="#L-8"><span class="linenos">  8</span></a>
@@ -104,11 +104,11 @@ flavors_rst    </h1>
 </span><span id="L-13"><a href="#L-13"><span class="linenos"> 13</span></a>
 </span><span id="L-14"><a href="#L-14"><span class="linenos"> 14</span></a>
 </span><span id="L-15"><a href="#L-15"><span class="linenos"> 15</span></a><span class="k">def</span> <span class="nf">refs</span><span class="p">():</span>
-</span><span id="L-16"><a href="#L-16"><span class="linenos"> 16</span></a>    <span class="sd">&quot;&quot;&quot;Here we have refs to :py:obj:`links` and :func:`admonitions`.&quot;&quot;&quot;</span>
+</span><span id="L-16"><a href="#L-16"><span class="linenos"> 16</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Here we have refs to :py:obj:`links` and :func:`admonitions`.&quot;&quot;&quot;</span>
 </span><span id="L-17"><a href="#L-17"><span class="linenos"> 17</span></a>
 </span><span id="L-18"><a href="#L-18"><span class="linenos"> 18</span></a>
 </span><span id="L-19"><a href="#L-19"><span class="linenos"> 19</span></a><span class="k">def</span> <span class="nf">admonitions</span><span class="p">():</span>
-</span><span id="L-20"><a href="#L-20"><span class="linenos"> 20</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-20"><a href="#L-20"><span class="linenos"> 20</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-21"><a href="#L-21"><span class="linenos"> 21</span></a>
 </span><span id="L-22"><a href="#L-22"><span class="linenos"> 22</span></a><span class="sd">    .. note::</span>
 </span><span id="L-23"><a href="#L-23"><span class="linenos"> 23</span></a>
@@ -142,7 +142,7 @@ flavors_rst    </h1>
 </span><span id="L-51"><a href="#L-51"><span class="linenos"> 51</span></a>
 </span><span id="L-52"><a href="#L-52"><span class="linenos"> 52</span></a><span class="k">def</span> <span class="nf">seealso</span><span class="p">():</span>
 </span><span id="L-53"><a href="#L-53"><span class="linenos"> 53</span></a>    <span class="c1"># this is not properly supported yet</span>
-</span><span id="L-54"><a href="#L-54"><span class="linenos"> 54</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-54"><a href="#L-54"><span class="linenos"> 54</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-55"><a href="#L-55"><span class="linenos"> 55</span></a><span class="sd">    .. seealso::</span>
 </span><span id="L-56"><a href="#L-56"><span class="linenos"> 56</span></a>
 </span><span id="L-57"><a href="#L-57"><span class="linenos"> 57</span></a><span class="sd">       Module :py:mod:`zipfile`</span>
@@ -155,13 +155,13 @@ flavors_rst    </h1>
 </span><span id="L-64"><a href="#L-64"><span class="linenos"> 64</span></a>
 </span><span id="L-65"><a href="#L-65"><span class="linenos"> 65</span></a><span class="k">def</span> <span class="nf">seealso_short</span><span class="p">():</span>
 </span><span id="L-66"><a href="#L-66"><span class="linenos"> 66</span></a>    <span class="c1"># this is not properly supported yet</span>
-</span><span id="L-67"><a href="#L-67"><span class="linenos"> 67</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-67"><a href="#L-67"><span class="linenos"> 67</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-68"><a href="#L-68"><span class="linenos"> 68</span></a><span class="sd">    .. seealso:: modules :py:mod:`zipfile`, :py:mod:`tarfile`</span>
 </span><span id="L-69"><a href="#L-69"><span class="linenos"> 69</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-70"><a href="#L-70"><span class="linenos"> 70</span></a>
 </span><span id="L-71"><a href="#L-71"><span class="linenos"> 71</span></a>
 </span><span id="L-72"><a href="#L-72"><span class="linenos"> 72</span></a><span class="k">def</span> <span class="nf">tables</span><span class="p">():</span>
-</span><span id="L-73"><a href="#L-73"><span class="linenos"> 73</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-73"><a href="#L-73"><span class="linenos"> 73</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-74"><a href="#L-74"><span class="linenos"> 74</span></a><span class="sd">    | Header 1 | *Header* 2 |</span>
 </span><span id="L-75"><a href="#L-75"><span class="linenos"> 75</span></a><span class="sd">    | -------- | -------- |</span>
 </span><span id="L-76"><a href="#L-76"><span class="linenos"> 76</span></a><span class="sd">    | `Cell 1` | [Cell 2](http://example.com) link |</span>
@@ -170,7 +170,7 @@ flavors_rst    </h1>
 </span><span id="L-79"><a href="#L-79"><span class="linenos"> 79</span></a>
 </span><span id="L-80"><a href="#L-80"><span class="linenos"> 80</span></a>
 </span><span id="L-81"><a href="#L-81"><span class="linenos"> 81</span></a><span class="k">def</span> <span class="nf">footnote1</span><span class="p">():</span>
-</span><span id="L-82"><a href="#L-82"><span class="linenos"> 82</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-82"><a href="#L-82"><span class="linenos"> 82</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-83"><a href="#L-83"><span class="linenos"> 83</span></a><span class="sd">    Cite the relevant literature, e.g. [1]_.  You may also cite these</span>
 </span><span id="L-84"><a href="#L-84"><span class="linenos"> 84</span></a><span class="sd">    references in the notes section above.</span>
 </span><span id="L-85"><a href="#L-85"><span class="linenos"> 85</span></a>
@@ -183,7 +183,7 @@ flavors_rst    </h1>
 </span><span id="L-92"><a href="#L-92"><span class="linenos"> 92</span></a>
 </span><span id="L-93"><a href="#L-93"><span class="linenos"> 93</span></a>
 </span><span id="L-94"><a href="#L-94"><span class="linenos"> 94</span></a><span class="k">def</span> <span class="nf">footnote2</span><span class="p">():</span>
-</span><span id="L-95"><a href="#L-95"><span class="linenos"> 95</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-95"><a href="#L-95"><span class="linenos"> 95</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-96"><a href="#L-96"><span class="linenos"> 96</span></a><span class="sd">    Autonumbered footnotes are</span>
 </span><span id="L-97"><a href="#L-97"><span class="linenos"> 97</span></a><span class="sd">    possible, like using [#]_ and [#]_.</span>
 </span><span id="L-98"><a href="#L-98"><span class="linenos"> 98</span></a>
@@ -201,7 +201,7 @@ flavors_rst    </h1>
 </span><span id="L-110"><a href="#L-110"><span class="linenos">110</span></a>
 </span><span id="L-111"><a href="#L-111"><span class="linenos">111</span></a>
 </span><span id="L-112"><a href="#L-112"><span class="linenos">112</span></a><span class="k">def</span> <span class="nf">footnote3</span><span class="p">():</span>
-</span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a><span class="sd">    Auto-symbol footnotes are also</span>
 </span><span id="L-115"><a href="#L-115"><span class="linenos">115</span></a><span class="sd">    possible, like this: [*]_ and [*]_.</span>
 </span><span id="L-116"><a href="#L-116"><span class="linenos">116</span></a>
@@ -211,13 +211,13 @@ flavors_rst    </h1>
 </span><span id="L-120"><a href="#L-120"><span class="linenos">120</span></a>
 </span><span id="L-121"><a href="#L-121"><span class="linenos">121</span></a>
 </span><span id="L-122"><a href="#L-122"><span class="linenos">122</span></a><span class="k">def</span> <span class="nf">footnote4</span><span class="p">():</span>
-</span><span id="L-123"><a href="#L-123"><span class="linenos">123</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-123"><a href="#L-123"><span class="linenos">123</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-124"><a href="#L-124"><span class="linenos">124</span></a><span class="sd">    There is no footnote for this reference [#]_.</span>
 </span><span id="L-125"><a href="#L-125"><span class="linenos">125</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-126"><a href="#L-126"><span class="linenos">126</span></a>
 </span><span id="L-127"><a href="#L-127"><span class="linenos">127</span></a>
 </span><span id="L-128"><a href="#L-128"><span class="linenos">128</span></a><span class="k">def</span> <span class="nf">include</span><span class="p">():</span>
-</span><span id="L-129"><a href="#L-129"><span class="linenos">129</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-129"><a href="#L-129"><span class="linenos">129</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-130"><a href="#L-130"><span class="linenos">130</span></a><span class="sd">    Included from another file:</span>
 </span><span id="L-131"><a href="#L-131"><span class="linenos">131</span></a>
 </span><span id="L-132"><a href="#L-132"><span class="linenos">132</span></a><span class="sd">    .. include:: flavors_rst_include/include.rst</span>
@@ -225,7 +225,7 @@ flavors_rst    </h1>
 </span><span id="L-134"><a href="#L-134"><span class="linenos">134</span></a>
 </span><span id="L-135"><a href="#L-135"><span class="linenos">135</span></a>
 </span><span id="L-136"><a href="#L-136"><span class="linenos">136</span></a><span class="k">def</span> <span class="nf">fields</span><span class="p">(</span><span class="n">foo</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;foo&quot;</span><span class="p">,</span> <span class="n">bar</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-137"><a href="#L-137"><span class="linenos">137</span></a>    <span class="sd">&quot;&quot;&quot;This method has field descriptions.</span>
+</span><span id="L-137"><a href="#L-137"><span class="linenos">137</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This method has field descriptions.</span>
 </span><span id="L-138"><a href="#L-138"><span class="linenos">138</span></a>
 </span><span id="L-139"><a href="#L-139"><span class="linenos">139</span></a><span class="sd">    :param foo: A string,</span>
 </span><span id="L-140"><a href="#L-140"><span class="linenos">140</span></a><span class="sd">        defaults to None</span>
@@ -240,7 +240,7 @@ flavors_rst    </h1>
 </span><span id="L-149"><a href="#L-149"><span class="linenos">149</span></a>
 </span><span id="L-150"><a href="#L-150"><span class="linenos">150</span></a>
 </span><span id="L-151"><a href="#L-151"><span class="linenos">151</span></a><span class="k">def</span> <span class="nf">fields_text_after_param</span><span class="p">(</span><span class="n">foo</span><span class="p">):</span>
-</span><span id="L-152"><a href="#L-152"><span class="linenos">152</span></a>    <span class="sd">&quot;&quot;&quot;This method has text after the `:param` fields.</span>
+</span><span id="L-152"><a href="#L-152"><span class="linenos">152</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This method has text after the `:param` fields.</span>
 </span><span id="L-153"><a href="#L-153"><span class="linenos">153</span></a>
 </span><span id="L-154"><a href="#L-154"><span class="linenos">154</span></a><span class="sd">    :param foo: Some text.</span>
 </span><span id="L-155"><a href="#L-155"><span class="linenos">155</span></a>
@@ -249,7 +249,7 @@ flavors_rst    </h1>
 </span><span id="L-158"><a href="#L-158"><span class="linenos">158</span></a>
 </span><span id="L-159"><a href="#L-159"><span class="linenos">159</span></a>
 </span><span id="L-160"><a href="#L-160"><span class="linenos">160</span></a><span class="k">def</span> <span class="nf">fields_invalid</span><span class="p">(</span><span class="n">foo</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;foo&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-161"><a href="#L-161"><span class="linenos">161</span></a>    <span class="sd">&quot;&quot;&quot;This method has invalid `:param` definitions.</span>
+</span><span id="L-161"><a href="#L-161"><span class="linenos">161</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This method has invalid `:param` definitions.</span>
 </span><span id="L-162"><a href="#L-162"><span class="linenos">162</span></a>
 </span><span id="L-163"><a href="#L-163"><span class="linenos">163</span></a><span class="sd">    :param: What is this for?</span>
 </span><span id="L-164"><a href="#L-164"><span class="linenos">164</span></a>
@@ -259,7 +259,7 @@ flavors_rst    </h1>
 </span><span id="L-168"><a href="#L-168"><span class="linenos">168</span></a>
 </span><span id="L-169"><a href="#L-169"><span class="linenos">169</span></a>
 </span><span id="L-170"><a href="#L-170"><span class="linenos">170</span></a><span class="k">def</span> <span class="nf">fields_exception</span><span class="p">():</span>
-</span><span id="L-171"><a href="#L-171"><span class="linenos">171</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-171"><a href="#L-171"><span class="linenos">171</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-172"><a href="#L-172"><span class="linenos">172</span></a><span class="sd">    :raises RuntimeError: Some multi-line</span>
 </span><span id="L-173"><a href="#L-173"><span class="linenos">173</span></a><span class="sd">        exception description.</span>
 </span><span id="L-174"><a href="#L-174"><span class="linenos">174</span></a><span class="sd">    &quot;&quot;&quot;</span>
@@ -279,7 +279,7 @@ flavors_rst    </h1>
     </div>
     <a class="headerlink" href="#links"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="links-5"><a href="#links-5"><span class="linenos"> 5</span></a><span class="k">def</span> <span class="nf">links</span><span class="p">():</span>
-</span><span id="links-6"><a href="#links-6"><span class="linenos"> 6</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="links-6"><a href="#links-6"><span class="linenos"> 6</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="links-7"><a href="#links-7"><span class="linenos"> 7</span></a><span class="sd">    For type hints, read `PEP 484`_.</span>
 </span><span id="links-8"><a href="#links-8"><span class="linenos"> 8</span></a><span class="sd">    See the `Python home page &lt;http://www.python.org&gt;`_ for info.</span>
 </span><span id="links-9"><a href="#links-9"><span class="linenos"> 9</span></a>
@@ -308,7 +308,7 @@ See the <a href="http://www.python.org">Python home page </a> for info.</p>
     </div>
     <a class="headerlink" href="#refs"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="refs-16"><a href="#refs-16"><span class="linenos">16</span></a><span class="k">def</span> <span class="nf">refs</span><span class="p">():</span>
-</span><span id="refs-17"><a href="#refs-17"><span class="linenos">17</span></a>    <span class="sd">&quot;&quot;&quot;Here we have refs to :py:obj:`links` and :func:`admonitions`.&quot;&quot;&quot;</span>
+</span><span id="refs-17"><a href="#refs-17"><span class="linenos">17</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Here we have refs to :py:obj:`links` and :func:`admonitions`.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -329,7 +329,7 @@ See the <a href="http://www.python.org">Python home page </a> for info.</p>
     </div>
     <a class="headerlink" href="#admonitions"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="admonitions-20"><a href="#admonitions-20"><span class="linenos">20</span></a><span class="k">def</span> <span class="nf">admonitions</span><span class="p">():</span>
-</span><span id="admonitions-21"><a href="#admonitions-21"><span class="linenos">21</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="admonitions-21"><a href="#admonitions-21"><span class="linenos">21</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="admonitions-22"><a href="#admonitions-22"><span class="linenos">22</span></a>
 </span><span id="admonitions-23"><a href="#admonitions-23"><span class="linenos">23</span></a><span class="sd">    .. note::</span>
 </span><span id="admonitions-24"><a href="#admonitions-24"><span class="linenos">24</span></a>
@@ -423,7 +423,7 @@ Use <code>spam()</code> instead.</p>
     <a class="headerlink" href="#seealso"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="seealso-53"><a href="#seealso-53"><span class="linenos">53</span></a><span class="k">def</span> <span class="nf">seealso</span><span class="p">():</span>
 </span><span id="seealso-54"><a href="#seealso-54"><span class="linenos">54</span></a>    <span class="c1"># this is not properly supported yet</span>
-</span><span id="seealso-55"><a href="#seealso-55"><span class="linenos">55</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="seealso-55"><a href="#seealso-55"><span class="linenos">55</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="seealso-56"><a href="#seealso-56"><span class="linenos">56</span></a><span class="sd">    .. seealso::</span>
 </span><span id="seealso-57"><a href="#seealso-57"><span class="linenos">57</span></a>
 </span><span id="seealso-58"><a href="#seealso-58"><span class="linenos">58</span></a><span class="sd">       Module :py:mod:`zipfile`</span>
@@ -458,7 +458,7 @@ Module <code>zipfile</code>
     <a class="headerlink" href="#seealso_short"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="seealso_short-66"><a href="#seealso_short-66"><span class="linenos">66</span></a><span class="k">def</span> <span class="nf">seealso_short</span><span class="p">():</span>
 </span><span id="seealso_short-67"><a href="#seealso_short-67"><span class="linenos">67</span></a>    <span class="c1"># this is not properly supported yet</span>
-</span><span id="seealso_short-68"><a href="#seealso_short-68"><span class="linenos">68</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="seealso_short-68"><a href="#seealso_short-68"><span class="linenos">68</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="seealso_short-69"><a href="#seealso_short-69"><span class="linenos">69</span></a><span class="sd">    .. seealso:: modules :py:mod:`zipfile`, :py:mod:`tarfile`</span>
 </span><span id="seealso_short-70"><a href="#seealso_short-70"><span class="linenos">70</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span></pre></div>
@@ -481,7 +481,7 @@ Module <code>zipfile</code>
     </div>
     <a class="headerlink" href="#tables"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="tables-73"><a href="#tables-73"><span class="linenos">73</span></a><span class="k">def</span> <span class="nf">tables</span><span class="p">():</span>
-</span><span id="tables-74"><a href="#tables-74"><span class="linenos">74</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="tables-74"><a href="#tables-74"><span class="linenos">74</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="tables-75"><a href="#tables-75"><span class="linenos">75</span></a><span class="sd">    | Header 1 | *Header* 2 |</span>
 </span><span id="tables-76"><a href="#tables-76"><span class="linenos">76</span></a><span class="sd">    | -------- | -------- |</span>
 </span><span id="tables-77"><a href="#tables-77"><span class="linenos">77</span></a><span class="sd">    | `Cell 1` | [Cell 2](http://example.com) link |</span>
@@ -524,7 +524,7 @@ Module <code>zipfile</code>
     </div>
     <a class="headerlink" href="#footnote1"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="footnote1-82"><a href="#footnote1-82"><span class="linenos">82</span></a><span class="k">def</span> <span class="nf">footnote1</span><span class="p">():</span>
-</span><span id="footnote1-83"><a href="#footnote1-83"><span class="linenos">83</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="footnote1-83"><a href="#footnote1-83"><span class="linenos">83</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="footnote1-84"><a href="#footnote1-84"><span class="linenos">84</span></a><span class="sd">    Cite the relevant literature, e.g. [1]_.  You may also cite these</span>
 </span><span id="footnote1-85"><a href="#footnote1-85"><span class="linenos">85</span></a><span class="sd">    references in the notes section above.</span>
 </span><span id="footnote1-86"><a href="#footnote1-86"><span class="linenos">86</span></a>
@@ -568,7 +568,7 @@ pp. 585-588, 1996.&#160;<a href="#fnref-1" class="footnoteBackLink" title="Jump 
     </div>
     <a class="headerlink" href="#footnote2"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="footnote2-95"><a href="#footnote2-95"><span class="linenos"> 95</span></a><span class="k">def</span> <span class="nf">footnote2</span><span class="p">():</span>
-</span><span id="footnote2-96"><a href="#footnote2-96"><span class="linenos"> 96</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="footnote2-96"><a href="#footnote2-96"><span class="linenos"> 96</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="footnote2-97"><a href="#footnote2-97"><span class="linenos"> 97</span></a><span class="sd">    Autonumbered footnotes are</span>
 </span><span id="footnote2-98"><a href="#footnote2-98"><span class="linenos"> 98</span></a><span class="sd">    possible, like using [#]_ and [#]_.</span>
 </span><span id="footnote2-99"><a href="#footnote2-99"><span class="linenos"> 99</span></a>
@@ -629,7 +629,7 @@ labels' - for instance,
     </div>
     <a class="headerlink" href="#footnote3"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="footnote3-113"><a href="#footnote3-113"><span class="linenos">113</span></a><span class="k">def</span> <span class="nf">footnote3</span><span class="p">():</span>
-</span><span id="footnote3-114"><a href="#footnote3-114"><span class="linenos">114</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="footnote3-114"><a href="#footnote3-114"><span class="linenos">114</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="footnote3-115"><a href="#footnote3-115"><span class="linenos">115</span></a><span class="sd">    Auto-symbol footnotes are also</span>
 </span><span id="footnote3-116"><a href="#footnote3-116"><span class="linenos">116</span></a><span class="sd">    possible, like this: [*]_ and [*]_.</span>
 </span><span id="footnote3-117"><a href="#footnote3-117"><span class="linenos">117</span></a>
@@ -670,7 +670,7 @@ possible, like this: <sup class="footnote-ref" id="fnref-fn-1"><a href="#fn-fn-1
     </div>
     <a class="headerlink" href="#footnote4"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="footnote4-123"><a href="#footnote4-123"><span class="linenos">123</span></a><span class="k">def</span> <span class="nf">footnote4</span><span class="p">():</span>
-</span><span id="footnote4-124"><a href="#footnote4-124"><span class="linenos">124</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="footnote4-124"><a href="#footnote4-124"><span class="linenos">124</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="footnote4-125"><a href="#footnote4-125"><span class="linenos">125</span></a><span class="sd">    There is no footnote for this reference [#]_.</span>
 </span><span id="footnote4-126"><a href="#footnote4-126"><span class="linenos">126</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span></pre></div>
@@ -693,7 +693,7 @@ possible, like this: <sup class="footnote-ref" id="fnref-fn-1"><a href="#fn-fn-1
     </div>
     <a class="headerlink" href="#include"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="include-129"><a href="#include-129"><span class="linenos">129</span></a><span class="k">def</span> <span class="nf">include</span><span class="p">():</span>
-</span><span id="include-130"><a href="#include-130"><span class="linenos">130</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="include-130"><a href="#include-130"><span class="linenos">130</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="include-131"><a href="#include-131"><span class="linenos">131</span></a><span class="sd">    Included from another file:</span>
 </span><span id="include-132"><a href="#include-132"><span class="linenos">132</span></a>
 </span><span id="include-133"><a href="#include-133"><span class="linenos">133</span></a><span class="sd">    .. include:: flavors_rst_include/include.rst</span>
@@ -724,7 +724,7 @@ possible, like this: <sup class="footnote-ref" id="fnref-fn-1"><a href="#fn-fn-1
     </div>
     <a class="headerlink" href="#fields"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="fields-137"><a href="#fields-137"><span class="linenos">137</span></a><span class="k">def</span> <span class="nf">fields</span><span class="p">(</span><span class="n">foo</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;foo&quot;</span><span class="p">,</span> <span class="n">bar</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="fields-138"><a href="#fields-138"><span class="linenos">138</span></a>    <span class="sd">&quot;&quot;&quot;This method has field descriptions.</span>
+</span><span id="fields-138"><a href="#fields-138"><span class="linenos">138</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This method has field descriptions.</span>
 </span><span id="fields-139"><a href="#fields-139"><span class="linenos">139</span></a>
 </span><span id="fields-140"><a href="#fields-140"><span class="linenos">140</span></a><span class="sd">    :param foo: A string,</span>
 </span><span id="fields-141"><a href="#fields-141"><span class="linenos">141</span></a><span class="sd">        defaults to None</span>
@@ -772,7 +772,7 @@ boolean.</li>
     </div>
     <a class="headerlink" href="#fields_text_after_param"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="fields_text_after_param-152"><a href="#fields_text_after_param-152"><span class="linenos">152</span></a><span class="k">def</span> <span class="nf">fields_text_after_param</span><span class="p">(</span><span class="n">foo</span><span class="p">):</span>
-</span><span id="fields_text_after_param-153"><a href="#fields_text_after_param-153"><span class="linenos">153</span></a>    <span class="sd">&quot;&quot;&quot;This method has text after the `:param` fields.</span>
+</span><span id="fields_text_after_param-153"><a href="#fields_text_after_param-153"><span class="linenos">153</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This method has text after the `:param` fields.</span>
 </span><span id="fields_text_after_param-154"><a href="#fields_text_after_param-154"><span class="linenos">154</span></a>
 </span><span id="fields_text_after_param-155"><a href="#fields_text_after_param-155"><span class="linenos">155</span></a><span class="sd">    :param foo: Some text.</span>
 </span><span id="fields_text_after_param-156"><a href="#fields_text_after_param-156"><span class="linenos">156</span></a>
@@ -806,7 +806,7 @@ boolean.</li>
     </div>
     <a class="headerlink" href="#fields_invalid"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="fields_invalid-161"><a href="#fields_invalid-161"><span class="linenos">161</span></a><span class="k">def</span> <span class="nf">fields_invalid</span><span class="p">(</span><span class="n">foo</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;foo&quot;</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="fields_invalid-162"><a href="#fields_invalid-162"><span class="linenos">162</span></a>    <span class="sd">&quot;&quot;&quot;This method has invalid `:param` definitions.</span>
+</span><span id="fields_invalid-162"><a href="#fields_invalid-162"><span class="linenos">162</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This method has invalid `:param` definitions.</span>
 </span><span id="fields_invalid-163"><a href="#fields_invalid-163"><span class="linenos">163</span></a>
 </span><span id="fields_invalid-164"><a href="#fields_invalid-164"><span class="linenos">164</span></a><span class="sd">    :param: What is this for?</span>
 </span><span id="fields_invalid-165"><a href="#fields_invalid-165"><span class="linenos">165</span></a>
@@ -841,7 +841,7 @@ boolean.</li>
     </div>
     <a class="headerlink" href="#fields_exception"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="fields_exception-171"><a href="#fields_exception-171"><span class="linenos">171</span></a><span class="k">def</span> <span class="nf">fields_exception</span><span class="p">():</span>
-</span><span id="fields_exception-172"><a href="#fields_exception-172"><span class="linenos">172</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="fields_exception-172"><a href="#fields_exception-172"><span class="linenos">172</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="fields_exception-173"><a href="#fields_exception-173"><span class="linenos">173</span></a><span class="sd">    :raises RuntimeError: Some multi-line</span>
 </span><span id="fields_exception-174"><a href="#fields_exception-174"><span class="linenos">174</span></a><span class="sd">        exception description.</span>
 </span><span id="fields_exception-175"><a href="#fields_exception-175"><span class="linenos">175</span></a><span class="sd">    &quot;&quot;&quot;</span>

--- a/test/testdata/math_demo.html
+++ b/test/testdata/math_demo.html
@@ -83,7 +83,7 @@ You can either escape a backslash with a second backslash:</p>
 
 <div class="pdoc-code codehilite">
 <pre><span></span><code><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
-    <span class="sd">&quot;&quot;&quot;docstring with $\\frac{x}{y}$.&quot;&quot;&quot;</span>
+<span class="w">    </span><span class="sd">&quot;&quot;&quot;docstring with $\\frac{x}{y}$.&quot;&quot;&quot;</span>
 </code></pre>
 </div>
 
@@ -93,7 +93,7 @@ where backslashes are not processed:</p>
 
 <div class="pdoc-code codehilite">
 <pre><span></span><code><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
-    <span class="sa">r</span><span class="sd">&quot;&quot;&quot;raw docstring with $\frac{x}{y}$.&quot;&quot;&quot;</span>
+<span class="w">    </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;raw docstring with $\frac{x}{y}$.&quot;&quot;&quot;</span>
 </code></pre>
 </div>
 
@@ -148,7 +148,7 @@ You can create a <code>math.html.jinja2</code> file in your pdoc template direct
 </span><span id="L-35"><a href="#L-35"><span class="linenos">35</span></a>
 </span><span id="L-36"><a href="#L-36"><span class="linenos">36</span></a>
 </span><span id="L-37"><a href="#L-37"><span class="linenos">37</span></a><span class="k">def</span> <span class="nf">binom_coef</span><span class="p">(</span><span class="n">n</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">k</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="L-38"><a href="#L-38"><span class="linenos">38</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-38"><a href="#L-38"><span class="linenos">38</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-39"><a href="#L-39"><span class="linenos">39</span></a><span class="sd">    Return the number of ways to choose $k$ items from $n$ items without repetition and without order.</span>
 </span><span id="L-40"><a href="#L-40"><span class="linenos">40</span></a>
 </span><span id="L-41"><a href="#L-41"><span class="linenos">41</span></a><span class="sd">    Evaluates to $n! / (k! * (n - k)!)$ when $k &lt;= n$ and evaluates to zero when $k &gt; n$.</span>
@@ -157,7 +157,7 @@ You can create a <code>math.html.jinja2</code> file in your pdoc template direct
 </span><span id="L-44"><a href="#L-44"><span class="linenos">44</span></a>
 </span><span id="L-45"><a href="#L-45"><span class="linenos">45</span></a>
 </span><span id="L-46"><a href="#L-46"><span class="linenos">46</span></a><span class="k">def</span> <span class="nf">long_formula</span><span class="p">():</span>
-</span><span id="L-47"><a href="#L-47"><span class="linenos">47</span></a>    <span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-47"><a href="#L-47"><span class="linenos">47</span></a><span class="w">    </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-48"><a href="#L-48"><span class="linenos">48</span></a><span class="sd">    $$</span>
 </span><span id="L-49"><a href="#L-49"><span class="linenos">49</span></a><span class="sd">        \Delta =</span>
 </span><span id="L-50"><a href="#L-50"><span class="linenos">50</span></a><span class="sd">        \Delta_\text{this} +</span>
@@ -192,7 +192,7 @@ You can create a <code>math.html.jinja2</code> file in your pdoc template direct
     </div>
     <a class="headerlink" href="#binom_coef"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="binom_coef-38"><a href="#binom_coef-38"><span class="linenos">38</span></a><span class="k">def</span> <span class="nf">binom_coef</span><span class="p">(</span><span class="n">n</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">k</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="binom_coef-39"><a href="#binom_coef-39"><span class="linenos">39</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="binom_coef-39"><a href="#binom_coef-39"><span class="linenos">39</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="binom_coef-40"><a href="#binom_coef-40"><span class="linenos">40</span></a><span class="sd">    Return the number of ways to choose $k$ items from $n$ items without repetition and without order.</span>
 </span><span id="binom_coef-41"><a href="#binom_coef-41"><span class="linenos">41</span></a>
 </span><span id="binom_coef-42"><a href="#binom_coef-42"><span class="linenos">42</span></a><span class="sd">    Evaluates to $n! / (k! * (n - k)!)$ when $k &lt;= n$ and evaluates to zero when $k &gt; n$.</span>
@@ -220,7 +220,7 @@ You can create a <code>math.html.jinja2</code> file in your pdoc template direct
     </div>
     <a class="headerlink" href="#long_formula"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="long_formula-47"><a href="#long_formula-47"><span class="linenos">47</span></a><span class="k">def</span> <span class="nf">long_formula</span><span class="p">():</span>
-</span><span id="long_formula-48"><a href="#long_formula-48"><span class="linenos">48</span></a>    <span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
+</span><span id="long_formula-48"><a href="#long_formula-48"><span class="linenos">48</span></a><span class="w">    </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="long_formula-49"><a href="#long_formula-49"><span class="linenos">49</span></a><span class="sd">    $$</span>
 </span><span id="long_formula-50"><a href="#long_formula-50"><span class="linenos">50</span></a><span class="sd">        \Delta =</span>
 </span><span id="long_formula-51"><a href="#long_formula-51"><span class="linenos">51</span></a><span class="sd">        \Delta_\text{this} +</span>

--- a/test/testdata/misc.html
+++ b/test/testdata/misc.html
@@ -340,7 +340,7 @@ misc    </h1>
 </span><span id="L-24"><a href="#L-24"><span class="linenos"> 24</span></a><span class="k">class</span> <span class="nc">Issue226</span><span class="p">:</span>
 </span><span id="L-25"><a href="#L-25"><span class="linenos"> 25</span></a>    <span class="nd">@Descriptor</span>
 </span><span id="L-26"><a href="#L-26"><span class="linenos"> 26</span></a>    <span class="k">def</span> <span class="nf">size</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-27"><a href="#L-27"><span class="linenos"> 27</span></a>        <span class="sd">&quot;&quot;&quot;This is the size&quot;&quot;&quot;</span>
+</span><span id="L-27"><a href="#L-27"><span class="linenos"> 27</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is the size&quot;&quot;&quot;</span>
 </span><span id="L-28"><a href="#L-28"><span class="linenos"> 28</span></a>
 </span><span id="L-29"><a href="#L-29"><span class="linenos"> 29</span></a>
 </span><span id="L-30"><a href="#L-30"><span class="linenos"> 30</span></a><span class="c1"># Testing function and object default values</span>
@@ -359,13 +359,13 @@ misc    </h1>
 </span><span id="L-43"><a href="#L-43"><span class="linenos"> 43</span></a>
 </span><span id="L-44"><a href="#L-44"><span class="linenos"> 44</span></a>
 </span><span id="L-45"><a href="#L-45"><span class="linenos"> 45</span></a><span class="k">def</span> <span class="nf">func_with_defaults</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="n">default_obj</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="n">default_func</span><span class="p">):</span>
-</span><span id="L-46"><a href="#L-46"><span class="linenos"> 46</span></a>    <span class="sd">&quot;&quot;&quot;this shouldn&#39;t render object or function addresses&quot;&quot;&quot;</span>
+</span><span id="L-46"><a href="#L-46"><span class="linenos"> 46</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;this shouldn&#39;t render object or function addresses&quot;&quot;&quot;</span>
 </span><span id="L-47"><a href="#L-47"><span class="linenos"> 47</span></a>    <span class="k">pass</span>
 </span><span id="L-48"><a href="#L-48"><span class="linenos"> 48</span></a>
 </span><span id="L-49"><a href="#L-49"><span class="linenos"> 49</span></a>
 </span><span id="L-50"><a href="#L-50"><span class="linenos"> 50</span></a><span class="c1"># Testing classmethod links in code</span>
 </span><span id="L-51"><a href="#L-51"><span class="linenos"> 51</span></a><span class="k">class</span> <span class="nc">ClassmethodLink</span><span class="p">:</span>
-</span><span id="L-52"><a href="#L-52"><span class="linenos"> 52</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-52"><a href="#L-52"><span class="linenos"> 52</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-53"><a href="#L-53"><span class="linenos"> 53</span></a><span class="sd">    You can either do</span>
 </span><span id="L-54"><a href="#L-54"><span class="linenos"> 54</span></a>
 </span><span id="L-55"><a href="#L-55"><span class="linenos"> 55</span></a><span class="sd">    &gt;&gt;&gt; ClassmethodLink.bar()</span>
@@ -403,35 +403,35 @@ misc    </h1>
 </span><span id="L-87"><a href="#L-87"><span class="linenos"> 87</span></a>
 </span><span id="L-88"><a href="#L-88"><span class="linenos"> 88</span></a><span class="k">class</span> <span class="nc">Base</span><span class="p">:</span>
 </span><span id="L-89"><a href="#L-89"><span class="linenos"> 89</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-90"><a href="#L-90"><span class="linenos"> 90</span></a>        <span class="sd">&quot;&quot;&quot;init&quot;&quot;&quot;</span>
+</span><span id="L-90"><a href="#L-90"><span class="linenos"> 90</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;init&quot;&quot;&quot;</span>
 </span><span id="L-91"><a href="#L-91"><span class="linenos"> 91</span></a>        <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__init__</span><span class="p">()</span>
 </span><span id="L-92"><a href="#L-92"><span class="linenos"> 92</span></a>
 </span><span id="L-93"><a href="#L-93"><span class="linenos"> 93</span></a>    <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-94"><a href="#L-94"><span class="linenos"> 94</span></a>        <span class="sd">&quot;&quot;&quot;foo&quot;&quot;&quot;</span>
+</span><span id="L-94"><a href="#L-94"><span class="linenos"> 94</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;foo&quot;&quot;&quot;</span>
 </span><span id="L-95"><a href="#L-95"><span class="linenos"> 95</span></a>        <span class="k">pass</span>
 </span><span id="L-96"><a href="#L-96"><span class="linenos"> 96</span></a>
 </span><span id="L-97"><a href="#L-97"><span class="linenos"> 97</span></a>    <span class="nd">@classmethod</span>
 </span><span id="L-98"><a href="#L-98"><span class="linenos"> 98</span></a>    <span class="k">def</span> <span class="nf">bar</span><span class="p">(</span><span class="bp">cls</span><span class="p">):</span>
-</span><span id="L-99"><a href="#L-99"><span class="linenos"> 99</span></a>        <span class="sd">&quot;&quot;&quot;bar&quot;&quot;&quot;</span>
+</span><span id="L-99"><a href="#L-99"><span class="linenos"> 99</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;bar&quot;&quot;&quot;</span>
 </span><span id="L-100"><a href="#L-100"><span class="linenos">100</span></a>        <span class="k">pass</span>
 </span><span id="L-101"><a href="#L-101"><span class="linenos">101</span></a>
 </span><span id="L-102"><a href="#L-102"><span class="linenos">102</span></a>    <span class="nd">@staticmethod</span>
 </span><span id="L-103"><a href="#L-103"><span class="linenos">103</span></a>    <span class="k">def</span> <span class="nf">baz</span><span class="p">():</span>
-</span><span id="L-104"><a href="#L-104"><span class="linenos">104</span></a>        <span class="sd">&quot;&quot;&quot;baz&quot;&quot;&quot;</span>
+</span><span id="L-104"><a href="#L-104"><span class="linenos">104</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;baz&quot;&quot;&quot;</span>
 </span><span id="L-105"><a href="#L-105"><span class="linenos">105</span></a>        <span class="k">pass</span>
 </span><span id="L-106"><a href="#L-106"><span class="linenos">106</span></a>
 </span><span id="L-107"><a href="#L-107"><span class="linenos">107</span></a>    <span class="nd">@property</span>
 </span><span id="L-108"><a href="#L-108"><span class="linenos">108</span></a>    <span class="k">def</span> <span class="nf">qux</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-109"><a href="#L-109"><span class="linenos">109</span></a>        <span class="sd">&quot;&quot;&quot;qux&quot;&quot;&quot;</span>
+</span><span id="L-109"><a href="#L-109"><span class="linenos">109</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;qux&quot;&quot;&quot;</span>
 </span><span id="L-110"><a href="#L-110"><span class="linenos">110</span></a>        <span class="k">return</span>
 </span><span id="L-111"><a href="#L-111"><span class="linenos">111</span></a>
 </span><span id="L-112"><a href="#L-112"><span class="linenos">112</span></a>    <span class="nd">@cached_property</span>
 </span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a>    <span class="k">def</span> <span class="nf">quux</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a>        <span class="sd">&quot;&quot;&quot;quux&quot;&quot;&quot;</span>
+</span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;quux&quot;&quot;&quot;</span>
 </span><span id="L-115"><a href="#L-115"><span class="linenos">115</span></a>        <span class="k">return</span>
 </span><span id="L-116"><a href="#L-116"><span class="linenos">116</span></a>
 </span><span id="L-117"><a href="#L-117"><span class="linenos">117</span></a>    <span class="n">quuux</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">42</span>
-</span><span id="L-118"><a href="#L-118"><span class="linenos">118</span></a>    <span class="sd">&quot;&quot;&quot;quuux&quot;&quot;&quot;</span>
+</span><span id="L-118"><a href="#L-118"><span class="linenos">118</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;quuux&quot;&quot;&quot;</span>
 </span><span id="L-119"><a href="#L-119"><span class="linenos">119</span></a>
 </span><span id="L-120"><a href="#L-120"><span class="linenos">120</span></a>
 </span><span id="L-121"><a href="#L-121"><span class="linenos">121</span></a><span class="k">class</span> <span class="nc">Child</span><span class="p">(</span><span class="n">Base</span><span class="p">):</span>
@@ -469,12 +469,12 @@ misc    </h1>
 </span><span id="L-153"><a href="#L-153"><span class="linenos">153</span></a>
 </span><span id="L-154"><a href="#L-154"><span class="linenos">154</span></a>
 </span><span id="L-155"><a href="#L-155"><span class="linenos">155</span></a><span class="k">class</span> <span class="nc">_Private</span><span class="p">:</span>
-</span><span id="L-156"><a href="#L-156"><span class="linenos">156</span></a>    <span class="sd">&quot;&quot;&quot;private class&quot;&quot;&quot;</span>
+</span><span id="L-156"><a href="#L-156"><span class="linenos">156</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;private class&quot;&quot;&quot;</span>
 </span><span id="L-157"><a href="#L-157"><span class="linenos">157</span></a>
 </span><span id="L-158"><a href="#L-158"><span class="linenos">158</span></a>    <span class="k">pass</span>
 </span><span id="L-159"><a href="#L-159"><span class="linenos">159</span></a>
 </span><span id="L-160"><a href="#L-160"><span class="linenos">160</span></a>    <span class="k">def</span> <span class="nf">_do</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-161"><a href="#L-161"><span class="linenos">161</span></a>        <span class="sd">&quot;&quot;&quot;private method&quot;&quot;&quot;</span>
+</span><span id="L-161"><a href="#L-161"><span class="linenos">161</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;private method&quot;&quot;&quot;</span>
 </span><span id="L-162"><a href="#L-162"><span class="linenos">162</span></a>
 </span><span id="L-163"><a href="#L-163"><span class="linenos">163</span></a>
 </span><span id="L-164"><a href="#L-164"><span class="linenos">164</span></a><span class="c1"># Testing a class attribute that is a lambda (which generates quirky sources)</span>
@@ -490,21 +490,21 @@ misc    </h1>
 </span><span id="L-174"><a href="#L-174"><span class="linenos">174</span></a>
 </span><span id="L-175"><a href="#L-175"><span class="linenos">175</span></a>
 </span><span id="L-176"><a href="#L-176"><span class="linenos">176</span></a><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
-</span><span id="L-177"><a href="#L-177"><span class="linenos">177</span></a>    <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="L-177"><a href="#L-177"><span class="linenos">177</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span><span id="L-178"><a href="#L-178"><span class="linenos">178</span></a>
 </span><span id="L-179"><a href="#L-179"><span class="linenos">179</span></a>
 </span><span id="L-180"><a href="#L-180"><span class="linenos">180</span></a><span class="k">def</span> <span class="nf">bar</span><span class="p">():</span>
-</span><span id="L-181"><a href="#L-181"><span class="linenos">181</span></a>    <span class="sd">&quot;&quot;&quot;no</span>
+</span><span id="L-181"><a href="#L-181"><span class="linenos">181</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;no</span>
 </span><span id="L-182"><a href="#L-182"><span class="linenos">182</span></a><span class="sd">indents&quot;&quot;&quot;</span>
 </span><span id="L-183"><a href="#L-183"><span class="linenos">183</span></a>
 </span><span id="L-184"><a href="#L-184"><span class="linenos">184</span></a>
 </span><span id="L-185"><a href="#L-185"><span class="linenos">185</span></a><span class="k">def</span> <span class="nf">baz</span><span class="p">():</span>
-</span><span id="L-186"><a href="#L-186"><span class="linenos">186</span></a>    <span class="sd">&quot;&quot;&quot;one</span>
+</span><span id="L-186"><a href="#L-186"><span class="linenos">186</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;one</span>
 </span><span id="L-187"><a href="#L-187"><span class="linenos">187</span></a><span class="sd">    indent&quot;&quot;&quot;</span>
 </span><span id="L-188"><a href="#L-188"><span class="linenos">188</span></a>
 </span><span id="L-189"><a href="#L-189"><span class="linenos">189</span></a>
 </span><span id="L-190"><a href="#L-190"><span class="linenos">190</span></a><span class="k">def</span> <span class="nf">qux</span><span class="p">():</span>
-</span><span id="L-191"><a href="#L-191"><span class="linenos">191</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-191"><a href="#L-191"><span class="linenos">191</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-192"><a href="#L-192"><span class="linenos">192</span></a><span class="sd">    two</span>
 </span><span id="L-193"><a href="#L-193"><span class="linenos">193</span></a><span class="sd">    indents</span>
 </span><span id="L-194"><a href="#L-194"><span class="linenos">194</span></a><span class="sd">    &quot;&quot;&quot;</span>
@@ -512,44 +512,44 @@ misc    </h1>
 </span><span id="L-196"><a href="#L-196"><span class="linenos">196</span></a>
 </span><span id="L-197"><a href="#L-197"><span class="linenos">197</span></a><span class="k">class</span> <span class="nc">Indented</span><span class="p">:</span>
 </span><span id="L-198"><a href="#L-198"><span class="linenos">198</span></a>    <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-199"><a href="#L-199"><span class="linenos">199</span></a>        <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="L-199"><a href="#L-199"><span class="linenos">199</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span><span id="L-200"><a href="#L-200"><span class="linenos">200</span></a>
 </span><span id="L-201"><a href="#L-201"><span class="linenos">201</span></a>    <span class="k">def</span> <span class="nf">bar</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-202"><a href="#L-202"><span class="linenos">202</span></a>        <span class="sd">&quot;&quot;&quot;no</span>
+</span><span id="L-202"><a href="#L-202"><span class="linenos">202</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no</span>
 </span><span id="L-203"><a href="#L-203"><span class="linenos">203</span></a><span class="sd">indents&quot;&quot;&quot;</span>
 </span><span id="L-204"><a href="#L-204"><span class="linenos">204</span></a>
 </span><span id="L-205"><a href="#L-205"><span class="linenos">205</span></a>    <span class="k">def</span> <span class="nf">baz</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-206"><a href="#L-206"><span class="linenos">206</span></a>        <span class="sd">&quot;&quot;&quot;one</span>
+</span><span id="L-206"><a href="#L-206"><span class="linenos">206</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;one</span>
 </span><span id="L-207"><a href="#L-207"><span class="linenos">207</span></a><span class="sd">        indent&quot;&quot;&quot;</span>
 </span><span id="L-208"><a href="#L-208"><span class="linenos">208</span></a>
 </span><span id="L-209"><a href="#L-209"><span class="linenos">209</span></a>    <span class="k">def</span> <span class="nf">qux</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-210"><a href="#L-210"><span class="linenos">210</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-210"><a href="#L-210"><span class="linenos">210</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-211"><a href="#L-211"><span class="linenos">211</span></a><span class="sd">        two</span>
 </span><span id="L-212"><a href="#L-212"><span class="linenos">212</span></a><span class="sd">        indents</span>
 </span><span id="L-213"><a href="#L-213"><span class="linenos">213</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="L-214"><a href="#L-214"><span class="linenos">214</span></a>
 </span><span id="L-215"><a href="#L-215"><span class="linenos">215</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="L-216"><a href="#L-216"><span class="linenos">216</span></a>    <span class="k">def</span> <span class="nf">foo_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-217"><a href="#L-217"><span class="linenos">217</span></a>        <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="L-217"><a href="#L-217"><span class="linenos">217</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span><span id="L-218"><a href="#L-218"><span class="linenos">218</span></a>
 </span><span id="L-219"><a href="#L-219"><span class="linenos">219</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="L-220"><a href="#L-220"><span class="linenos">220</span></a>    <span class="c1"># comment</span>
 </span><span id="L-221"><a href="#L-221"><span class="linenos">221</span></a>    <span class="k">def</span> <span class="nf">foo_commented</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-222"><a href="#L-222"><span class="linenos">222</span></a>        <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="L-222"><a href="#L-222"><span class="linenos">222</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span><span id="L-223"><a href="#L-223"><span class="linenos">223</span></a>
 </span><span id="L-224"><a href="#L-224"><span class="linenos">224</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="L-225"><a href="#L-225"><span class="linenos">225</span></a>    <span class="k">def</span> <span class="nf">bar_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-226"><a href="#L-226"><span class="linenos">226</span></a>        <span class="sd">&quot;&quot;&quot;no</span>
+</span><span id="L-226"><a href="#L-226"><span class="linenos">226</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no</span>
 </span><span id="L-227"><a href="#L-227"><span class="linenos">227</span></a><span class="sd">indents&quot;&quot;&quot;</span>
 </span><span id="L-228"><a href="#L-228"><span class="linenos">228</span></a>
 </span><span id="L-229"><a href="#L-229"><span class="linenos">229</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="L-230"><a href="#L-230"><span class="linenos">230</span></a>    <span class="k">def</span> <span class="nf">baz_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-231"><a href="#L-231"><span class="linenos">231</span></a>        <span class="sd">&quot;&quot;&quot;one</span>
+</span><span id="L-231"><a href="#L-231"><span class="linenos">231</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;one</span>
 </span><span id="L-232"><a href="#L-232"><span class="linenos">232</span></a><span class="sd">        indent&quot;&quot;&quot;</span>
 </span><span id="L-233"><a href="#L-233"><span class="linenos">233</span></a>
 </span><span id="L-234"><a href="#L-234"><span class="linenos">234</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="L-235"><a href="#L-235"><span class="linenos">235</span></a>    <span class="k">def</span> <span class="nf">qux_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-236"><a href="#L-236"><span class="linenos">236</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-236"><a href="#L-236"><span class="linenos">236</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-237"><a href="#L-237"><span class="linenos">237</span></a><span class="sd">        two</span>
 </span><span id="L-238"><a href="#L-238"><span class="linenos">238</span></a><span class="sd">        indents</span>
 </span><span id="L-239"><a href="#L-239"><span class="linenos">239</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -558,7 +558,7 @@ misc    </h1>
 </span><span id="L-242"><a href="#L-242"><span class="linenos">242</span></a>        <span class="n">maxsize</span><span class="o">=</span><span class="mi">42</span>
 </span><span id="L-243"><a href="#L-243"><span class="linenos">243</span></a>    <span class="p">)</span>
 </span><span id="L-244"><a href="#L-244"><span class="linenos">244</span></a>    <span class="k">def</span> <span class="nf">quux_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a>        <span class="sd">&quot;&quot;&quot;multi-line decorator, https://github.com/mitmproxy/pdoc/issues/246&quot;&quot;&quot;</span>
+</span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;multi-line decorator, https://github.com/mitmproxy/pdoc/issues/246&quot;&quot;&quot;</span>
 </span><span id="L-246"><a href="#L-246"><span class="linenos">246</span></a>
 </span><span id="L-247"><a href="#L-247"><span class="linenos">247</span></a>
 </span><span id="L-248"><a href="#L-248"><span class="linenos">248</span></a><span class="k">def</span> <span class="nf">_protected_decorator</span><span class="p">(</span><span class="n">f</span><span class="p">):</span>
@@ -567,7 +567,7 @@ misc    </h1>
 </span><span id="L-251"><a href="#L-251"><span class="linenos">251</span></a>
 </span><span id="L-252"><a href="#L-252"><span class="linenos">252</span></a><span class="nd">@_protected_decorator</span>
 </span><span id="L-253"><a href="#L-253"><span class="linenos">253</span></a><span class="k">def</span> <span class="nf">fun_with_protected_decorator</span><span class="p">():</span>
-</span><span id="L-254"><a href="#L-254"><span class="linenos">254</span></a>    <span class="sd">&quot;&quot;&quot;This function has a protected decorator (name starting with a single `_`).&quot;&quot;&quot;</span>
+</span><span id="L-254"><a href="#L-254"><span class="linenos">254</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This function has a protected decorator (name starting with a single `_`).&quot;&quot;&quot;</span>
 </span><span id="L-255"><a href="#L-255"><span class="linenos">255</span></a>
 </span><span id="L-256"><a href="#L-256"><span class="linenos">256</span></a>
 </span><span id="L-257"><a href="#L-257"><span class="linenos">257</span></a><span class="k">class</span> <span class="nc">UnhashableDataDescriptor</span><span class="p">:</span>
@@ -580,7 +580,7 @@ misc    </h1>
 </span><span id="L-264"><a href="#L-264"><span class="linenos">264</span></a>
 </span><span id="L-265"><a href="#L-265"><span class="linenos">265</span></a>
 </span><span id="L-266"><a href="#L-266"><span class="linenos">266</span></a><span class="k">class</span> <span class="nc">AbstractClass</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">abc</span><span class="o">.</span><span class="n">ABCMeta</span><span class="p">):</span>
-</span><span id="L-267"><a href="#L-267"><span class="linenos">267</span></a>    <span class="sd">&quot;&quot;&quot;This class shouldn&#39;t show a constructor as it&#39;s abstract.&quot;&quot;&quot;</span>
+</span><span id="L-267"><a href="#L-267"><span class="linenos">267</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This class shouldn&#39;t show a constructor as it&#39;s abstract.&quot;&quot;&quot;</span>
 </span><span id="L-268"><a href="#L-268"><span class="linenos">268</span></a>    <span class="nd">@abc</span><span class="o">.</span><span class="n">abstractmethod</span>
 </span><span id="L-269"><a href="#L-269"><span class="linenos">269</span></a>    <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
 </span><span id="L-270"><a href="#L-270"><span class="linenos">270</span></a>        <span class="k">pass</span>
@@ -590,7 +590,7 @@ misc    </h1>
 </span><span id="L-274"><a href="#L-274"><span class="linenos">274</span></a>
 </span><span id="L-275"><a href="#L-275"><span class="linenos">275</span></a><span class="k">def</span> <span class="nf">make_adder</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
 </span><span id="L-276"><a href="#L-276"><span class="linenos">276</span></a>    <span class="k">def</span> <span class="nf">add_func</span><span class="p">(</span><span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="L-277"><a href="#L-277"><span class="linenos">277</span></a>        <span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
+</span><span id="L-277"><a href="#L-277"><span class="linenos">277</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
 </span><span id="L-278"><a href="#L-278"><span class="linenos">278</span></a>        <span class="k">return</span> <span class="n">a</span> <span class="o">+</span> <span class="n">b</span>
 </span><span id="L-279"><a href="#L-279"><span class="linenos">279</span></a>    <span class="k">return</span> <span class="n">add_func</span>
 </span><span id="L-280"><a href="#L-280"><span class="linenos">280</span></a>
@@ -604,7 +604,7 @@ misc    </h1>
 </span><span id="L-288"><a href="#L-288"><span class="linenos">288</span></a>
 </span><span id="L-289"><a href="#L-289"><span class="linenos">289</span></a><span class="c1"># Adapted from https://github.com/mitmproxy/pdoc/issues/335</span>
 </span><span id="L-290"><a href="#L-290"><span class="linenos">290</span></a><span class="k">def</span> <span class="nf">linkify_links</span><span class="p">():</span>
-</span><span id="L-291"><a href="#L-291"><span class="linenos">291</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-291"><a href="#L-291"><span class="linenos">291</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-292"><a href="#L-292"><span class="linenos">292</span></a><span class="sd">    This docstring contains links that are also identifiers:</span>
 </span><span id="L-293"><a href="#L-293"><span class="linenos">293</span></a>
 </span><span id="L-294"><a href="#L-294"><span class="linenos">294</span></a><span class="sd">    - [`linkify_links`](https://example.com/)</span>
@@ -618,12 +618,12 @@ misc    </h1>
 </span><span id="L-302"><a href="#L-302"><span class="linenos">302</span></a>
 </span><span id="L-303"><a href="#L-303"><span class="linenos">303</span></a><span class="k">class</span> <span class="nc">Issue352aMeta</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
 </span><span id="L-304"><a href="#L-304"><span class="linenos">304</span></a>    <span class="k">def</span> <span class="fm">__call__</span><span class="p">(</span><span class="bp">cls</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-</span><span id="L-305"><a href="#L-305"><span class="linenos">305</span></a>        <span class="sd">&quot;&quot;&quot;Meta.__call__&quot;&quot;&quot;</span>
+</span><span id="L-305"><a href="#L-305"><span class="linenos">305</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Meta.__call__&quot;&quot;&quot;</span>
 </span><span id="L-306"><a href="#L-306"><span class="linenos">306</span></a>
 </span><span id="L-307"><a href="#L-307"><span class="linenos">307</span></a>
 </span><span id="L-308"><a href="#L-308"><span class="linenos">308</span></a><span class="k">class</span> <span class="nc">Issue352a</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">Issue352aMeta</span><span class="p">):</span>
 </span><span id="L-309"><a href="#L-309"><span class="linenos">309</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="L-310"><a href="#L-310"><span class="linenos">310</span></a>        <span class="sd">&quot;&quot;&quot;Issue352.__init__ should be preferred over Meta.__call__.&quot;&quot;&quot;</span>
+</span><span id="L-310"><a href="#L-310"><span class="linenos">310</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Issue352.__init__ should be preferred over Meta.__call__.&quot;&quot;&quot;</span>
 </span><span id="L-311"><a href="#L-311"><span class="linenos">311</span></a>
 </span><span id="L-312"><a href="#L-312"><span class="linenos">312</span></a>
 </span><span id="L-313"><a href="#L-313"><span class="linenos">313</span></a><span class="k">class</span> <span class="nc">Issue352bMeta</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
@@ -632,20 +632,20 @@ misc    </h1>
 </span><span id="L-316"><a href="#L-316"><span class="linenos">316</span></a>
 </span><span id="L-317"><a href="#L-317"><span class="linenos">317</span></a>
 </span><span id="L-318"><a href="#L-318"><span class="linenos">318</span></a><span class="k">class</span> <span class="nc">Issue352b</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">Issue352bMeta</span><span class="p">):</span>
-</span><span id="L-319"><a href="#L-319"><span class="linenos">319</span></a>    <span class="sd">&quot;&quot;&quot;No docstrings for the constructor here.&quot;&quot;&quot;</span>
+</span><span id="L-319"><a href="#L-319"><span class="linenos">319</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;No docstrings for the constructor here.&quot;&quot;&quot;</span>
 </span><span id="L-320"><a href="#L-320"><span class="linenos">320</span></a>
 </span><span id="L-321"><a href="#L-321"><span class="linenos">321</span></a>
 </span><span id="L-322"><a href="#L-322"><span class="linenos">322</span></a><span class="k">class</span> <span class="nc">CustomCallMeta</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
 </span><span id="L-323"><a href="#L-323"><span class="linenos">323</span></a>    <span class="k">def</span> <span class="fm">__call__</span><span class="p">(</span><span class="bp">cls</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-</span><span id="L-324"><a href="#L-324"><span class="linenos">324</span></a>        <span class="sd">&quot;&quot;&quot;Custom docstring in metaclass.`__call__`&quot;&quot;&quot;</span>
+</span><span id="L-324"><a href="#L-324"><span class="linenos">324</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Custom docstring in metaclass.`__call__`&quot;&quot;&quot;</span>
 </span><span id="L-325"><a href="#L-325"><span class="linenos">325</span></a>
 </span><span id="L-326"><a href="#L-326"><span class="linenos">326</span></a>
 </span><span id="L-327"><a href="#L-327"><span class="linenos">327</span></a><span class="k">class</span> <span class="nc">CustomCall</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">CustomCallMeta</span><span class="p">):</span>
-</span><span id="L-328"><a href="#L-328"><span class="linenos">328</span></a>    <span class="sd">&quot;&quot;&quot;A class where the constructor is defined by its metaclass.&quot;&quot;&quot;</span>
+</span><span id="L-328"><a href="#L-328"><span class="linenos">328</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A class where the constructor is defined by its metaclass.&quot;&quot;&quot;</span>
 </span><span id="L-329"><a href="#L-329"><span class="linenos">329</span></a>
 </span><span id="L-330"><a href="#L-330"><span class="linenos">330</span></a>
 </span><span id="L-331"><a href="#L-331"><span class="linenos">331</span></a><span class="k">class</span> <span class="nc">Headings</span><span class="p">:</span>
-</span><span id="L-332"><a href="#L-332"><span class="linenos">332</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-332"><a href="#L-332"><span class="linenos">332</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-333"><a href="#L-333"><span class="linenos">333</span></a><span class="sd">    # Heading 1</span>
 </span><span id="L-334"><a href="#L-334"><span class="linenos">334</span></a>
 </span><span id="L-335"><a href="#L-335"><span class="linenos">335</span></a><span class="sd">    Here is some text.</span>
@@ -679,18 +679,18 @@ misc    </h1>
 </span><span id="L-363"><a href="#L-363"><span class="linenos">363</span></a>
 </span><span id="L-364"><a href="#L-364"><span class="linenos">364</span></a>
 </span><span id="L-365"><a href="#L-365"><span class="linenos">365</span></a><span class="k">def</span> <span class="nf">repr_not_syntax_highlightable</span><span class="p">(</span><span class="n">x</span><span class="o">=</span><span class="n">CustomRepr</span><span class="p">()):</span>
-</span><span id="L-366"><a href="#L-366"><span class="linenos">366</span></a>    <span class="sd">&quot;&quot;&quot;The default value for x fails to highlight with pygments.&quot;&quot;&quot;</span>
+</span><span id="L-366"><a href="#L-366"><span class="linenos">366</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The default value for x fails to highlight with pygments.&quot;&quot;&quot;</span>
 </span><span id="L-367"><a href="#L-367"><span class="linenos">367</span></a>
 </span><span id="L-368"><a href="#L-368"><span class="linenos">368</span></a>
 </span><span id="L-369"><a href="#L-369"><span class="linenos">369</span></a><span class="k">class</span> <span class="nc">ClassDecorator</span><span class="p">:</span>
-</span><span id="L-370"><a href="#L-370"><span class="linenos">370</span></a>    <span class="sd">&quot;&quot;&quot;This is a class that wraps a function. It will be documented correctly.&quot;&quot;&quot;</span>
+</span><span id="L-370"><a href="#L-370"><span class="linenos">370</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This is a class that wraps a function. It will be documented correctly.&quot;&quot;&quot;</span>
 </span><span id="L-371"><a href="#L-371"><span class="linenos">371</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">f</span><span class="p">):</span>
 </span><span id="L-372"><a href="#L-372"><span class="linenos">372</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">f</span> <span class="o">=</span> <span class="n">f</span>
 </span><span id="L-373"><a href="#L-373"><span class="linenos">373</span></a>
 </span><span id="L-374"><a href="#L-374"><span class="linenos">374</span></a>
 </span><span id="L-375"><a href="#L-375"><span class="linenos">375</span></a><span class="nd">@ClassDecorator</span>
 </span><span id="L-376"><a href="#L-376"><span class="linenos">376</span></a><span class="k">def</span> <span class="nf">another_decorated_function</span><span class="p">(</span><span class="n">arg</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-377"><a href="#L-377"><span class="linenos">377</span></a>    <span class="sd">&quot;&quot;&quot;This is another decorated function. It will not be documented correctly.&quot;&quot;&quot;</span>
+</span><span id="L-377"><a href="#L-377"><span class="linenos">377</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This is another decorated function. It will not be documented correctly.&quot;&quot;&quot;</span>
 </span><span id="L-378"><a href="#L-378"><span class="linenos">378</span></a>    <span class="k">raise</span> <span class="ne">NotImplementedError</span>
 </span><span id="L-379"><a href="#L-379"><span class="linenos">379</span></a>
 </span><span id="L-380"><a href="#L-380"><span class="linenos">380</span></a>
@@ -704,14 +704,14 @@ misc    </h1>
 </span><span id="L-388"><a href="#L-388"><span class="linenos">388</span></a>
 </span><span id="L-389"><a href="#L-389"><span class="linenos">389</span></a><span class="k">class</span> <span class="nc">ClassAsAttribute</span><span class="p">:</span>
 </span><span id="L-390"><a href="#L-390"><span class="linenos">390</span></a>    <span class="n">static_attr_to_class</span> <span class="o">=</span> <span class="n">ClassDecorator</span>
-</span><span id="L-391"><a href="#L-391"><span class="linenos">391</span></a>    <span class="sd">&quot;&quot;&quot;this is a static attribute that point to a Class (not an instance)&quot;&quot;&quot;</span>
+</span><span id="L-391"><a href="#L-391"><span class="linenos">391</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;this is a static attribute that point to a Class (not an instance)&quot;&quot;&quot;</span>
 </span><span id="L-392"><a href="#L-392"><span class="linenos">392</span></a>
 </span><span id="L-393"><a href="#L-393"><span class="linenos">393</span></a>    <span class="n">static_attr_to_instance</span> <span class="o">=</span> <span class="n">ClassDecorator</span><span class="p">(</span><span class="kc">None</span><span class="p">)</span>
-</span><span id="L-394"><a href="#L-394"><span class="linenos">394</span></a>    <span class="sd">&quot;&quot;&quot;this is a static attribute that point to an instance&quot;&quot;&quot;</span>
+</span><span id="L-394"><a href="#L-394"><span class="linenos">394</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;this is a static attribute that point to an instance&quot;&quot;&quot;</span>
 </span><span id="L-395"><a href="#L-395"><span class="linenos">395</span></a>
 </span><span id="L-396"><a href="#L-396"><span class="linenos">396</span></a>
 </span><span id="L-397"><a href="#L-397"><span class="linenos">397</span></a><span class="k">class</span> <span class="nc">scheduler</span><span class="p">(</span><span class="n">sched</span><span class="o">.</span><span class="n">scheduler</span><span class="p">):</span>
-</span><span id="L-398"><a href="#L-398"><span class="linenos">398</span></a>    <span class="sd">&quot;&quot;&quot;Test for broken links for inherited methods, https://github.com/mitmproxy/pdoc/issues/490&quot;&quot;&quot;</span>
+</span><span id="L-398"><a href="#L-398"><span class="linenos">398</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Test for broken links for inherited methods, https://github.com/mitmproxy/pdoc/issues/490&quot;&quot;&quot;</span>
 </span><span id="L-399"><a href="#L-399"><span class="linenos">399</span></a>
 </span><span id="L-400"><a href="#L-400"><span class="linenos">400</span></a>
 </span><span id="L-401"><a href="#L-401"><span class="linenos">401</span></a><span class="n">__all__</span> <span class="o">=</span> <span class="p">[</span>
@@ -767,7 +767,7 @@ misc    </h1>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Issue226-25"><a href="#Issue226-25"><span class="linenos">25</span></a><span class="k">class</span> <span class="nc">Issue226</span><span class="p">:</span>
 </span><span id="Issue226-26"><a href="#Issue226-26"><span class="linenos">26</span></a>    <span class="nd">@Descriptor</span>
 </span><span id="Issue226-27"><a href="#Issue226-27"><span class="linenos">27</span></a>    <span class="k">def</span> <span class="nf">size</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Issue226-28"><a href="#Issue226-28"><span class="linenos">28</span></a>        <span class="sd">&quot;&quot;&quot;This is the size&quot;&quot;&quot;</span>
+</span><span id="Issue226-28"><a href="#Issue226-28"><span class="linenos">28</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This is the size&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -800,13 +800,19 @@ misc    </h1>
                             </div>
                 </section>
                 <section id="var_with_default_obj">
-                    <div class="attr variable">
-            <span class="name">var_with_default_obj</span><span class="default_value"> = &lt;object object&gt;</span>
-
+                            <input id="var_with_default_obj-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">var_with_default_obj</span>
         
+
+                <label class="view-source-button" for="var_with_default_obj-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#var_with_default_obj"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="var_with_default_obj-1"><a href="#var_with_default_obj-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="o">&lt;</span><span class="nb">object</span> <span class="nb">object</span><span class="o">&gt;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>this shouldn't render the object address</p>
 </div>
 
@@ -845,7 +851,7 @@ misc    </h1>
     </div>
     <a class="headerlink" href="#func_with_defaults"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="func_with_defaults-46"><a href="#func_with_defaults-46"><span class="linenos">46</span></a><span class="k">def</span> <span class="nf">func_with_defaults</span><span class="p">(</span><span class="n">a</span><span class="o">=</span><span class="n">default_obj</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="n">default_func</span><span class="p">):</span>
-</span><span id="func_with_defaults-47"><a href="#func_with_defaults-47"><span class="linenos">47</span></a>    <span class="sd">&quot;&quot;&quot;this shouldn&#39;t render object or function addresses&quot;&quot;&quot;</span>
+</span><span id="func_with_defaults-47"><a href="#func_with_defaults-47"><span class="linenos">47</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;this shouldn&#39;t render object or function addresses&quot;&quot;&quot;</span>
 </span><span id="func_with_defaults-48"><a href="#func_with_defaults-48"><span class="linenos">48</span></a>    <span class="k">pass</span>
 </span></pre></div>
 
@@ -867,7 +873,7 @@ misc    </h1>
     </div>
     <a class="headerlink" href="#ClassmethodLink"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ClassmethodLink-52"><a href="#ClassmethodLink-52"><span class="linenos">52</span></a><span class="k">class</span> <span class="nc">ClassmethodLink</span><span class="p">:</span>
-</span><span id="ClassmethodLink-53"><a href="#ClassmethodLink-53"><span class="linenos">53</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="ClassmethodLink-53"><a href="#ClassmethodLink-53"><span class="linenos">53</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="ClassmethodLink-54"><a href="#ClassmethodLink-54"><span class="linenos">54</span></a><span class="sd">    You can either do</span>
 </span><span id="ClassmethodLink-55"><a href="#ClassmethodLink-55"><span class="linenos">55</span></a>
 </span><span id="ClassmethodLink-56"><a href="#ClassmethodLink-56"><span class="linenos">56</span></a><span class="sd">    &gt;&gt;&gt; ClassmethodLink.bar()</span>
@@ -1195,13 +1201,19 @@ For example, a generic mapping type might be defined as::</p>
 
                             </div>
                             <div id="Child.quuux" class="classattr">
-                                <div class="attr variable">
-            <span class="name">quuux</span><span class="annotation">: int</span><span class="default_value"> = 42</span>
-
+                                        <input id="Child.quuux-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">quuux</span><span class="annotation">: int</span>
         
+
+                <label class="view-source-button" for="Child.quuux-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Child.quuux"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Child.quuux-1"><a href="#Child.quuux-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="mi">42</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>quuux</p>
 </div>
 
@@ -1231,12 +1243,12 @@ For example, a generic mapping type might be defined as::</p>
     </div>
     <a class="headerlink" href="#_Private"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="_Private-156"><a href="#_Private-156"><span class="linenos">156</span></a><span class="k">class</span> <span class="nc">_Private</span><span class="p">:</span>
-</span><span id="_Private-157"><a href="#_Private-157"><span class="linenos">157</span></a>    <span class="sd">&quot;&quot;&quot;private class&quot;&quot;&quot;</span>
+</span><span id="_Private-157"><a href="#_Private-157"><span class="linenos">157</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;private class&quot;&quot;&quot;</span>
 </span><span id="_Private-158"><a href="#_Private-158"><span class="linenos">158</span></a>
 </span><span id="_Private-159"><a href="#_Private-159"><span class="linenos">159</span></a>    <span class="k">pass</span>
 </span><span id="_Private-160"><a href="#_Private-160"><span class="linenos">160</span></a>
 </span><span id="_Private-161"><a href="#_Private-161"><span class="linenos">161</span></a>    <span class="k">def</span> <span class="nf">_do</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="_Private-162"><a href="#_Private-162"><span class="linenos">162</span></a>        <span class="sd">&quot;&quot;&quot;private method&quot;&quot;&quot;</span>
+</span><span id="_Private-162"><a href="#_Private-162"><span class="linenos">162</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;private method&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1319,7 +1331,7 @@ For example, a generic mapping type might be defined as::</p>
     </div>
     <a class="headerlink" href="#foo"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="foo-177"><a href="#foo-177"><span class="linenos">177</span></a><span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>
-</span><span id="foo-178"><a href="#foo-178"><span class="linenos">178</span></a>    <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="foo-178"><a href="#foo-178"><span class="linenos">178</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1340,7 +1352,7 @@ For example, a generic mapping type might be defined as::</p>
     </div>
     <a class="headerlink" href="#bar"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="bar-181"><a href="#bar-181"><span class="linenos">181</span></a><span class="k">def</span> <span class="nf">bar</span><span class="p">():</span>
-</span><span id="bar-182"><a href="#bar-182"><span class="linenos">182</span></a>    <span class="sd">&quot;&quot;&quot;no</span>
+</span><span id="bar-182"><a href="#bar-182"><span class="linenos">182</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;no</span>
 </span><span id="bar-183"><a href="#bar-183"><span class="linenos">183</span></a><span class="sd">indents&quot;&quot;&quot;</span>
 </span></pre></div>
 
@@ -1363,7 +1375,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#baz"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="baz-186"><a href="#baz-186"><span class="linenos">186</span></a><span class="k">def</span> <span class="nf">baz</span><span class="p">():</span>
-</span><span id="baz-187"><a href="#baz-187"><span class="linenos">187</span></a>    <span class="sd">&quot;&quot;&quot;one</span>
+</span><span id="baz-187"><a href="#baz-187"><span class="linenos">187</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;one</span>
 </span><span id="baz-188"><a href="#baz-188"><span class="linenos">188</span></a><span class="sd">    indent&quot;&quot;&quot;</span>
 </span></pre></div>
 
@@ -1386,7 +1398,7 @@ indent</p>
     </div>
     <a class="headerlink" href="#qux"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="qux-191"><a href="#qux-191"><span class="linenos">191</span></a><span class="k">def</span> <span class="nf">qux</span><span class="p">():</span>
-</span><span id="qux-192"><a href="#qux-192"><span class="linenos">192</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="qux-192"><a href="#qux-192"><span class="linenos">192</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="qux-193"><a href="#qux-193"><span class="linenos">193</span></a><span class="sd">    two</span>
 </span><span id="qux-194"><a href="#qux-194"><span class="linenos">194</span></a><span class="sd">    indents</span>
 </span><span id="qux-195"><a href="#qux-195"><span class="linenos">195</span></a><span class="sd">    &quot;&quot;&quot;</span>
@@ -1412,44 +1424,44 @@ indents</p>
     <a class="headerlink" href="#Indented"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Indented-198"><a href="#Indented-198"><span class="linenos">198</span></a><span class="k">class</span> <span class="nc">Indented</span><span class="p">:</span>
 </span><span id="Indented-199"><a href="#Indented-199"><span class="linenos">199</span></a>    <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented-200"><a href="#Indented-200"><span class="linenos">200</span></a>        <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="Indented-200"><a href="#Indented-200"><span class="linenos">200</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span><span id="Indented-201"><a href="#Indented-201"><span class="linenos">201</span></a>
 </span><span id="Indented-202"><a href="#Indented-202"><span class="linenos">202</span></a>    <span class="k">def</span> <span class="nf">bar</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented-203"><a href="#Indented-203"><span class="linenos">203</span></a>        <span class="sd">&quot;&quot;&quot;no</span>
+</span><span id="Indented-203"><a href="#Indented-203"><span class="linenos">203</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no</span>
 </span><span id="Indented-204"><a href="#Indented-204"><span class="linenos">204</span></a><span class="sd">indents&quot;&quot;&quot;</span>
 </span><span id="Indented-205"><a href="#Indented-205"><span class="linenos">205</span></a>
 </span><span id="Indented-206"><a href="#Indented-206"><span class="linenos">206</span></a>    <span class="k">def</span> <span class="nf">baz</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented-207"><a href="#Indented-207"><span class="linenos">207</span></a>        <span class="sd">&quot;&quot;&quot;one</span>
+</span><span id="Indented-207"><a href="#Indented-207"><span class="linenos">207</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;one</span>
 </span><span id="Indented-208"><a href="#Indented-208"><span class="linenos">208</span></a><span class="sd">        indent&quot;&quot;&quot;</span>
 </span><span id="Indented-209"><a href="#Indented-209"><span class="linenos">209</span></a>
 </span><span id="Indented-210"><a href="#Indented-210"><span class="linenos">210</span></a>    <span class="k">def</span> <span class="nf">qux</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented-211"><a href="#Indented-211"><span class="linenos">211</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Indented-211"><a href="#Indented-211"><span class="linenos">211</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Indented-212"><a href="#Indented-212"><span class="linenos">212</span></a><span class="sd">        two</span>
 </span><span id="Indented-213"><a href="#Indented-213"><span class="linenos">213</span></a><span class="sd">        indents</span>
 </span><span id="Indented-214"><a href="#Indented-214"><span class="linenos">214</span></a><span class="sd">        &quot;&quot;&quot;</span>
 </span><span id="Indented-215"><a href="#Indented-215"><span class="linenos">215</span></a>
 </span><span id="Indented-216"><a href="#Indented-216"><span class="linenos">216</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="Indented-217"><a href="#Indented-217"><span class="linenos">217</span></a>    <span class="k">def</span> <span class="nf">foo_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented-218"><a href="#Indented-218"><span class="linenos">218</span></a>        <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="Indented-218"><a href="#Indented-218"><span class="linenos">218</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span><span id="Indented-219"><a href="#Indented-219"><span class="linenos">219</span></a>
 </span><span id="Indented-220"><a href="#Indented-220"><span class="linenos">220</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="Indented-221"><a href="#Indented-221"><span class="linenos">221</span></a>    <span class="c1"># comment</span>
 </span><span id="Indented-222"><a href="#Indented-222"><span class="linenos">222</span></a>    <span class="k">def</span> <span class="nf">foo_commented</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented-223"><a href="#Indented-223"><span class="linenos">223</span></a>        <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="Indented-223"><a href="#Indented-223"><span class="linenos">223</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span><span id="Indented-224"><a href="#Indented-224"><span class="linenos">224</span></a>
 </span><span id="Indented-225"><a href="#Indented-225"><span class="linenos">225</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="Indented-226"><a href="#Indented-226"><span class="linenos">226</span></a>    <span class="k">def</span> <span class="nf">bar_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented-227"><a href="#Indented-227"><span class="linenos">227</span></a>        <span class="sd">&quot;&quot;&quot;no</span>
+</span><span id="Indented-227"><a href="#Indented-227"><span class="linenos">227</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no</span>
 </span><span id="Indented-228"><a href="#Indented-228"><span class="linenos">228</span></a><span class="sd">indents&quot;&quot;&quot;</span>
 </span><span id="Indented-229"><a href="#Indented-229"><span class="linenos">229</span></a>
 </span><span id="Indented-230"><a href="#Indented-230"><span class="linenos">230</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="Indented-231"><a href="#Indented-231"><span class="linenos">231</span></a>    <span class="k">def</span> <span class="nf">baz_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented-232"><a href="#Indented-232"><span class="linenos">232</span></a>        <span class="sd">&quot;&quot;&quot;one</span>
+</span><span id="Indented-232"><a href="#Indented-232"><span class="linenos">232</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;one</span>
 </span><span id="Indented-233"><a href="#Indented-233"><span class="linenos">233</span></a><span class="sd">        indent&quot;&quot;&quot;</span>
 </span><span id="Indented-234"><a href="#Indented-234"><span class="linenos">234</span></a>
 </span><span id="Indented-235"><a href="#Indented-235"><span class="linenos">235</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="Indented-236"><a href="#Indented-236"><span class="linenos">236</span></a>    <span class="k">def</span> <span class="nf">qux_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented-237"><a href="#Indented-237"><span class="linenos">237</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Indented-237"><a href="#Indented-237"><span class="linenos">237</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Indented-238"><a href="#Indented-238"><span class="linenos">238</span></a><span class="sd">        two</span>
 </span><span id="Indented-239"><a href="#Indented-239"><span class="linenos">239</span></a><span class="sd">        indents</span>
 </span><span id="Indented-240"><a href="#Indented-240"><span class="linenos">240</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -1458,7 +1470,7 @@ indents</p>
 </span><span id="Indented-243"><a href="#Indented-243"><span class="linenos">243</span></a>        <span class="n">maxsize</span><span class="o">=</span><span class="mi">42</span>
 </span><span id="Indented-244"><a href="#Indented-244"><span class="linenos">244</span></a>    <span class="p">)</span>
 </span><span id="Indented-245"><a href="#Indented-245"><span class="linenos">245</span></a>    <span class="k">def</span> <span class="nf">quux_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented-246"><a href="#Indented-246"><span class="linenos">246</span></a>        <span class="sd">&quot;&quot;&quot;multi-line decorator, https://github.com/mitmproxy/pdoc/issues/246&quot;&quot;&quot;</span>
+</span><span id="Indented-246"><a href="#Indented-246"><span class="linenos">246</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;multi-line decorator, https://github.com/mitmproxy/pdoc/issues/246&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1488,7 +1500,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#Indented.foo"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Indented.foo-199"><a href="#Indented.foo-199"><span class="linenos">199</span></a>    <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented.foo-200"><a href="#Indented.foo-200"><span class="linenos">200</span></a>        <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="Indented.foo-200"><a href="#Indented.foo-200"><span class="linenos">200</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1509,7 +1521,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#Indented.bar"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Indented.bar-202"><a href="#Indented.bar-202"><span class="linenos">202</span></a>    <span class="k">def</span> <span class="nf">bar</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented.bar-203"><a href="#Indented.bar-203"><span class="linenos">203</span></a>        <span class="sd">&quot;&quot;&quot;no</span>
+</span><span id="Indented.bar-203"><a href="#Indented.bar-203"><span class="linenos">203</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no</span>
 </span><span id="Indented.bar-204"><a href="#Indented.bar-204"><span class="linenos">204</span></a><span class="sd">indents&quot;&quot;&quot;</span>
 </span></pre></div>
 
@@ -1532,7 +1544,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#Indented.baz"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Indented.baz-206"><a href="#Indented.baz-206"><span class="linenos">206</span></a>    <span class="k">def</span> <span class="nf">baz</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented.baz-207"><a href="#Indented.baz-207"><span class="linenos">207</span></a>        <span class="sd">&quot;&quot;&quot;one</span>
+</span><span id="Indented.baz-207"><a href="#Indented.baz-207"><span class="linenos">207</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;one</span>
 </span><span id="Indented.baz-208"><a href="#Indented.baz-208"><span class="linenos">208</span></a><span class="sd">        indent&quot;&quot;&quot;</span>
 </span></pre></div>
 
@@ -1555,7 +1567,7 @@ indent</p>
     </div>
     <a class="headerlink" href="#Indented.qux"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Indented.qux-210"><a href="#Indented.qux-210"><span class="linenos">210</span></a>    <span class="k">def</span> <span class="nf">qux</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented.qux-211"><a href="#Indented.qux-211"><span class="linenos">211</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Indented.qux-211"><a href="#Indented.qux-211"><span class="linenos">211</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Indented.qux-212"><a href="#Indented.qux-212"><span class="linenos">212</span></a><span class="sd">        two</span>
 </span><span id="Indented.qux-213"><a href="#Indented.qux-213"><span class="linenos">213</span></a><span class="sd">        indents</span>
 </span><span id="Indented.qux-214"><a href="#Indented.qux-214"><span class="linenos">214</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -1582,7 +1594,7 @@ indents</p>
     <a class="headerlink" href="#Indented.foo_decorated"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Indented.foo_decorated-216"><a href="#Indented.foo_decorated-216"><span class="linenos">216</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="Indented.foo_decorated-217"><a href="#Indented.foo_decorated-217"><span class="linenos">217</span></a>    <span class="k">def</span> <span class="nf">foo_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented.foo_decorated-218"><a href="#Indented.foo_decorated-218"><span class="linenos">218</span></a>        <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="Indented.foo_decorated-218"><a href="#Indented.foo_decorated-218"><span class="linenos">218</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1606,7 +1618,7 @@ indents</p>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Indented.foo_commented-220"><a href="#Indented.foo_commented-220"><span class="linenos">220</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="Indented.foo_commented-221"><a href="#Indented.foo_commented-221"><span class="linenos">221</span></a>    <span class="c1"># comment</span>
 </span><span id="Indented.foo_commented-222"><a href="#Indented.foo_commented-222"><span class="linenos">222</span></a>    <span class="k">def</span> <span class="nf">foo_commented</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented.foo_commented-223"><a href="#Indented.foo_commented-223"><span class="linenos">223</span></a>        <span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
+</span><span id="Indented.foo_commented-223"><a href="#Indented.foo_commented-223"><span class="linenos">223</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no indents&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1629,7 +1641,7 @@ indents</p>
     <a class="headerlink" href="#Indented.bar_decorated"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Indented.bar_decorated-225"><a href="#Indented.bar_decorated-225"><span class="linenos">225</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="Indented.bar_decorated-226"><a href="#Indented.bar_decorated-226"><span class="linenos">226</span></a>    <span class="k">def</span> <span class="nf">bar_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented.bar_decorated-227"><a href="#Indented.bar_decorated-227"><span class="linenos">227</span></a>        <span class="sd">&quot;&quot;&quot;no</span>
+</span><span id="Indented.bar_decorated-227"><a href="#Indented.bar_decorated-227"><span class="linenos">227</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;no</span>
 </span><span id="Indented.bar_decorated-228"><a href="#Indented.bar_decorated-228"><span class="linenos">228</span></a><span class="sd">indents&quot;&quot;&quot;</span>
 </span></pre></div>
 
@@ -1654,7 +1666,7 @@ indents</p>
     <a class="headerlink" href="#Indented.baz_decorated"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Indented.baz_decorated-230"><a href="#Indented.baz_decorated-230"><span class="linenos">230</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="Indented.baz_decorated-231"><a href="#Indented.baz_decorated-231"><span class="linenos">231</span></a>    <span class="k">def</span> <span class="nf">baz_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented.baz_decorated-232"><a href="#Indented.baz_decorated-232"><span class="linenos">232</span></a>        <span class="sd">&quot;&quot;&quot;one</span>
+</span><span id="Indented.baz_decorated-232"><a href="#Indented.baz_decorated-232"><span class="linenos">232</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;one</span>
 </span><span id="Indented.baz_decorated-233"><a href="#Indented.baz_decorated-233"><span class="linenos">233</span></a><span class="sd">        indent&quot;&quot;&quot;</span>
 </span></pre></div>
 
@@ -1679,7 +1691,7 @@ indent</p>
     <a class="headerlink" href="#Indented.qux_decorated"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Indented.qux_decorated-235"><a href="#Indented.qux_decorated-235"><span class="linenos">235</span></a>    <span class="nd">@lru_cache</span><span class="p">()</span>
 </span><span id="Indented.qux_decorated-236"><a href="#Indented.qux_decorated-236"><span class="linenos">236</span></a>    <span class="k">def</span> <span class="nf">qux_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented.qux_decorated-237"><a href="#Indented.qux_decorated-237"><span class="linenos">237</span></a>        <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Indented.qux_decorated-237"><a href="#Indented.qux_decorated-237"><span class="linenos">237</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Indented.qux_decorated-238"><a href="#Indented.qux_decorated-238"><span class="linenos">238</span></a><span class="sd">        two</span>
 </span><span id="Indented.qux_decorated-239"><a href="#Indented.qux_decorated-239"><span class="linenos">239</span></a><span class="sd">        indents</span>
 </span><span id="Indented.qux_decorated-240"><a href="#Indented.qux_decorated-240"><span class="linenos">240</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -1708,7 +1720,7 @@ indents</p>
 </span><span id="Indented.quux_decorated-243"><a href="#Indented.quux_decorated-243"><span class="linenos">243</span></a>        <span class="n">maxsize</span><span class="o">=</span><span class="mi">42</span>
 </span><span id="Indented.quux_decorated-244"><a href="#Indented.quux_decorated-244"><span class="linenos">244</span></a>    <span class="p">)</span>
 </span><span id="Indented.quux_decorated-245"><a href="#Indented.quux_decorated-245"><span class="linenos">245</span></a>    <span class="k">def</span> <span class="nf">quux_decorated</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Indented.quux_decorated-246"><a href="#Indented.quux_decorated-246"><span class="linenos">246</span></a>        <span class="sd">&quot;&quot;&quot;multi-line decorator, https://github.com/mitmproxy/pdoc/issues/246&quot;&quot;&quot;</span>
+</span><span id="Indented.quux_decorated-246"><a href="#Indented.quux_decorated-246"><span class="linenos">246</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;multi-line decorator, https://github.com/mitmproxy/pdoc/issues/246&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1731,7 +1743,7 @@ indents</p>
     <a class="headerlink" href="#fun_with_protected_decorator"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="fun_with_protected_decorator-253"><a href="#fun_with_protected_decorator-253"><span class="linenos">253</span></a><span class="nd">@_protected_decorator</span>
 </span><span id="fun_with_protected_decorator-254"><a href="#fun_with_protected_decorator-254"><span class="linenos">254</span></a><span class="k">def</span> <span class="nf">fun_with_protected_decorator</span><span class="p">():</span>
-</span><span id="fun_with_protected_decorator-255"><a href="#fun_with_protected_decorator-255"><span class="linenos">255</span></a>    <span class="sd">&quot;&quot;&quot;This function has a protected decorator (name starting with a single `_`).&quot;&quot;&quot;</span>
+</span><span id="fun_with_protected_decorator-255"><a href="#fun_with_protected_decorator-255"><span class="linenos">255</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This function has a protected decorator (name starting with a single `_`).&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1765,7 +1777,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#AbstractClass"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="AbstractClass-267"><a href="#AbstractClass-267"><span class="linenos">267</span></a><span class="k">class</span> <span class="nc">AbstractClass</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">abc</span><span class="o">.</span><span class="n">ABCMeta</span><span class="p">):</span>
-</span><span id="AbstractClass-268"><a href="#AbstractClass-268"><span class="linenos">268</span></a>    <span class="sd">&quot;&quot;&quot;This class shouldn&#39;t show a constructor as it&#39;s abstract.&quot;&quot;&quot;</span>
+</span><span id="AbstractClass-268"><a href="#AbstractClass-268"><span class="linenos">268</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This class shouldn&#39;t show a constructor as it&#39;s abstract.&quot;&quot;&quot;</span>
 </span><span id="AbstractClass-269"><a href="#AbstractClass-269"><span class="linenos">269</span></a>    <span class="nd">@abc</span><span class="o">.</span><span class="n">abstractmethod</span>
 </span><span id="AbstractClass-270"><a href="#AbstractClass-270"><span class="linenos">270</span></a>    <span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
 </span><span id="AbstractClass-271"><a href="#AbstractClass-271"><span class="linenos">271</span></a>        <span class="k">pass</span>
@@ -1810,7 +1822,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#add_four"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="add_four-277"><a href="#add_four-277"><span class="linenos">277</span></a>    <span class="k">def</span> <span class="nf">add_func</span><span class="p">(</span><span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="add_four-278"><a href="#add_four-278"><span class="linenos">278</span></a>        <span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
+</span><span id="add_four-278"><a href="#add_four-278"><span class="linenos">278</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
 </span><span id="add_four-279"><a href="#add_four-279"><span class="linenos">279</span></a>        <span class="k">return</span> <span class="n">a</span> <span class="o">+</span> <span class="n">b</span>
 </span></pre></div>
 
@@ -1832,7 +1844,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#add_five"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="add_five-277"><a href="#add_five-277"><span class="linenos">277</span></a>    <span class="k">def</span> <span class="nf">add_func</span><span class="p">(</span><span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="add_five-278"><a href="#add_five-278"><span class="linenos">278</span></a>        <span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
+</span><span id="add_five-278"><a href="#add_five-278"><span class="linenos">278</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
 </span><span id="add_five-279"><a href="#add_five-279"><span class="linenos">279</span></a>        <span class="k">return</span> <span class="n">a</span> <span class="o">+</span> <span class="n">b</span>
 </span></pre></div>
 
@@ -1854,7 +1866,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#add_six"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="add_six-277"><a href="#add_six-277"><span class="linenos">277</span></a>    <span class="k">def</span> <span class="nf">add_func</span><span class="p">(</span><span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="add_six-278"><a href="#add_six-278"><span class="linenos">278</span></a>        <span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
+</span><span id="add_six-278"><a href="#add_six-278"><span class="linenos">278</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;This function adds two numbers.&quot;&quot;&quot;</span>
 </span><span id="add_six-279"><a href="#add_six-279"><span class="linenos">279</span></a>        <span class="k">return</span> <span class="n">a</span> <span class="o">+</span> <span class="n">b</span>
 </span></pre></div>
 
@@ -1876,7 +1888,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#linkify_links"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="linkify_links-291"><a href="#linkify_links-291"><span class="linenos">291</span></a><span class="k">def</span> <span class="nf">linkify_links</span><span class="p">():</span>
-</span><span id="linkify_links-292"><a href="#linkify_links-292"><span class="linenos">292</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="linkify_links-292"><a href="#linkify_links-292"><span class="linenos">292</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="linkify_links-293"><a href="#linkify_links-293"><span class="linenos">293</span></a><span class="sd">    This docstring contains links that are also identifiers:</span>
 </span><span id="linkify_links-294"><a href="#linkify_links-294"><span class="linenos">294</span></a>
 </span><span id="linkify_links-295"><a href="#linkify_links-295"><span class="linenos">295</span></a><span class="sd">    - [`linkify_links`](https://example.com/)</span>
@@ -1916,7 +1928,7 @@ indents</p>
     <a class="headerlink" href="#Issue352a"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Issue352a-309"><a href="#Issue352a-309"><span class="linenos">309</span></a><span class="k">class</span> <span class="nc">Issue352a</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">Issue352aMeta</span><span class="p">):</span>
 </span><span id="Issue352a-310"><a href="#Issue352a-310"><span class="linenos">310</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Issue352a-311"><a href="#Issue352a-311"><span class="linenos">311</span></a>        <span class="sd">&quot;&quot;&quot;Issue352.__init__ should be preferred over Meta.__call__.&quot;&quot;&quot;</span>
+</span><span id="Issue352a-311"><a href="#Issue352a-311"><span class="linenos">311</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Issue352.__init__ should be preferred over Meta.__call__.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1933,7 +1945,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#Issue352a.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Issue352a.__init__-310"><a href="#Issue352a.__init__-310"><span class="linenos">310</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-</span><span id="Issue352a.__init__-311"><a href="#Issue352a.__init__-311"><span class="linenos">311</span></a>        <span class="sd">&quot;&quot;&quot;Issue352.__init__ should be preferred over Meta.__call__.&quot;&quot;&quot;</span>
+</span><span id="Issue352a.__init__-311"><a href="#Issue352a.__init__-311"><span class="linenos">311</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Issue352.__init__ should be preferred over Meta.__call__.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1955,7 +1967,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#Issue352b"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Issue352b-319"><a href="#Issue352b-319"><span class="linenos">319</span></a><span class="k">class</span> <span class="nc">Issue352b</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">Issue352bMeta</span><span class="p">):</span>
-</span><span id="Issue352b-320"><a href="#Issue352b-320"><span class="linenos">320</span></a>    <span class="sd">&quot;&quot;&quot;No docstrings for the constructor here.&quot;&quot;&quot;</span>
+</span><span id="Issue352b-320"><a href="#Issue352b-320"><span class="linenos">320</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;No docstrings for the constructor here.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1988,7 +2000,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#CustomCall"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="CustomCall-328"><a href="#CustomCall-328"><span class="linenos">328</span></a><span class="k">class</span> <span class="nc">CustomCall</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">CustomCallMeta</span><span class="p">):</span>
-</span><span id="CustomCall-329"><a href="#CustomCall-329"><span class="linenos">329</span></a>    <span class="sd">&quot;&quot;&quot;A class where the constructor is defined by its metaclass.&quot;&quot;&quot;</span>
+</span><span id="CustomCall-329"><a href="#CustomCall-329"><span class="linenos">329</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A class where the constructor is defined by its metaclass.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -2007,7 +2019,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#CustomCall.__init__"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="CustomCall.__init__-324"><a href="#CustomCall.__init__-324"><span class="linenos">324</span></a>    <span class="k">def</span> <span class="fm">__call__</span><span class="p">(</span><span class="bp">cls</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
-</span><span id="CustomCall.__init__-325"><a href="#CustomCall.__init__-325"><span class="linenos">325</span></a>        <span class="sd">&quot;&quot;&quot;Custom docstring in metaclass.`__call__`&quot;&quot;&quot;</span>
+</span><span id="CustomCall.__init__-325"><a href="#CustomCall.__init__-325"><span class="linenos">325</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Custom docstring in metaclass.`__call__`&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -2029,7 +2041,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#Headings"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Headings-332"><a href="#Headings-332"><span class="linenos">332</span></a><span class="k">class</span> <span class="nc">Headings</span><span class="p">:</span>
-</span><span id="Headings-333"><a href="#Headings-333"><span class="linenos">333</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="Headings-333"><a href="#Headings-333"><span class="linenos">333</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="Headings-334"><a href="#Headings-334"><span class="linenos">334</span></a><span class="sd">    # Heading 1</span>
 </span><span id="Headings-335"><a href="#Headings-335"><span class="linenos">335</span></a>
 </span><span id="Headings-336"><a href="#Headings-336"><span class="linenos">336</span></a><span class="sd">    Here is some text.</span>
@@ -2109,7 +2121,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#repr_not_syntax_highlightable"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="repr_not_syntax_highlightable-366"><a href="#repr_not_syntax_highlightable-366"><span class="linenos">366</span></a><span class="k">def</span> <span class="nf">repr_not_syntax_highlightable</span><span class="p">(</span><span class="n">x</span><span class="o">=</span><span class="n">CustomRepr</span><span class="p">()):</span>
-</span><span id="repr_not_syntax_highlightable-367"><a href="#repr_not_syntax_highlightable-367"><span class="linenos">367</span></a>    <span class="sd">&quot;&quot;&quot;The default value for x fails to highlight with pygments.&quot;&quot;&quot;</span>
+</span><span id="repr_not_syntax_highlightable-367"><a href="#repr_not_syntax_highlightable-367"><span class="linenos">367</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;The default value for x fails to highlight with pygments.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -2130,7 +2142,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#ClassDecorator"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ClassDecorator-370"><a href="#ClassDecorator-370"><span class="linenos">370</span></a><span class="k">class</span> <span class="nc">ClassDecorator</span><span class="p">:</span>
-</span><span id="ClassDecorator-371"><a href="#ClassDecorator-371"><span class="linenos">371</span></a>    <span class="sd">&quot;&quot;&quot;This is a class that wraps a function. It will be documented correctly.&quot;&quot;&quot;</span>
+</span><span id="ClassDecorator-371"><a href="#ClassDecorator-371"><span class="linenos">371</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;This is a class that wraps a function. It will be documented correctly.&quot;&quot;&quot;</span>
 </span><span id="ClassDecorator-372"><a href="#ClassDecorator-372"><span class="linenos">372</span></a>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">f</span><span class="p">):</span>
 </span><span id="ClassDecorator-373"><a href="#ClassDecorator-373"><span class="linenos">373</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">f</span> <span class="o">=</span> <span class="n">f</span>
 </span></pre></div>
@@ -2160,13 +2172,19 @@ indents</p>
                             </div>
                 </section>
                 <section id="another_decorated_function">
-                    <div class="attr variable">
-            <span class="name">another_decorated_function</span><span class="default_value"> = &lt;<a href="#ClassDecorator">misc.ClassDecorator</a> object&gt;</span>
-
+                            <input id="another_decorated_function-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">another_decorated_function</span>
         
+
+                <label class="view-source-button" for="another_decorated_function-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#another_decorated_function"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="another_decorated_function-1"><a href="#another_decorated_function-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="o">&lt;</span><span class="n">misc</span><span class="o">.</span><span class="n">ClassDecorator</span> <span class="nb">object</span><span class="o">&gt;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>This is another decorated function. It will not be documented correctly.</p>
 </div>
 
@@ -2257,10 +2275,10 @@ indents</p>
     <a class="headerlink" href="#ClassAsAttribute"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="ClassAsAttribute-390"><a href="#ClassAsAttribute-390"><span class="linenos">390</span></a><span class="k">class</span> <span class="nc">ClassAsAttribute</span><span class="p">:</span>
 </span><span id="ClassAsAttribute-391"><a href="#ClassAsAttribute-391"><span class="linenos">391</span></a>    <span class="n">static_attr_to_class</span> <span class="o">=</span> <span class="n">ClassDecorator</span>
-</span><span id="ClassAsAttribute-392"><a href="#ClassAsAttribute-392"><span class="linenos">392</span></a>    <span class="sd">&quot;&quot;&quot;this is a static attribute that point to a Class (not an instance)&quot;&quot;&quot;</span>
+</span><span id="ClassAsAttribute-392"><a href="#ClassAsAttribute-392"><span class="linenos">392</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;this is a static attribute that point to a Class (not an instance)&quot;&quot;&quot;</span>
 </span><span id="ClassAsAttribute-393"><a href="#ClassAsAttribute-393"><span class="linenos">393</span></a>
 </span><span id="ClassAsAttribute-394"><a href="#ClassAsAttribute-394"><span class="linenos">394</span></a>    <span class="n">static_attr_to_instance</span> <span class="o">=</span> <span class="n">ClassDecorator</span><span class="p">(</span><span class="kc">None</span><span class="p">)</span>
-</span><span id="ClassAsAttribute-395"><a href="#ClassAsAttribute-395"><span class="linenos">395</span></a>    <span class="sd">&quot;&quot;&quot;this is a static attribute that point to an instance&quot;&quot;&quot;</span>
+</span><span id="ClassAsAttribute-395"><a href="#ClassAsAttribute-395"><span class="linenos">395</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;this is a static attribute that point to an instance&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -2279,26 +2297,38 @@ indents</p>
 
                             </div>
                             <div id="ClassAsAttribute.static_attr_to_class" class="classattr">
-                                <div class="attr variable">
-            <span class="name">static_attr_to_class</span><span class="default_value"> = &lt;class &#39;<a href="#ClassDecorator">misc.ClassDecorator</a>&#39;&gt;</span>
-
+                                        <input id="ClassAsAttribute.static_attr_to_class-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">static_attr_to_class</span>
         
+
+                <label class="view-source-button" for="ClassAsAttribute.static_attr_to_class-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#ClassAsAttribute.static_attr_to_class"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="ClassAsAttribute.static_attr_to_class-1"><a href="#ClassAsAttribute.static_attr_to_class-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="o">&lt;</span><span class="k">class</span> <span class="err">&#39;</span><span class="nc">misc</span><span class="o">.</span><span class="n">ClassDecorator</span><span class="s1">&#39;&gt;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>this is a static attribute that point to a Class (not an instance)</p>
 </div>
 
 
                             </div>
                             <div id="ClassAsAttribute.static_attr_to_instance" class="classattr">
-                                <div class="attr variable">
-            <span class="name">static_attr_to_instance</span><span class="default_value"> = &lt;<a href="#ClassDecorator">misc.ClassDecorator</a> object&gt;</span>
-
+                                        <input id="ClassAsAttribute.static_attr_to_instance-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">static_attr_to_instance</span>
         
+
+                <label class="view-source-button" for="ClassAsAttribute.static_attr_to_instance-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#ClassAsAttribute.static_attr_to_instance"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="ClassAsAttribute.static_attr_to_instance-1"><a href="#ClassAsAttribute.static_attr_to_instance-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="o">&lt;</span><span class="n">misc</span><span class="o">.</span><span class="n">ClassDecorator</span> <span class="nb">object</span><span class="o">&gt;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>this is a static attribute that point to an instance</p>
 </div>
 
@@ -2317,7 +2347,7 @@ indents</p>
     </div>
     <a class="headerlink" href="#scheduler"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="scheduler-398"><a href="#scheduler-398"><span class="linenos">398</span></a><span class="k">class</span> <span class="nc">scheduler</span><span class="p">(</span><span class="n">sched</span><span class="o">.</span><span class="n">scheduler</span><span class="p">):</span>
-</span><span id="scheduler-399"><a href="#scheduler-399"><span class="linenos">399</span></a>    <span class="sd">&quot;&quot;&quot;Test for broken links for inherited methods, https://github.com/mitmproxy/pdoc/issues/490&quot;&quot;&quot;</span>
+</span><span id="scheduler-399"><a href="#scheduler-399"><span class="linenos">399</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Test for broken links for inherited methods, https://github.com/mitmproxy/pdoc/issues/490&quot;&quot;&quot;</span>
 </span></pre></div>
 
 

--- a/test/testdata/misc_py310.html
+++ b/test/testdata/misc_py310.html
@@ -66,7 +66,7 @@ misc_py310    </h1>
 </span><span id="L-2"><a href="#L-2"><span class="linenos"> 2</span></a>
 </span><span id="L-3"><a href="#L-3"><span class="linenos"> 3</span></a>
 </span><span id="L-4"><a href="#L-4"><span class="linenos"> 4</span></a><span class="k">def</span> <span class="nf">new_union</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="s2">&quot;Foo&quot;</span><span class="p">])</span> <span class="o">-&gt;</span> <span class="nb">bool</span> <span class="o">|</span> <span class="kc">None</span><span class="p">:</span>
-</span><span id="L-5"><a href="#L-5"><span class="linenos"> 5</span></a>    <span class="sd">&quot;&quot;&quot;Testing Python 3.10&#39;s new type union syntax.&quot;&quot;&quot;</span>
+</span><span id="L-5"><a href="#L-5"><span class="linenos"> 5</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Testing Python 3.10&#39;s new type union syntax.&quot;&quot;&quot;</span>
 </span><span id="L-6"><a href="#L-6"><span class="linenos"> 6</span></a>
 </span><span id="L-7"><a href="#L-7"><span class="linenos"> 7</span></a>
 </span><span id="L-8"><a href="#L-8"><span class="linenos"> 8</span></a><span class="k">class</span> <span class="nc">Foo</span><span class="p">:</span>
@@ -94,7 +94,7 @@ misc_py310    </h1>
     </div>
     <a class="headerlink" href="#new_union"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="new_union-5"><a href="#new_union-5"><span class="linenos">5</span></a><span class="k">def</span> <span class="nf">new_union</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="s2">&quot;Foo&quot;</span><span class="p">])</span> <span class="o">-&gt;</span> <span class="nb">bool</span> <span class="o">|</span> <span class="kc">None</span><span class="p">:</span>
-</span><span id="new_union-6"><a href="#new_union-6"><span class="linenos">6</span></a>    <span class="sd">&quot;&quot;&quot;Testing Python 3.10&#39;s new type union syntax.&quot;&quot;&quot;</span>
+</span><span id="new_union-6"><a href="#new_union-6"><span class="linenos">6</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Testing Python 3.10&#39;s new type union syntax.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -135,26 +135,38 @@ misc_py310    </h1>
                             </div>
                 </section>
                 <section id="NewStyleDict">
-                    <div class="attr variable">
-            <span class="name">NewStyleDict</span><span class="default_value"> = dict[str, str]</span>
-
+                            <input id="NewStyleDict-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">NewStyleDict</span>
         
+
+                <label class="view-source-button" for="NewStyleDict-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#NewStyleDict"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="NewStyleDict-1"><a href="#NewStyleDict-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>New-style dict.</p>
 </div>
 
 
                 </section>
                 <section id="OldStyleDict">
-                    <div class="attr variable">
-            <span class="name">OldStyleDict</span><span class="default_value"> = typing.Dict[str, str]</span>
-
+                            <input id="OldStyleDict-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">OldStyleDict</span>
         
+
+                <label class="view-source-button" for="OldStyleDict-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#OldStyleDict"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="OldStyleDict-1"><a href="#OldStyleDict-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="n">typing</span><span class="o">.</span><span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>Old-style dict.</p>
 </div>
 

--- a/test/testdata/misc_py311.html
+++ b/test/testdata/misc_py311.html
@@ -54,7 +54,7 @@ misc_py311    </h1>
 </span><span id="L-2"><a href="#L-2"><span class="linenos">2</span></a>
 </span><span id="L-3"><a href="#L-3"><span class="linenos">3</span></a>
 </span><span id="L-4"><a href="#L-4"><span class="linenos">4</span></a><span class="k">class</span> <span class="nc">CustomException</span><span class="p">(</span><span class="ne">RuntimeError</span><span class="p">):</span>
-</span><span id="L-5"><a href="#L-5"><span class="linenos">5</span></a>    <span class="sd">&quot;&quot;&quot;custom exception type&quot;&quot;&quot;</span>
+</span><span id="L-5"><a href="#L-5"><span class="linenos">5</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;custom exception type&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -71,7 +71,7 @@ misc_py311    </h1>
     </div>
     <a class="headerlink" href="#CustomException"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="CustomException-5"><a href="#CustomException-5"><span class="linenos">5</span></a><span class="k">class</span> <span class="nc">CustomException</span><span class="p">(</span><span class="ne">RuntimeError</span><span class="p">):</span>
-</span><span id="CustomException-6"><a href="#CustomException-6"><span class="linenos">6</span></a>    <span class="sd">&quot;&quot;&quot;custom exception type&quot;&quot;&quot;</span>
+</span><span id="CustomException-6"><a href="#CustomException-6"><span class="linenos">6</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;custom exception type&quot;&quot;&quot;</span>
 </span></pre></div>
 
 

--- a/test/testdata/misc_py39.html
+++ b/test/testdata/misc_py39.html
@@ -121,39 +121,39 @@ misc_py39    </h1>
 </span><span id="L-16"><a href="#L-16"><span class="linenos">16</span></a>
 </span><span id="L-17"><a href="#L-17"><span class="linenos">17</span></a>
 </span><span id="L-18"><a href="#L-18"><span class="linenos">18</span></a><span class="k">class</span> <span class="nc">NamedTupleExample</span><span class="p">(</span><span class="n">NamedTuple</span><span class="p">):</span>
-</span><span id="L-19"><a href="#L-19"><span class="linenos">19</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-19"><a href="#L-19"><span class="linenos">19</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-20"><a href="#L-20"><span class="linenos">20</span></a><span class="sd">    An example for a typing.NamedTuple.</span>
 </span><span id="L-21"><a href="#L-21"><span class="linenos">21</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-22"><a href="#L-22"><span class="linenos">22</span></a>
 </span><span id="L-23"><a href="#L-23"><span class="linenos">23</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="L-24"><a href="#L-24"><span class="linenos">24</span></a>    <span class="sd">&quot;&quot;&quot;Name of our example tuple.&quot;&quot;&quot;</span>
+</span><span id="L-24"><a href="#L-24"><span class="linenos">24</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Name of our example tuple.&quot;&quot;&quot;</span>
 </span><span id="L-25"><a href="#L-25"><span class="linenos">25</span></a>    <span class="nb">id</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
 </span><span id="L-26"><a href="#L-26"><span class="linenos">26</span></a>
 </span><span id="L-27"><a href="#L-27"><span class="linenos">27</span></a>
 </span><span id="L-28"><a href="#L-28"><span class="linenos">28</span></a><span class="c1"># Testing some edge cases in our inlined implementation of ForwardRef._evaluate in _eval_type.</span>
 </span><span id="L-29"><a href="#L-29"><span class="linenos">29</span></a><span class="k">class</span> <span class="nc">Foo</span><span class="p">(</span><span class="n">TypedDict</span><span class="p">):</span>
 </span><span id="L-30"><a href="#L-30"><span class="linenos">30</span></a>    <span class="n">a</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">int</span><span class="p">]</span>
-</span><span id="L-31"><a href="#L-31"><span class="linenos">31</span></a>    <span class="sd">&quot;&quot;&quot;First attribute.&quot;&quot;&quot;</span>
+</span><span id="L-31"><a href="#L-31"><span class="linenos">31</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;First attribute.&quot;&quot;&quot;</span>
 </span><span id="L-32"><a href="#L-32"><span class="linenos">32</span></a>
 </span><span id="L-33"><a href="#L-33"><span class="linenos">33</span></a>
 </span><span id="L-34"><a href="#L-34"><span class="linenos">34</span></a><span class="k">class</span> <span class="nc">Bar</span><span class="p">(</span><span class="n">Foo</span><span class="p">,</span> <span class="n">total</span><span class="o">=</span><span class="kc">False</span><span class="p">):</span>
-</span><span id="L-35"><a href="#L-35"><span class="linenos">35</span></a>    <span class="sd">&quot;&quot;&quot;A TypedDict subclass. TypedDict botches the MRO, so things aren&#39;t perfect here.&quot;&quot;&quot;</span>
+</span><span id="L-35"><a href="#L-35"><span class="linenos">35</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A TypedDict subclass. TypedDict botches the MRO, so things aren&#39;t perfect here.&quot;&quot;&quot;</span>
 </span><span id="L-36"><a href="#L-36"><span class="linenos">36</span></a>
 </span><span id="L-37"><a href="#L-37"><span class="linenos">37</span></a>    <span class="n">b</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="L-38"><a href="#L-38"><span class="linenos">38</span></a>    <span class="sd">&quot;&quot;&quot;Second attribute.&quot;&quot;&quot;</span>
+</span><span id="L-38"><a href="#L-38"><span class="linenos">38</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Second attribute.&quot;&quot;&quot;</span>
 </span><span id="L-39"><a href="#L-39"><span class="linenos">39</span></a>    <span class="n">c</span><span class="p">:</span> <span class="nb">str</span>
 </span><span id="L-40"><a href="#L-40"><span class="linenos">40</span></a>    <span class="c1"># undocumented attribute</span>
 </span><span id="L-41"><a href="#L-41"><span class="linenos">41</span></a>
 </span><span id="L-42"><a href="#L-42"><span class="linenos">42</span></a>
 </span><span id="L-43"><a href="#L-43"><span class="linenos">43</span></a><span class="k">class</span> <span class="nc">BarWorkaround</span><span class="p">(</span><span class="n">Foo</span><span class="p">,</span> <span class="n">TypedDict</span><span class="p">,</span> <span class="n">total</span><span class="o">=</span><span class="kc">False</span><span class="p">):</span>
-</span><span id="L-44"><a href="#L-44"><span class="linenos">44</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-44"><a href="#L-44"><span class="linenos">44</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="L-45"><a href="#L-45"><span class="linenos">45</span></a><span class="sd">    A TypedDict subclass with the workaround to also inherit from TypedDict.</span>
 </span><span id="L-46"><a href="#L-46"><span class="linenos">46</span></a>
 </span><span id="L-47"><a href="#L-47"><span class="linenos">47</span></a><span class="sd">    See https://github.com/sphinx-doc/sphinx/pull/10806.</span>
 </span><span id="L-48"><a href="#L-48"><span class="linenos">48</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-49"><a href="#L-49"><span class="linenos">49</span></a>
 </span><span id="L-50"><a href="#L-50"><span class="linenos">50</span></a>    <span class="n">b</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="L-51"><a href="#L-51"><span class="linenos">51</span></a>    <span class="sd">&quot;&quot;&quot;Second attribute.&quot;&quot;&quot;</span>
+</span><span id="L-51"><a href="#L-51"><span class="linenos">51</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Second attribute.&quot;&quot;&quot;</span>
 </span><span id="L-52"><a href="#L-52"><span class="linenos">52</span></a>    <span class="n">c</span><span class="p">:</span> <span class="nb">str</span>
 </span><span id="L-53"><a href="#L-53"><span class="linenos">53</span></a>    <span class="c1"># undocumented attribute</span>
 </span><span id="L-54"><a href="#L-54"><span class="linenos">54</span></a>
@@ -161,7 +161,7 @@ misc_py39    </h1>
 </span><span id="L-56"><a href="#L-56"><span class="linenos">56</span></a><span class="k">class</span> <span class="nc">SingleDispatchMethodExample</span><span class="p">:</span>
 </span><span id="L-57"><a href="#L-57"><span class="linenos">57</span></a>    <span class="nd">@functools</span><span class="o">.</span><span class="n">singledispatchmethod</span>
 </span><span id="L-58"><a href="#L-58"><span class="linenos">58</span></a>    <span class="k">def</span> <span class="nf">fancymethod</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">str_or_int</span><span class="p">:</span> <span class="n">Union</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">int</span><span class="p">]):</span>
-</span><span id="L-59"><a href="#L-59"><span class="linenos">59</span></a>        <span class="sd">&quot;&quot;&quot;A fancy method which is capable of handling either `str` or `int`.</span>
+</span><span id="L-59"><a href="#L-59"><span class="linenos">59</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;A fancy method which is capable of handling either `str` or `int`.</span>
 </span><span id="L-60"><a href="#L-60"><span class="linenos">60</span></a>
 </span><span id="L-61"><a href="#L-61"><span class="linenos">61</span></a><span class="sd">        :param str_or_int: string or integer to handle</span>
 </span><span id="L-62"><a href="#L-62"><span class="linenos">62</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -169,7 +169,7 @@ misc_py39    </h1>
 </span><span id="L-64"><a href="#L-64"><span class="linenos">64</span></a>
 </span><span id="L-65"><a href="#L-65"><span class="linenos">65</span></a>    <span class="nd">@fancymethod</span><span class="o">.</span><span class="n">register</span>
 </span><span id="L-66"><a href="#L-66"><span class="linenos">66</span></a>    <span class="k">def</span> <span class="nf">fancymethod_handle_str</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">str_to_handle</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-67"><a href="#L-67"><span class="linenos">67</span></a>        <span class="sd">&quot;&quot;&quot;Fancy method handles a string.</span>
+</span><span id="L-67"><a href="#L-67"><span class="linenos">67</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Fancy method handles a string.</span>
 </span><span id="L-68"><a href="#L-68"><span class="linenos">68</span></a>
 </span><span id="L-69"><a href="#L-69"><span class="linenos">69</span></a><span class="sd">        :param str_to_handle: string which will be handled</span>
 </span><span id="L-70"><a href="#L-70"><span class="linenos">70</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -177,7 +177,7 @@ misc_py39    </h1>
 </span><span id="L-72"><a href="#L-72"><span class="linenos">72</span></a>
 </span><span id="L-73"><a href="#L-73"><span class="linenos">73</span></a>    <span class="nd">@fancymethod</span><span class="o">.</span><span class="n">register</span>
 </span><span id="L-74"><a href="#L-74"><span class="linenos">74</span></a>    <span class="k">def</span> <span class="nf">_fancymethod_handle_int</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">int_to_handle</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="L-75"><a href="#L-75"><span class="linenos">75</span></a>        <span class="sd">&quot;&quot;&quot;Fancy method handles int (not shown in doc).</span>
+</span><span id="L-75"><a href="#L-75"><span class="linenos">75</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Fancy method handles int (not shown in doc).</span>
 </span><span id="L-76"><a href="#L-76"><span class="linenos">76</span></a>
 </span><span id="L-77"><a href="#L-77"><span class="linenos">77</span></a><span class="sd">        :param int_to_handle: int which will be handled</span>
 </span><span id="L-78"><a href="#L-78"><span class="linenos">78</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -198,12 +198,12 @@ misc_py39    </h1>
     </div>
     <a class="headerlink" href="#NamedTupleExample"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="NamedTupleExample-19"><a href="#NamedTupleExample-19"><span class="linenos">19</span></a><span class="k">class</span> <span class="nc">NamedTupleExample</span><span class="p">(</span><span class="n">NamedTuple</span><span class="p">):</span>
-</span><span id="NamedTupleExample-20"><a href="#NamedTupleExample-20"><span class="linenos">20</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="NamedTupleExample-20"><a href="#NamedTupleExample-20"><span class="linenos">20</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="NamedTupleExample-21"><a href="#NamedTupleExample-21"><span class="linenos">21</span></a><span class="sd">    An example for a typing.NamedTuple.</span>
 </span><span id="NamedTupleExample-22"><a href="#NamedTupleExample-22"><span class="linenos">22</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="NamedTupleExample-23"><a href="#NamedTupleExample-23"><span class="linenos">23</span></a>
 </span><span id="NamedTupleExample-24"><a href="#NamedTupleExample-24"><span class="linenos">24</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
-</span><span id="NamedTupleExample-25"><a href="#NamedTupleExample-25"><span class="linenos">25</span></a>    <span class="sd">&quot;&quot;&quot;Name of our example tuple.&quot;&quot;&quot;</span>
+</span><span id="NamedTupleExample-25"><a href="#NamedTupleExample-25"><span class="linenos">25</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Name of our example tuple.&quot;&quot;&quot;</span>
 </span><span id="NamedTupleExample-26"><a href="#NamedTupleExample-26"><span class="linenos">26</span></a>    <span class="nb">id</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
 </span></pre></div>
 
@@ -276,7 +276,7 @@ misc_py39    </h1>
     <a class="headerlink" href="#Foo"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Foo-30"><a href="#Foo-30"><span class="linenos">30</span></a><span class="k">class</span> <span class="nc">Foo</span><span class="p">(</span><span class="n">TypedDict</span><span class="p">):</span>
 </span><span id="Foo-31"><a href="#Foo-31"><span class="linenos">31</span></a>    <span class="n">a</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">int</span><span class="p">]</span>
-</span><span id="Foo-32"><a href="#Foo-32"><span class="linenos">32</span></a>    <span class="sd">&quot;&quot;&quot;First attribute.&quot;&quot;&quot;</span>
+</span><span id="Foo-32"><a href="#Foo-32"><span class="linenos">32</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;First attribute.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -308,10 +308,10 @@ misc_py39    </h1>
     </div>
     <a class="headerlink" href="#Bar"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Bar-35"><a href="#Bar-35"><span class="linenos">35</span></a><span class="k">class</span> <span class="nc">Bar</span><span class="p">(</span><span class="n">Foo</span><span class="p">,</span> <span class="n">total</span><span class="o">=</span><span class="kc">False</span><span class="p">):</span>
-</span><span id="Bar-36"><a href="#Bar-36"><span class="linenos">36</span></a>    <span class="sd">&quot;&quot;&quot;A TypedDict subclass. TypedDict botches the MRO, so things aren&#39;t perfect here.&quot;&quot;&quot;</span>
+</span><span id="Bar-36"><a href="#Bar-36"><span class="linenos">36</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A TypedDict subclass. TypedDict botches the MRO, so things aren&#39;t perfect here.&quot;&quot;&quot;</span>
 </span><span id="Bar-37"><a href="#Bar-37"><span class="linenos">37</span></a>
 </span><span id="Bar-38"><a href="#Bar-38"><span class="linenos">38</span></a>    <span class="n">b</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="Bar-39"><a href="#Bar-39"><span class="linenos">39</span></a>    <span class="sd">&quot;&quot;&quot;Second attribute.&quot;&quot;&quot;</span>
+</span><span id="Bar-39"><a href="#Bar-39"><span class="linenos">39</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Second attribute.&quot;&quot;&quot;</span>
 </span><span id="Bar-40"><a href="#Bar-40"><span class="linenos">40</span></a>    <span class="n">c</span><span class="p">:</span> <span class="nb">str</span>
 </span><span id="Bar-41"><a href="#Bar-41"><span class="linenos">41</span></a>    <span class="c1"># undocumented attribute</span>
 </span></pre></div>
@@ -366,14 +366,14 @@ misc_py39    </h1>
     </div>
     <a class="headerlink" href="#BarWorkaround"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="BarWorkaround-44"><a href="#BarWorkaround-44"><span class="linenos">44</span></a><span class="k">class</span> <span class="nc">BarWorkaround</span><span class="p">(</span><span class="n">Foo</span><span class="p">,</span> <span class="n">TypedDict</span><span class="p">,</span> <span class="n">total</span><span class="o">=</span><span class="kc">False</span><span class="p">):</span>
-</span><span id="BarWorkaround-45"><a href="#BarWorkaround-45"><span class="linenos">45</span></a>    <span class="sd">&quot;&quot;&quot;</span>
+</span><span id="BarWorkaround-45"><a href="#BarWorkaround-45"><span class="linenos">45</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="BarWorkaround-46"><a href="#BarWorkaround-46"><span class="linenos">46</span></a><span class="sd">    A TypedDict subclass with the workaround to also inherit from TypedDict.</span>
 </span><span id="BarWorkaround-47"><a href="#BarWorkaround-47"><span class="linenos">47</span></a>
 </span><span id="BarWorkaround-48"><a href="#BarWorkaround-48"><span class="linenos">48</span></a><span class="sd">    See https://github.com/sphinx-doc/sphinx/pull/10806.</span>
 </span><span id="BarWorkaround-49"><a href="#BarWorkaround-49"><span class="linenos">49</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="BarWorkaround-50"><a href="#BarWorkaround-50"><span class="linenos">50</span></a>
 </span><span id="BarWorkaround-51"><a href="#BarWorkaround-51"><span class="linenos">51</span></a>    <span class="n">b</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="BarWorkaround-52"><a href="#BarWorkaround-52"><span class="linenos">52</span></a>    <span class="sd">&quot;&quot;&quot;Second attribute.&quot;&quot;&quot;</span>
+</span><span id="BarWorkaround-52"><a href="#BarWorkaround-52"><span class="linenos">52</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Second attribute.&quot;&quot;&quot;</span>
 </span><span id="BarWorkaround-53"><a href="#BarWorkaround-53"><span class="linenos">53</span></a>    <span class="n">c</span><span class="p">:</span> <span class="nb">str</span>
 </span><span id="BarWorkaround-54"><a href="#BarWorkaround-54"><span class="linenos">54</span></a>    <span class="c1"># undocumented attribute</span>
 </span></pre></div>
@@ -422,7 +422,7 @@ misc_py39    </h1>
             <div class="pdoc-code codehilite"><pre><span></span><span id="SingleDispatchMethodExample-57"><a href="#SingleDispatchMethodExample-57"><span class="linenos">57</span></a><span class="k">class</span> <span class="nc">SingleDispatchMethodExample</span><span class="p">:</span>
 </span><span id="SingleDispatchMethodExample-58"><a href="#SingleDispatchMethodExample-58"><span class="linenos">58</span></a>    <span class="nd">@functools</span><span class="o">.</span><span class="n">singledispatchmethod</span>
 </span><span id="SingleDispatchMethodExample-59"><a href="#SingleDispatchMethodExample-59"><span class="linenos">59</span></a>    <span class="k">def</span> <span class="nf">fancymethod</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">str_or_int</span><span class="p">:</span> <span class="n">Union</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">int</span><span class="p">]):</span>
-</span><span id="SingleDispatchMethodExample-60"><a href="#SingleDispatchMethodExample-60"><span class="linenos">60</span></a>        <span class="sd">&quot;&quot;&quot;A fancy method which is capable of handling either `str` or `int`.</span>
+</span><span id="SingleDispatchMethodExample-60"><a href="#SingleDispatchMethodExample-60"><span class="linenos">60</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;A fancy method which is capable of handling either `str` or `int`.</span>
 </span><span id="SingleDispatchMethodExample-61"><a href="#SingleDispatchMethodExample-61"><span class="linenos">61</span></a>
 </span><span id="SingleDispatchMethodExample-62"><a href="#SingleDispatchMethodExample-62"><span class="linenos">62</span></a><span class="sd">        :param str_or_int: string or integer to handle</span>
 </span><span id="SingleDispatchMethodExample-63"><a href="#SingleDispatchMethodExample-63"><span class="linenos">63</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -430,7 +430,7 @@ misc_py39    </h1>
 </span><span id="SingleDispatchMethodExample-65"><a href="#SingleDispatchMethodExample-65"><span class="linenos">65</span></a>
 </span><span id="SingleDispatchMethodExample-66"><a href="#SingleDispatchMethodExample-66"><span class="linenos">66</span></a>    <span class="nd">@fancymethod</span><span class="o">.</span><span class="n">register</span>
 </span><span id="SingleDispatchMethodExample-67"><a href="#SingleDispatchMethodExample-67"><span class="linenos">67</span></a>    <span class="k">def</span> <span class="nf">fancymethod_handle_str</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">str_to_handle</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="SingleDispatchMethodExample-68"><a href="#SingleDispatchMethodExample-68"><span class="linenos">68</span></a>        <span class="sd">&quot;&quot;&quot;Fancy method handles a string.</span>
+</span><span id="SingleDispatchMethodExample-68"><a href="#SingleDispatchMethodExample-68"><span class="linenos">68</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Fancy method handles a string.</span>
 </span><span id="SingleDispatchMethodExample-69"><a href="#SingleDispatchMethodExample-69"><span class="linenos">69</span></a>
 </span><span id="SingleDispatchMethodExample-70"><a href="#SingleDispatchMethodExample-70"><span class="linenos">70</span></a><span class="sd">        :param str_to_handle: string which will be handled</span>
 </span><span id="SingleDispatchMethodExample-71"><a href="#SingleDispatchMethodExample-71"><span class="linenos">71</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -438,7 +438,7 @@ misc_py39    </h1>
 </span><span id="SingleDispatchMethodExample-73"><a href="#SingleDispatchMethodExample-73"><span class="linenos">73</span></a>
 </span><span id="SingleDispatchMethodExample-74"><a href="#SingleDispatchMethodExample-74"><span class="linenos">74</span></a>    <span class="nd">@fancymethod</span><span class="o">.</span><span class="n">register</span>
 </span><span id="SingleDispatchMethodExample-75"><a href="#SingleDispatchMethodExample-75"><span class="linenos">75</span></a>    <span class="k">def</span> <span class="nf">_fancymethod_handle_int</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">int_to_handle</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="SingleDispatchMethodExample-76"><a href="#SingleDispatchMethodExample-76"><span class="linenos">76</span></a>        <span class="sd">&quot;&quot;&quot;Fancy method handles int (not shown in doc).</span>
+</span><span id="SingleDispatchMethodExample-76"><a href="#SingleDispatchMethodExample-76"><span class="linenos">76</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Fancy method handles int (not shown in doc).</span>
 </span><span id="SingleDispatchMethodExample-77"><a href="#SingleDispatchMethodExample-77"><span class="linenos">77</span></a>
 </span><span id="SingleDispatchMethodExample-78"><a href="#SingleDispatchMethodExample-78"><span class="linenos">78</span></a><span class="sd">        :param int_to_handle: int which will be handled</span>
 </span><span id="SingleDispatchMethodExample-79"><a href="#SingleDispatchMethodExample-79"><span class="linenos">79</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -474,7 +474,7 @@ misc_py39    </h1>
     <a class="headerlink" href="#SingleDispatchMethodExample.fancymethod"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="SingleDispatchMethodExample.fancymethod-58"><a href="#SingleDispatchMethodExample.fancymethod-58"><span class="linenos">58</span></a>    <span class="nd">@functools</span><span class="o">.</span><span class="n">singledispatchmethod</span>
 </span><span id="SingleDispatchMethodExample.fancymethod-59"><a href="#SingleDispatchMethodExample.fancymethod-59"><span class="linenos">59</span></a>    <span class="k">def</span> <span class="nf">fancymethod</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">str_or_int</span><span class="p">:</span> <span class="n">Union</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">int</span><span class="p">]):</span>
-</span><span id="SingleDispatchMethodExample.fancymethod-60"><a href="#SingleDispatchMethodExample.fancymethod-60"><span class="linenos">60</span></a>        <span class="sd">&quot;&quot;&quot;A fancy method which is capable of handling either `str` or `int`.</span>
+</span><span id="SingleDispatchMethodExample.fancymethod-60"><a href="#SingleDispatchMethodExample.fancymethod-60"><span class="linenos">60</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;A fancy method which is capable of handling either `str` or `int`.</span>
 </span><span id="SingleDispatchMethodExample.fancymethod-61"><a href="#SingleDispatchMethodExample.fancymethod-61"><span class="linenos">61</span></a>
 </span><span id="SingleDispatchMethodExample.fancymethod-62"><a href="#SingleDispatchMethodExample.fancymethod-62"><span class="linenos">62</span></a><span class="sd">        :param str_or_int: string or integer to handle</span>
 </span><span id="SingleDispatchMethodExample.fancymethod-63"><a href="#SingleDispatchMethodExample.fancymethod-63"><span class="linenos">63</span></a><span class="sd">        &quot;&quot;&quot;</span>
@@ -507,7 +507,7 @@ misc_py39    </h1>
     <a class="headerlink" href="#SingleDispatchMethodExample.fancymethod_handle_str"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="SingleDispatchMethodExample.fancymethod_handle_str-66"><a href="#SingleDispatchMethodExample.fancymethod_handle_str-66"><span class="linenos">66</span></a>    <span class="nd">@fancymethod</span><span class="o">.</span><span class="n">register</span>
 </span><span id="SingleDispatchMethodExample.fancymethod_handle_str-67"><a href="#SingleDispatchMethodExample.fancymethod_handle_str-67"><span class="linenos">67</span></a>    <span class="k">def</span> <span class="nf">fancymethod_handle_str</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">str_to_handle</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="SingleDispatchMethodExample.fancymethod_handle_str-68"><a href="#SingleDispatchMethodExample.fancymethod_handle_str-68"><span class="linenos">68</span></a>        <span class="sd">&quot;&quot;&quot;Fancy method handles a string.</span>
+</span><span id="SingleDispatchMethodExample.fancymethod_handle_str-68"><a href="#SingleDispatchMethodExample.fancymethod_handle_str-68"><span class="linenos">68</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Fancy method handles a string.</span>
 </span><span id="SingleDispatchMethodExample.fancymethod_handle_str-69"><a href="#SingleDispatchMethodExample.fancymethod_handle_str-69"><span class="linenos">69</span></a>
 </span><span id="SingleDispatchMethodExample.fancymethod_handle_str-70"><a href="#SingleDispatchMethodExample.fancymethod_handle_str-70"><span class="linenos">70</span></a><span class="sd">        :param str_to_handle: string which will be handled</span>
 </span><span id="SingleDispatchMethodExample.fancymethod_handle_str-71"><a href="#SingleDispatchMethodExample.fancymethod_handle_str-71"><span class="linenos">71</span></a><span class="sd">        &quot;&quot;&quot;</span>

--- a/test/testdata/render_options.html
+++ b/test/testdata/render_options.html
@@ -135,7 +135,7 @@ You can either escape a backslash with a second backslash:</p>
 
 <div class=&quot;pdoc-code codehilite&quot;>
 <pre><span></span><code><span class=&quot;k&quot;>def</span> <span class=&quot;nf&quot;>foo</span><span class=&quot;p&quot;>():</span>
-    <span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;docstring with $\\frac{x}{y}$.&amp;quot;&amp;quot;&amp;quot;</span>
+<span class=&quot;w&quot;>    </span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;docstring with $\\frac{x}{y}$.&amp;quot;&amp;quot;&amp;quot;</span>
 </code></pre>
 </div>
 
@@ -145,7 +145,7 @@ where backslashes are not processed:</p>
 
 <div class=&quot;pdoc-code codehilite&quot;>
 <pre><span></span><code><span class=&quot;k&quot;>def</span> <span class=&quot;nf&quot;>foo</span><span class=&quot;p&quot;>():</span>
-    <span class=&quot;sa&quot;>r</span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;raw docstring with $\frac{x}{y}$.&amp;quot;&amp;quot;&amp;quot;</span>
+<span class=&quot;w&quot;>    </span><span class=&quot;sa&quot;>r</span><span class=&quot;sd&quot;>&amp;quot;&amp;quot;&amp;quot;raw docstring with $\frac{x}{y}$.&amp;quot;&amp;quot;&amp;quot;</span>
 </code></pre>
 </div>
 

--- a/test/testdata/type_checking_imports.html
+++ b/test/testdata/type_checking_imports.html
@@ -63,7 +63,7 @@ type_checking_imports    </h1>
 </span><span id="L-11"><a href="#L-11"><span class="linenos">11</span></a>
 </span><span id="L-12"><a href="#L-12"><span class="linenos">12</span></a>
 </span><span id="L-13"><a href="#L-13"><span class="linenos">13</span></a><span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">],</span> <span class="n">b</span><span class="p">:</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]):</span>
-</span><span id="L-14"><a href="#L-14"><span class="linenos">14</span></a>    <span class="sd">&quot;&quot;&quot;A method with TYPE_CHECKING type annotations.&quot;&quot;&quot;</span>
+</span><span id="L-14"><a href="#L-14"><span class="linenos">14</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A method with TYPE_CHECKING type annotations.&quot;&quot;&quot;</span>
 </span><span id="L-15"><a href="#L-15"><span class="linenos">15</span></a>
 </span><span id="L-16"><a href="#L-16"><span class="linenos">16</span></a>
 </span><span id="L-17"><a href="#L-17"><span class="linenos">17</span></a><span class="n">var</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">int</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">3</span><span class="p">)</span>
@@ -84,7 +84,7 @@ type_checking_imports    </h1>
     </div>
     <a class="headerlink" href="#foo"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="foo-14"><a href="#foo-14"><span class="linenos">14</span></a><span class="k">def</span> <span class="nf">foo</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">],</span> <span class="n">b</span><span class="p">:</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]):</span>
-</span><span id="foo-15"><a href="#foo-15"><span class="linenos">15</span></a>    <span class="sd">&quot;&quot;&quot;A method with TYPE_CHECKING type annotations.&quot;&quot;&quot;</span>
+</span><span id="foo-15"><a href="#foo-15"><span class="linenos">15</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A method with TYPE_CHECKING type annotations.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -94,13 +94,19 @@ type_checking_imports    </h1>
 
                 </section>
                 <section id="var">
-                    <div class="attr variable">
-            <span class="name">var</span><span class="annotation">: Sequence[int]</span><span class="default_value"> = (1, 2, 3)</span>
-
+                            <input id="var-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">var</span><span class="annotation">: Sequence[int]</span>
         
+
+                <label class="view-source-button" for="var-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#var"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="var-1"><a href="#var-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">3</span><span class="p">)</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A variable with TYPE_CHECKING type annotations.</p>
 </div>
 

--- a/test/testdata/type_stub.html
+++ b/test/testdata/type_stub.html
@@ -88,7 +88,7 @@ type_stub    </h1>
 </span><span id="L-4"><a href="#L-4"><span class="linenos"> 4</span></a>
 </span><span id="L-5"><a href="#L-5"><span class="linenos"> 5</span></a>
 </span><span id="L-6"><a href="#L-6"><span class="linenos"> 6</span></a><span class="k">def</span> <span class="nf">func</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
-</span><span id="L-7"><a href="#L-7"><span class="linenos"> 7</span></a>    <span class="sd">&quot;&quot;&quot;A simple function.&quot;&quot;&quot;</span>
+</span><span id="L-7"><a href="#L-7"><span class="linenos"> 7</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A simple function.&quot;&quot;&quot;</span>
 </span><span id="L-8"><a href="#L-8"><span class="linenos"> 8</span></a>
 </span><span id="L-9"><a href="#L-9"><span class="linenos"> 9</span></a>
 </span><span id="L-10"><a href="#L-10"><span class="linenos">10</span></a><span class="n">var</span> <span class="o">=</span> <span class="p">[]</span>
@@ -97,17 +97,17 @@ type_stub    </h1>
 </span><span id="L-13"><a href="#L-13"><span class="linenos">13</span></a>
 </span><span id="L-14"><a href="#L-14"><span class="linenos">14</span></a><span class="k">class</span> <span class="nc">Class</span><span class="p">:</span>
 </span><span id="L-15"><a href="#L-15"><span class="linenos">15</span></a>    <span class="n">attr</span> <span class="o">=</span> <span class="mi">42</span>
-</span><span id="L-16"><a href="#L-16"><span class="linenos">16</span></a>    <span class="sd">&quot;&quot;&quot;An attribute&quot;&quot;&quot;</span>
+</span><span id="L-16"><a href="#L-16"><span class="linenos">16</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An attribute&quot;&quot;&quot;</span>
 </span><span id="L-17"><a href="#L-17"><span class="linenos">17</span></a>
 </span><span id="L-18"><a href="#L-18"><span class="linenos">18</span></a>    <span class="k">def</span> <span class="nf">meth</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
-</span><span id="L-19"><a href="#L-19"><span class="linenos">19</span></a>        <span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
+</span><span id="L-19"><a href="#L-19"><span class="linenos">19</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
 </span><span id="L-20"><a href="#L-20"><span class="linenos">20</span></a>
 </span><span id="L-21"><a href="#L-21"><span class="linenos">21</span></a>    <span class="k">class</span> <span class="nc">Subclass</span><span class="p">:</span>
 </span><span id="L-22"><a href="#L-22"><span class="linenos">22</span></a>        <span class="n">attr</span> <span class="o">=</span> <span class="s2">&quot;42&quot;</span>
-</span><span id="L-23"><a href="#L-23"><span class="linenos">23</span></a>        <span class="sd">&quot;&quot;&quot;An attribute&quot;&quot;&quot;</span>
+</span><span id="L-23"><a href="#L-23"><span class="linenos">23</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;An attribute&quot;&quot;&quot;</span>
 </span><span id="L-24"><a href="#L-24"><span class="linenos">24</span></a>
 </span><span id="L-25"><a href="#L-25"><span class="linenos">25</span></a>        <span class="k">def</span> <span class="nf">meth</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
-</span><span id="L-26"><a href="#L-26"><span class="linenos">26</span></a>            <span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
+</span><span id="L-26"><a href="#L-26"><span class="linenos">26</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -124,7 +124,7 @@ type_stub    </h1>
     </div>
     <a class="headerlink" href="#func"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="func-7"><a href="#func-7"><span class="linenos">7</span></a><span class="k">def</span> <span class="nf">func</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
-</span><span id="func-8"><a href="#func-8"><span class="linenos">8</span></a>    <span class="sd">&quot;&quot;&quot;A simple function.&quot;&quot;&quot;</span>
+</span><span id="func-8"><a href="#func-8"><span class="linenos">8</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A simple function.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -134,13 +134,19 @@ type_stub    </h1>
 
                 </section>
                 <section id="var">
-                    <div class="attr variable">
-            <span class="name">var</span><span class="annotation">: list[str]</span><span class="default_value"> = []</span>
-
+                            <input id="var-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">var</span><span class="annotation">: list[str]</span>
         
+
+                <label class="view-source-button" for="var-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#var"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="var-1"><a href="#var-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="p">[]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A simple variable.</p>
 </div>
 
@@ -159,17 +165,17 @@ type_stub    </h1>
     <a class="headerlink" href="#Class"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Class-15"><a href="#Class-15"><span class="linenos">15</span></a><span class="k">class</span> <span class="nc">Class</span><span class="p">:</span>
 </span><span id="Class-16"><a href="#Class-16"><span class="linenos">16</span></a>    <span class="n">attr</span> <span class="o">=</span> <span class="mi">42</span>
-</span><span id="Class-17"><a href="#Class-17"><span class="linenos">17</span></a>    <span class="sd">&quot;&quot;&quot;An attribute&quot;&quot;&quot;</span>
+</span><span id="Class-17"><a href="#Class-17"><span class="linenos">17</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An attribute&quot;&quot;&quot;</span>
 </span><span id="Class-18"><a href="#Class-18"><span class="linenos">18</span></a>
 </span><span id="Class-19"><a href="#Class-19"><span class="linenos">19</span></a>    <span class="k">def</span> <span class="nf">meth</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
-</span><span id="Class-20"><a href="#Class-20"><span class="linenos">20</span></a>        <span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
+</span><span id="Class-20"><a href="#Class-20"><span class="linenos">20</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
 </span><span id="Class-21"><a href="#Class-21"><span class="linenos">21</span></a>
 </span><span id="Class-22"><a href="#Class-22"><span class="linenos">22</span></a>    <span class="k">class</span> <span class="nc">Subclass</span><span class="p">:</span>
 </span><span id="Class-23"><a href="#Class-23"><span class="linenos">23</span></a>        <span class="n">attr</span> <span class="o">=</span> <span class="s2">&quot;42&quot;</span>
-</span><span id="Class-24"><a href="#Class-24"><span class="linenos">24</span></a>        <span class="sd">&quot;&quot;&quot;An attribute&quot;&quot;&quot;</span>
+</span><span id="Class-24"><a href="#Class-24"><span class="linenos">24</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;An attribute&quot;&quot;&quot;</span>
 </span><span id="Class-25"><a href="#Class-25"><span class="linenos">25</span></a>
 </span><span id="Class-26"><a href="#Class-26"><span class="linenos">26</span></a>        <span class="k">def</span> <span class="nf">meth</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
-</span><span id="Class-27"><a href="#Class-27"><span class="linenos">27</span></a>            <span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
+</span><span id="Class-27"><a href="#Class-27"><span class="linenos">27</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -188,13 +194,19 @@ type_stub    </h1>
 
                             </div>
                             <div id="Class.attr" class="classattr">
-                                <div class="attr variable">
-            <span class="name">attr</span><span class="annotation">: int</span><span class="default_value"> = 42</span>
-
+                                        <input id="Class.attr-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">attr</span><span class="annotation">: int</span>
         
+
+                <label class="view-source-button" for="Class.attr-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Class.attr"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Class.attr-1"><a href="#Class.attr-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="mi">42</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>An attribute</p>
 </div>
 
@@ -212,7 +224,7 @@ type_stub    </h1>
     </div>
     <a class="headerlink" href="#Class.meth"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Class.meth-19"><a href="#Class.meth-19"><span class="linenos">19</span></a>    <span class="k">def</span> <span class="nf">meth</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
-</span><span id="Class.meth-20"><a href="#Class.meth-20"><span class="linenos">20</span></a>        <span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
+</span><span id="Class.meth-20"><a href="#Class.meth-20"><span class="linenos">20</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -235,10 +247,10 @@ type_stub    </h1>
     <a class="headerlink" href="#Class.Subclass"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Class.Subclass-22"><a href="#Class.Subclass-22"><span class="linenos">22</span></a>    <span class="k">class</span> <span class="nc">Subclass</span><span class="p">:</span>
 </span><span id="Class.Subclass-23"><a href="#Class.Subclass-23"><span class="linenos">23</span></a>        <span class="n">attr</span> <span class="o">=</span> <span class="s2">&quot;42&quot;</span>
-</span><span id="Class.Subclass-24"><a href="#Class.Subclass-24"><span class="linenos">24</span></a>        <span class="sd">&quot;&quot;&quot;An attribute&quot;&quot;&quot;</span>
+</span><span id="Class.Subclass-24"><a href="#Class.Subclass-24"><span class="linenos">24</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;An attribute&quot;&quot;&quot;</span>
 </span><span id="Class.Subclass-25"><a href="#Class.Subclass-25"><span class="linenos">25</span></a>
 </span><span id="Class.Subclass-26"><a href="#Class.Subclass-26"><span class="linenos">26</span></a>        <span class="k">def</span> <span class="nf">meth</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
-</span><span id="Class.Subclass-27"><a href="#Class.Subclass-27"><span class="linenos">27</span></a>            <span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
+</span><span id="Class.Subclass-27"><a href="#Class.Subclass-27"><span class="linenos">27</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -257,13 +269,19 @@ type_stub    </h1>
 
                             </div>
                             <div id="Class.Subclass.attr" class="classattr">
-                                <div class="attr variable">
-            <span class="name">attr</span><span class="annotation">: str</span><span class="default_value"> = &#39;42&#39;</span>
-
+                                        <input id="Class.Subclass.attr-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
+            <span class="name">attr</span><span class="annotation">: str</span>
         
+
+                <label class="view-source-button" for="Class.Subclass.attr-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Class.Subclass.attr"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Class.Subclass.attr-1"><a href="#Class.Subclass.attr-1"><span class="linenos">1</span></a> <span class="o">=</span> <span class="s1">&#39;42&#39;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>An attribute</p>
 </div>
 
@@ -281,7 +299,7 @@ type_stub    </h1>
     </div>
     <a class="headerlink" href="#Class.Subclass.meth"></a>
             <div class="pdoc-code codehilite"><pre><span></span><span id="Class.Subclass.meth-26"><a href="#Class.Subclass.meth-26"><span class="linenos">26</span></a>        <span class="k">def</span> <span class="nf">meth</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span>
-</span><span id="Class.Subclass.meth-27"><a href="#Class.Subclass.meth-27"><span class="linenos">27</span></a>            <span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
+</span><span id="Class.Subclass.meth-27"><a href="#Class.Subclass.meth-27"><span class="linenos">27</span></a><span class="w">            </span><span class="sd">&quot;&quot;&quot;A simple method.&quot;&quot;&quot;</span>
 </span></pre></div>
 
 


### PR DESCRIPTION
Adds a `Variable.source` property similar to the top-level `Doc.source`, ensuring that variables always have a source-like render available.

Also adds the docstring for each variable to the `default_value` render.

Some other notes:

* My editor auto-corrected some whitespace. Let me know if you'd like to avoid those changes, and I can squash them out!
* My solution here (adding `Variable.source`) is arguably a bit of a hack, but it seemed a bit cleaner than the alternative (specializing all of the macros to handle `Variable.default_value_str`)
* I've put the docstring render in the `default_var` macro, but it arguably belongs one level higher. Let me know if you'd prefer that, and I can move it up!

Fixes #507.