### PR TITLE
fix possible search bar freezes

### DIFF
--- a/pdoc/templates/search.html.jinja2
+++ b/pdoc/templates/search.html.jinja2
@@ -8,73 +8,15 @@
     const originalContent = document.querySelector("main.pdoc");
     let currentContent = originalContent;
 
-    function setContent(innerHTML) {
-        {# Replace the entire page contents. Calling this with an empty argument restores the original page. #}
-        let elem;
-        if (innerHTML) {
-            elem = document.createElement("main");
-            elem.classList.add("pdoc");
-            elem.innerHTML = innerHTML;
-        } else {
-            elem = originalContent;
-        }
-        if (currentContent !== elem) {
-            currentContent.replaceWith(elem);
-            currentContent = elem;
-        }
+    function smooth(func) {
+        var timeout;
+        return function (...args) {
+            clearTimeout(timeout);
+            timeout = setTimeout(function() { func(...args); }, 300);
+        };
     }
 
-    function getSearchTerm() {
-        return (new URL(window.location)).searchParams.get("search");
-    }
-
-    {# the control flow here is: search input -> update location -> onInput #}
-    const searchBox = document.querySelector(".pdoc input[type=search]");
-    searchBox.addEventListener("input", function () {
-        let url = new URL(window.location);
-        if (searchBox.value.trim()) {
-            url.hash = "";
-            url.searchParams.set("search", searchBox.value);
-        } else {
-            url.searchParams.delete("search");
-        }
-        history.replaceState("", "", url.toString());
-        onInput();
-    });
-    window.addEventListener("popstate", onInput);
-
-
-    let search, searchErr;
-
-    async function initialize() {
-        {# Get the search index and compile it if necessary.
-           This function will only be called once. #}
-        try {
-            search = await new Promise((resolve, reject) => {
-                const script = document.createElement("script");
-                script.type = "text/javascript";
-                script.async = true;
-                script.onload = () => resolve(window.pdocSearch);
-                script.onerror = (e) => reject(e);
-                script.src = "{{ rootprefix }}search.js";
-                document.getElementsByTagName("head")[0].appendChild(script);
-            });
-        } catch (e) {
-            console.error("Cannot fetch pdoc search index");
-            searchErr = "Cannot fetch search index.";
-        }
-        onInput();
-
-        {# if the user clicks an anchor link in the navigation, we need to restore the original contents. #}
-        document.querySelector("nav.pdoc").addEventListener("click", e => {
-            if (e.target.hash) {
-                searchBox.value = "";
-                searchBox.dispatchEvent(new Event("input"));
-            }
-        });
-    }
-
-    function onInput() {
+    const onInput = smooth(function () {
         setContent((() => {
             const term = getSearchTerm();
             if (!term) {
@@ -140,6 +82,72 @@
             }
             return html;
         })());
+    });
+
+    function setContent(innerHTML) {
+        {# Replace the entire page contents. Calling this with an empty argument restores the original page. #}
+        let elem;
+        if (innerHTML) {
+            elem = document.createElement("main");
+            elem.classList.add("pdoc");
+            elem.innerHTML = innerHTML;
+        } else {
+            elem = originalContent;
+        }
+        if (currentContent !== elem) {
+            currentContent.replaceWith(elem);
+            currentContent = elem;
+        }
+    }
+
+    function getSearchTerm() {
+        return (new URL(window.location)).searchParams.get("search");
+    }
+
+    {# the control flow here is: search input -> update location -> onInput #}
+    const searchBox = document.querySelector(".pdoc input[type=search]");
+    searchBox.addEventListener("input", function () {
+        let url = new URL(window.location);
+        if (searchBox.value.trim()) {
+            url.hash = "";
+            url.searchParams.set("search", searchBox.value);
+        } else {
+            url.searchParams.delete("search");
+        }
+        history.replaceState("", "", url.toString());
+        onInput();
+    });
+    window.addEventListener("popstate", onInput);
+
+
+    let search, searchErr;
+
+    async function initialize() {
+        {# Get the search index and compile it if necessary.
+           This function will only be called once. #}
+        try {
+            search = await new Promise((resolve, reject) => {
+                const script = document.createElement("script");
+                script.type = "text/javascript";
+                script.async = true;
+                script.onload = () => resolve(window.pdocSearch);
+                script.onerror = (e) => reject(e);
+                script.src = "{{ rootprefix }}search.js";
+                document.getElementsByTagName("head")[0].appendChild(script);
+            });
+        } catch (e) {
+            console.error("Cannot fetch pdoc search index");
+            searchErr = "Cannot fetch search index.";
+        }
+        onInput();
+
+        {# if the user clicks an anchor link in the navigation, we need to restore the original contents. #}
+        document.querySelector("nav.pdoc").addEventListener("click", e => {
+            if (e.target.hash) {
+                searchBox.value = "";
+                searchBox.dispatchEvent(new Event("input"));
+            }
+        });
     }
 
     if (getSearchTerm()) {

--- a/test/testdata/demopackage.html
+++ b/test/testdata/demopackage.html
@@ -276,68 +276,15 @@ demopackage    </h1>
     const originalContent = document.querySelector("main.pdoc");
     let currentContent = originalContent;
 
-    function setContent(innerHTML) {
-        let elem;
-        if (innerHTML) {
-            elem = document.createElement("main");
-            elem.classList.add("pdoc");
-            elem.innerHTML = innerHTML;
-        } else {
-            elem = originalContent;
-        }
-        if (currentContent !== elem) {
-            currentContent.replaceWith(elem);
-            currentContent = elem;
-        }
+    function smooth(func) {
+        var timeout;
+        return function (...args) {
+            clearTimeout(timeout);
+            timeout = setTimeout(function() { func(...args); }, 300);
+        };
     }
 
-    function getSearchTerm() {
-        return (new URL(window.location)).searchParams.get("search");
-    }
-
-    const searchBox = document.querySelector(".pdoc input[type=search]");
-    searchBox.addEventListener("input", function () {
-        let url = new URL(window.location);
-        if (searchBox.value.trim()) {
-            url.hash = "";
-            url.searchParams.set("search", searchBox.value);
-        } else {
-            url.searchParams.delete("search");
-        }
-        history.replaceState("", "", url.toString());
-        onInput();
-    });
-    window.addEventListener("popstate", onInput);
-
-
-    let search, searchErr;
-
-    async function initialize() {
-        try {
-            search = await new Promise((resolve, reject) => {
-                const script = document.createElement("script");
-                script.type = "text/javascript";
-                script.async = true;
-                script.onload = () => resolve(window.pdocSearch);
-                script.onerror = (e) => reject(e);
-                script.src = "search.js";
-                document.getElementsByTagName("head")[0].appendChild(script);
-            });
-        } catch (e) {
-            console.error("Cannot fetch pdoc search index");
-            searchErr = "Cannot fetch search index.";
-        }
-        onInput();
-
-        document.querySelector("nav.pdoc").addEventListener("click", e => {
-            if (e.target.hash) {
-                searchBox.value = "";
-                searchBox.dispatchEvent(new Event("input"));
-            }
-        });
-    }
-
-    function onInput() {
+    const onInput = smooth(function () {
         setContent((() => {
             const term = getSearchTerm();
             if (!term) {
@@ -403,6 +350,67 @@ demopackage    </h1>
             }
             return html;
         })());
+    });
+
+    function setContent(innerHTML) {
+        let elem;
+        if (innerHTML) {
+            elem = document.createElement("main");
+            elem.classList.add("pdoc");
+            elem.innerHTML = innerHTML;
+        } else {
+            elem = originalContent;
+        }
+        if (currentContent !== elem) {
+            currentContent.replaceWith(elem);
+            currentContent = elem;
+        }
+    }
+
+    function getSearchTerm() {
+        return (new URL(window.location)).searchParams.get("search");
+    }
+
+    const searchBox = document.querySelector(".pdoc input[type=search]");
+    searchBox.addEventListener("input", function () {
+        let url = new URL(window.location);
+        if (searchBox.value.trim()) {
+            url.hash = "";
+            url.searchParams.set("search", searchBox.value);
+        } else {
+            url.searchParams.delete("search");
+        }
+        history.replaceState("", "", url.toString());
+        onInput();
+    });
+    window.addEventListener("popstate", onInput);
+
+
+    let search, searchErr;
+
+    async function initialize() {
+        try {
+            search = await new Promise((resolve, reject) => {
+                const script = document.createElement("script");
+                script.type = "text/javascript";
+                script.async = true;
+                script.onload = () => resolve(window.pdocSearch);
+                script.onerror = (e) => reject(e);
+                script.src = "search.js";
+                document.getElementsByTagName("head")[0].appendChild(script);
+            });
+        } catch (e) {
+            console.error("Cannot fetch pdoc search index");
+            searchErr = "Cannot fetch search index.";
+        }
+        onInput();
+
+        document.querySelector("nav.pdoc").addEventListener("click", e => {
+            if (e.target.hash) {
+                searchBox.value = "";
+                searchBox.dispatchEvent(new Event("input"));
+            }
+        });
     }
 
     if (getSearchTerm()) {

--- a/test/testdata/demopackage_dir.html
+++ b/test/testdata/demopackage_dir.html
@@ -95,68 +95,15 @@ window.pdocSearch = (function(){
     const originalContent = document.querySelector(&quot;main.pdoc&quot;);
     let currentContent = originalContent;
 
-    function setContent(innerHTML) {
-        let elem;
-        if (innerHTML) {
-            elem = document.createElement(&quot;main&quot;);
-            elem.classList.add(&quot;pdoc&quot;);
-            elem.innerHTML = innerHTML;
-        } else {
-            elem = originalContent;
-        }
-        if (currentContent !== elem) {
-            currentContent.replaceWith(elem);
-            currentContent = elem;
-        }
+    function smooth(func) {
+        var timeout;
+        return function (...args) {
+            clearTimeout(timeout);
+            timeout = setTimeout(function() { func(...args); }, 300);
+        };
     }
 
-    function getSearchTerm() {
-        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
-    }
-
-    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
-    searchBox.addEventListener(&quot;input&quot;, function () {
-        let url = new URL(window.location);
-        if (searchBox.value.trim()) {
-            url.hash = &quot;&quot;;
-            url.searchParams.set(&quot;search&quot;, searchBox.value);
-        } else {
-            url.searchParams.delete(&quot;search&quot;);
-        }
-        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
-        onInput();
-    });
-    window.addEventListener(&quot;popstate&quot;, onInput);
-
-
-    let search, searchErr;
-
-    async function initialize() {
-        try {
-            search = await new Promise((resolve, reject) => {
-                const script = document.createElement(&quot;script&quot;);
-                script.type = &quot;text/javascript&quot;;
-                script.async = true;
-                script.onload = () => resolve(window.pdocSearch);
-                script.onerror = (e) => reject(e);
-                script.src = &quot;search.js&quot;;
-                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
-            });
-        } catch (e) {
-            console.error(&quot;Cannot fetch pdoc search index&quot;);
-            searchErr = &quot;Cannot fetch search index.&quot;;
-        }
-        onInput();
-
-        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
-            if (e.target.hash) {
-                searchBox.value = &quot;&quot;;
-                searchBox.dispatchEvent(new Event(&quot;input&quot;));
-            }
-        });
-    }
-
-    function onInput() {
+    const onInput = smooth(function () {
         setContent((() => {
             const term = getSearchTerm();
             if (!term) {
@@ -222,6 +169,67 @@ window.pdocSearch = (function(){
             }
             return html;
         })());
+    });
+
+    function setContent(innerHTML) {
+        let elem;
+        if (innerHTML) {
+            elem = document.createElement(&quot;main&quot;);
+            elem.classList.add(&quot;pdoc&quot;);
+            elem.innerHTML = innerHTML;
+        } else {
+            elem = originalContent;
+        }
+        if (currentContent !== elem) {
+            currentContent.replaceWith(elem);
+            currentContent = elem;
+        }
+    }
+
+    function getSearchTerm() {
+        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
+    }
+
+    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
+    searchBox.addEventListener(&quot;input&quot;, function () {
+        let url = new URL(window.location);
+        if (searchBox.value.trim()) {
+            url.hash = &quot;&quot;;
+            url.searchParams.set(&quot;search&quot;, searchBox.value);
+        } else {
+            url.searchParams.delete(&quot;search&quot;);
+        }
+        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
+        onInput();
+    });
+    window.addEventListener(&quot;popstate&quot;, onInput);
+
+
+    let search, searchErr;
+
+    async function initialize() {
+        try {
+            search = await new Promise((resolve, reject) => {
+                const script = document.createElement(&quot;script&quot;);
+                script.type = &quot;text/javascript&quot;;
+                script.async = true;
+                script.onload = () => resolve(window.pdocSearch);
+                script.onerror = (e) => reject(e);
+                script.src = &quot;search.js&quot;;
+                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
+            });
+        } catch (e) {
+            console.error(&quot;Cannot fetch pdoc search index&quot;);
+            searchErr = &quot;Cannot fetch search index.&quot;;
+        }
+        onInput();
+
+        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
+            if (e.target.hash) {
+                searchBox.value = &quot;&quot;;
+                searchBox.dispatchEvent(new Event(&quot;input&quot;));
+            }
+        });
     }
 
     if (getSearchTerm()) {
@@ -346,68 +354,15 @@ demopackage2    </h1>
     const originalContent = document.querySelector(&quot;main.pdoc&quot;);
     let currentContent = originalContent;
 
-    function setContent(innerHTML) {
-        let elem;
-        if (innerHTML) {
-            elem = document.createElement(&quot;main&quot;);
-            elem.classList.add(&quot;pdoc&quot;);
-            elem.innerHTML = innerHTML;
-        } else {
-            elem = originalContent;
-        }
-        if (currentContent !== elem) {
-            currentContent.replaceWith(elem);
-            currentContent = elem;
-        }
+    function smooth(func) {
+        var timeout;
+        return function (...args) {
+            clearTimeout(timeout);
+            timeout = setTimeout(function() { func(...args); }, 300);
+        };
     }
 
-    function getSearchTerm() {
-        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
-    }
-
-    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
-    searchBox.addEventListener(&quot;input&quot;, function () {
-        let url = new URL(window.location);
-        if (searchBox.value.trim()) {
-            url.hash = &quot;&quot;;
-            url.searchParams.set(&quot;search&quot;, searchBox.value);
-        } else {
-            url.searchParams.delete(&quot;search&quot;);
-        }
-        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
-        onInput();
-    });
-    window.addEventListener(&quot;popstate&quot;, onInput);
-
-
-    let search, searchErr;
-
-    async function initialize() {
-        try {
-            search = await new Promise((resolve, reject) => {
-                const script = document.createElement(&quot;script&quot;);
-                script.type = &quot;text/javascript&quot;;
-                script.async = true;
-                script.onload = () => resolve(window.pdocSearch);
-                script.onerror = (e) => reject(e);
-                script.src = &quot;search.js&quot;;
-                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
-            });
-        } catch (e) {
-            console.error(&quot;Cannot fetch pdoc search index&quot;);
-            searchErr = &quot;Cannot fetch search index.&quot;;
-        }
-        onInput();
-
-        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
-            if (e.target.hash) {
-                searchBox.value = &quot;&quot;;
-                searchBox.dispatchEvent(new Event(&quot;input&quot;));
-            }
-        });
-    }
-
-    function onInput() {
+    const onInput = smooth(function () {
         setContent((() => {
             const term = getSearchTerm();
             if (!term) {
@@ -473,6 +428,67 @@ demopackage2    </h1>
             }
             return html;
         })());
+    });
+
+    function setContent(innerHTML) {
+        let elem;
+        if (innerHTML) {
+            elem = document.createElement(&quot;main&quot;);
+            elem.classList.add(&quot;pdoc&quot;);
+            elem.innerHTML = innerHTML;
+        } else {
+            elem = originalContent;
+        }
+        if (currentContent !== elem) {
+            currentContent.replaceWith(elem);
+            currentContent = elem;
+        }
+    }
+
+    function getSearchTerm() {
+        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
+    }
+
+    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
+    searchBox.addEventListener(&quot;input&quot;, function () {
+        let url = new URL(window.location);
+        if (searchBox.value.trim()) {
+            url.hash = &quot;&quot;;
+            url.searchParams.set(&quot;search&quot;, searchBox.value);
+        } else {
+            url.searchParams.delete(&quot;search&quot;);
+        }
+        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
+        onInput();
+    });
+    window.addEventListener(&quot;popstate&quot;, onInput);
+
+
+    let search, searchErr;
+
+    async function initialize() {
+        try {
+            search = await new Promise((resolve, reject) => {
+                const script = document.createElement(&quot;script&quot;);
+                script.type = &quot;text/javascript&quot;;
+                script.async = true;
+                script.onload = () => resolve(window.pdocSearch);
+                script.onerror = (e) => reject(e);
+                script.src = &quot;search.js&quot;;
+                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
+            });
+        } catch (e) {
+            console.error(&quot;Cannot fetch pdoc search index&quot;);
+            searchErr = &quot;Cannot fetch search index.&quot;;
+        }
+        onInput();
+
+        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
+            if (e.target.hash) {
+                searchBox.value = &quot;&quot;;
+                searchBox.dispatchEvent(new Event(&quot;input&quot;));
+            }
+        });
     }
 
     if (getSearchTerm()) {
@@ -811,68 +827,15 @@ demopackage    </h1>
     const originalContent = document.querySelector(&quot;main.pdoc&quot;);
     let currentContent = originalContent;
 
-    function setContent(innerHTML) {
-        let elem;
-        if (innerHTML) {
-            elem = document.createElement(&quot;main&quot;);
-            elem.classList.add(&quot;pdoc&quot;);
-            elem.innerHTML = innerHTML;
-        } else {
-            elem = originalContent;
-        }
-        if (currentContent !== elem) {
-            currentContent.replaceWith(elem);
-            currentContent = elem;
-        }
+    function smooth(func) {
+        var timeout;
+        return function (...args) {
+            clearTimeout(timeout);
+            timeout = setTimeout(function() { func(...args); }, 300);
+        };
     }
 
-    function getSearchTerm() {
-        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
-    }
-
-    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
-    searchBox.addEventListener(&quot;input&quot;, function () {
-        let url = new URL(window.location);
-        if (searchBox.value.trim()) {
-            url.hash = &quot;&quot;;
-            url.searchParams.set(&quot;search&quot;, searchBox.value);
-        } else {
-            url.searchParams.delete(&quot;search&quot;);
-        }
-        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
-        onInput();
-    });
-    window.addEventListener(&quot;popstate&quot;, onInput);
-
-
-    let search, searchErr;
-
-    async function initialize() {
-        try {
-            search = await new Promise((resolve, reject) => {
-                const script = document.createElement(&quot;script&quot;);
-                script.type = &quot;text/javascript&quot;;
-                script.async = true;
-                script.onload = () => resolve(window.pdocSearch);
-                script.onerror = (e) => reject(e);
-                script.src = &quot;search.js&quot;;
-                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
-            });
-        } catch (e) {
-            console.error(&quot;Cannot fetch pdoc search index&quot;);
-            searchErr = &quot;Cannot fetch search index.&quot;;
-        }
-        onInput();
-
-        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
-            if (e.target.hash) {
-                searchBox.value = &quot;&quot;;
-                searchBox.dispatchEvent(new Event(&quot;input&quot;));
-            }
-        });
-    }
-
-    function onInput() {
+    const onInput = smooth(function () {
         setContent((() => {
             const term = getSearchTerm();
             if (!term) {
@@ -938,6 +901,67 @@ demopackage    </h1>
             }
             return html;
         })());
+    });
+
+    function setContent(innerHTML) {
+        let elem;
+        if (innerHTML) {
+            elem = document.createElement(&quot;main&quot;);
+            elem.classList.add(&quot;pdoc&quot;);
+            elem.innerHTML = innerHTML;
+        } else {
+            elem = originalContent;
+        }
+        if (currentContent !== elem) {
+            currentContent.replaceWith(elem);
+            currentContent = elem;
+        }
+    }
+
+    function getSearchTerm() {
+        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
+    }
+
+    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
+    searchBox.addEventListener(&quot;input&quot;, function () {
+        let url = new URL(window.location);
+        if (searchBox.value.trim()) {
+            url.hash = &quot;&quot;;
+            url.searchParams.set(&quot;search&quot;, searchBox.value);
+        } else {
+            url.searchParams.delete(&quot;search&quot;);
+        }
+        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
+        onInput();
+    });
+    window.addEventListener(&quot;popstate&quot;, onInput);
+
+
+    let search, searchErr;
+
+    async function initialize() {
+        try {
+            search = await new Promise((resolve, reject) => {
+                const script = document.createElement(&quot;script&quot;);
+                script.type = &quot;text/javascript&quot;;
+                script.async = true;
+                script.onload = () => resolve(window.pdocSearch);
+                script.onerror = (e) => reject(e);
+                script.src = &quot;search.js&quot;;
+                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
+            });
+        } catch (e) {
+            console.error(&quot;Cannot fetch pdoc search index&quot;);
+            searchErr = &quot;Cannot fetch search index.&quot;;
+        }
+        onInput();
+
+        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
+            if (e.target.hash) {
+                searchBox.value = &quot;&quot;;
+                searchBox.dispatchEvent(new Event(&quot;input&quot;));
+            }
+        });
     }
 
     if (getSearchTerm()) {
@@ -1130,68 +1154,15 @@ demopackage    </h1>
     const originalContent = document.querySelector(&quot;main.pdoc&quot;);
     let currentContent = originalContent;
 
-    function setContent(innerHTML) {
-        let elem;
-        if (innerHTML) {
-            elem = document.createElement(&quot;main&quot;);
-            elem.classList.add(&quot;pdoc&quot;);
-            elem.innerHTML = innerHTML;
-        } else {
-            elem = originalContent;
-        }
-        if (currentContent !== elem) {
-            currentContent.replaceWith(elem);
-            currentContent = elem;
-        }
+    function smooth(func) {
+        var timeout;
+        return function (...args) {
+            clearTimeout(timeout);
+            timeout = setTimeout(function() { func(...args); }, 300);
+        };
     }
 
-    function getSearchTerm() {
-        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
-    }
-
-    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
-    searchBox.addEventListener(&quot;input&quot;, function () {
-        let url = new URL(window.location);
-        if (searchBox.value.trim()) {
-            url.hash = &quot;&quot;;
-            url.searchParams.set(&quot;search&quot;, searchBox.value);
-        } else {
-            url.searchParams.delete(&quot;search&quot;);
-        }
-        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
-        onInput();
-    });
-    window.addEventListener(&quot;popstate&quot;, onInput);
-
-
-    let search, searchErr;
-
-    async function initialize() {
-        try {
-            search = await new Promise((resolve, reject) => {
-                const script = document.createElement(&quot;script&quot;);
-                script.type = &quot;text/javascript&quot;;
-                script.async = true;
-                script.onload = () => resolve(window.pdocSearch);
-                script.onerror = (e) => reject(e);
-                script.src = &quot;../search.js&quot;;
-                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
-            });
-        } catch (e) {
-            console.error(&quot;Cannot fetch pdoc search index&quot;);
-            searchErr = &quot;Cannot fetch search index.&quot;;
-        }
-        onInput();
-
-        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
-            if (e.target.hash) {
-                searchBox.value = &quot;&quot;;
-                searchBox.dispatchEvent(new Event(&quot;input&quot;));
-            }
-        });
-    }
-
-    function onInput() {
+    const onInput = smooth(function () {
         setContent((() => {
             const term = getSearchTerm();
             if (!term) {
@@ -1257,6 +1228,67 @@ demopackage    </h1>
             }
             return html;
         })());
+    });
+
+    function setContent(innerHTML) {
+        let elem;
+        if (innerHTML) {
+            elem = document.createElement(&quot;main&quot;);
+            elem.classList.add(&quot;pdoc&quot;);
+            elem.innerHTML = innerHTML;
+        } else {
+            elem = originalContent;
+        }
+        if (currentContent !== elem) {
+            currentContent.replaceWith(elem);
+            currentContent = elem;
+        }
+    }
+
+    function getSearchTerm() {
+        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
+    }
+
+    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
+    searchBox.addEventListener(&quot;input&quot;, function () {
+        let url = new URL(window.location);
+        if (searchBox.value.trim()) {
+            url.hash = &quot;&quot;;
+            url.searchParams.set(&quot;search&quot;, searchBox.value);
+        } else {
+            url.searchParams.delete(&quot;search&quot;);
+        }
+        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
+        onInput();
+    });
+    window.addEventListener(&quot;popstate&quot;, onInput);
+
+
+    let search, searchErr;
+
+    async function initialize() {
+        try {
+            search = await new Promise((resolve, reject) => {
+                const script = document.createElement(&quot;script&quot;);
+                script.type = &quot;text/javascript&quot;;
+                script.async = true;
+                script.onload = () => resolve(window.pdocSearch);
+                script.onerror = (e) => reject(e);
+                script.src = &quot;../search.js&quot;;
+                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
+            });
+        } catch (e) {
+            console.error(&quot;Cannot fetch pdoc search index&quot;);
+            searchErr = &quot;Cannot fetch search index.&quot;;
+        }
+        onInput();
+
+        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
+            if (e.target.hash) {
+                searchBox.value = &quot;&quot;;
+                searchBox.dispatchEvent(new Event(&quot;input&quot;));
+            }
+        });
     }
 
     if (getSearchTerm()) {
@@ -1463,68 +1495,15 @@ demopackage    </h1>
     const originalContent = document.querySelector(&quot;main.pdoc&quot;);
     let currentContent = originalContent;
 
-    function setContent(innerHTML) {
-        let elem;
-        if (innerHTML) {
-            elem = document.createElement(&quot;main&quot;);
-            elem.classList.add(&quot;pdoc&quot;);
-            elem.innerHTML = innerHTML;
-        } else {
-            elem = originalContent;
-        }
-        if (currentContent !== elem) {
-            currentContent.replaceWith(elem);
-            currentContent = elem;
-        }
+    function smooth(func) {
+        var timeout;
+        return function (...args) {
+            clearTimeout(timeout);
+            timeout = setTimeout(function() { func(...args); }, 300);
+        };
     }
 
-    function getSearchTerm() {
-        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
-    }
-
-    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
-    searchBox.addEventListener(&quot;input&quot;, function () {
-        let url = new URL(window.location);
-        if (searchBox.value.trim()) {
-            url.hash = &quot;&quot;;
-            url.searchParams.set(&quot;search&quot;, searchBox.value);
-        } else {
-            url.searchParams.delete(&quot;search&quot;);
-        }
-        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
-        onInput();
-    });
-    window.addEventListener(&quot;popstate&quot;, onInput);
-
-
-    let search, searchErr;
-
-    async function initialize() {
-        try {
-            search = await new Promise((resolve, reject) => {
-                const script = document.createElement(&quot;script&quot;);
-                script.type = &quot;text/javascript&quot;;
-                script.async = true;
-                script.onload = () => resolve(window.pdocSearch);
-                script.onerror = (e) => reject(e);
-                script.src = &quot;../search.js&quot;;
-                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
-            });
-        } catch (e) {
-            console.error(&quot;Cannot fetch pdoc search index&quot;);
-            searchErr = &quot;Cannot fetch search index.&quot;;
-        }
-        onInput();
-
-        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
-            if (e.target.hash) {
-                searchBox.value = &quot;&quot;;
-                searchBox.dispatchEvent(new Event(&quot;input&quot;));
-            }
-        });
-    }
-
-    function onInput() {
+    const onInput = smooth(function () {
         setContent((() => {
             const term = getSearchTerm();
             if (!term) {
@@ -1590,6 +1569,67 @@ demopackage    </h1>
             }
             return html;
         })());
+    });
+
+    function setContent(innerHTML) {
+        let elem;
+        if (innerHTML) {
+            elem = document.createElement(&quot;main&quot;);
+            elem.classList.add(&quot;pdoc&quot;);
+            elem.innerHTML = innerHTML;
+        } else {
+            elem = originalContent;
+        }
+        if (currentContent !== elem) {
+            currentContent.replaceWith(elem);
+            currentContent = elem;
+        }
+    }
+
+    function getSearchTerm() {
+        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
+    }
+
+    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
+    searchBox.addEventListener(&quot;input&quot;, function () {
+        let url = new URL(window.location);
+        if (searchBox.value.trim()) {
+            url.hash = &quot;&quot;;
+            url.searchParams.set(&quot;search&quot;, searchBox.value);
+        } else {
+            url.searchParams.delete(&quot;search&quot;);
+        }
+        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
+        onInput();
+    });
+    window.addEventListener(&quot;popstate&quot;, onInput);
+
+
+    let search, searchErr;
+
+    async function initialize() {
+        try {
+            search = await new Promise((resolve, reject) => {
+                const script = document.createElement(&quot;script&quot;);
+                script.type = &quot;text/javascript&quot;;
+                script.async = true;
+                script.onload = () => resolve(window.pdocSearch);
+                script.onerror = (e) => reject(e);
+                script.src = &quot;../search.js&quot;;
+                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
+            });
+        } catch (e) {
+            console.error(&quot;Cannot fetch pdoc search index&quot;);
+            searchErr = &quot;Cannot fetch search index.&quot;;
+        }
+        onInput();
+
+        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
+            if (e.target.hash) {
+                searchBox.value = &quot;&quot;;
+                searchBox.dispatchEvent(new Event(&quot;input&quot;));
+            }
+        });
     }
 
     if (getSearchTerm()) {
@@ -1708,68 +1748,15 @@ demopackage    </h1>
     const originalContent = document.querySelector(&quot;main.pdoc&quot;);
     let currentContent = originalContent;
 
-    function setContent(innerHTML) {
-        let elem;
-        if (innerHTML) {
-            elem = document.createElement(&quot;main&quot;);
-            elem.classList.add(&quot;pdoc&quot;);
-            elem.innerHTML = innerHTML;
-        } else {
-            elem = originalContent;
-        }
-        if (currentContent !== elem) {
-            currentContent.replaceWith(elem);
-            currentContent = elem;
-        }
+    function smooth(func) {
+        var timeout;
+        return function (...args) {
+            clearTimeout(timeout);
+            timeout = setTimeout(function() { func(...args); }, 300);
+        };
     }
 
-    function getSearchTerm() {
-        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
-    }
-
-    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
-    searchBox.addEventListener(&quot;input&quot;, function () {
-        let url = new URL(window.location);
-        if (searchBox.value.trim()) {
-            url.hash = &quot;&quot;;
-            url.searchParams.set(&quot;search&quot;, searchBox.value);
-        } else {
-            url.searchParams.delete(&quot;search&quot;);
-        }
-        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
-        onInput();
-    });
-    window.addEventListener(&quot;popstate&quot;, onInput);
-
-
-    let search, searchErr;
-
-    async function initialize() {
-        try {
-            search = await new Promise((resolve, reject) => {
-                const script = document.createElement(&quot;script&quot;);
-                script.type = &quot;text/javascript&quot;;
-                script.async = true;
-                script.onload = () => resolve(window.pdocSearch);
-                script.onerror = (e) => reject(e);
-                script.src = &quot;../search.js&quot;;
-                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
-            });
-        } catch (e) {
-            console.error(&quot;Cannot fetch pdoc search index&quot;);
-            searchErr = &quot;Cannot fetch search index.&quot;;
-        }
-        onInput();
-
-        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
-            if (e.target.hash) {
-                searchBox.value = &quot;&quot;;
-                searchBox.dispatchEvent(new Event(&quot;input&quot;));
-            }
-        });
-    }
-
-    function onInput() {
+    const onInput = smooth(function () {
         setContent((() => {
             const term = getSearchTerm();
             if (!term) {
@@ -1835,6 +1822,67 @@ demopackage    </h1>
             }
             return html;
         })());
+    });
+
+    function setContent(innerHTML) {
+        let elem;
+        if (innerHTML) {
+            elem = document.createElement(&quot;main&quot;);
+            elem.classList.add(&quot;pdoc&quot;);
+            elem.innerHTML = innerHTML;
+        } else {
+            elem = originalContent;
+        }
+        if (currentContent !== elem) {
+            currentContent.replaceWith(elem);
+            currentContent = elem;
+        }
+    }
+
+    function getSearchTerm() {
+        return (new URL(window.location)).searchParams.get(&quot;search&quot;);
+    }
+
+    const searchBox = document.querySelector(&quot;.pdoc input[type=search]&quot;);
+    searchBox.addEventListener(&quot;input&quot;, function () {
+        let url = new URL(window.location);
+        if (searchBox.value.trim()) {
+            url.hash = &quot;&quot;;
+            url.searchParams.set(&quot;search&quot;, searchBox.value);
+        } else {
+            url.searchParams.delete(&quot;search&quot;);
+        }
+        history.replaceState(&quot;&quot;, &quot;&quot;, url.toString());
+        onInput();
+    });
+    window.addEventListener(&quot;popstate&quot;, onInput);
+
+
+    let search, searchErr;
+
+    async function initialize() {
+        try {
+            search = await new Promise((resolve, reject) => {
+                const script = document.createElement(&quot;script&quot;);
+                script.type = &quot;text/javascript&quot;;
+                script.async = true;
+                script.onload = () => resolve(window.pdocSearch);
+                script.onerror = (e) => reject(e);
+                script.src = &quot;../search.js&quot;;
+                document.getElementsByTagName(&quot;head&quot;)[0].appendChild(script);
+            });
+        } catch (e) {
+            console.error(&quot;Cannot fetch pdoc search index&quot;);
+            searchErr = &quot;Cannot fetch search index.&quot;;
+        }
+        onInput();
+
+        document.querySelector(&quot;nav.pdoc&quot;).addEventListener(&quot;click&quot;, e => {
+            if (e.target.hash) {
+                searchBox.value = &quot;&quot;;
+                searchBox.dispatchEvent(new Event(&quot;input&quot;));
+            }
+        });
     }
 
     if (getSearchTerm()) {


### PR DESCRIPTION
HTML pages, representing modules, include search bar, which replaces all module contents with search results. This cause browser freezes on big modules (example: https://docs.ballistica.net/api7/ba.html, freezes are noticeable when typing first character or when clearing search bar). 

This PR improves this aspect in fact that DOM reflow (which causes freeze) won't happen in the middle of typing the query.

Any ideas, suggestions, etc? Took the 300ms constant out if thin air. Not a JS expert but this seems to be working.