### PR TITLE
Added parsing of `code-block` ReST directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 <!-- ✨ You do not need to add a pull request reference or an author, this will be added automatically by CI. ✨ -->
 
+ - Add support for `code-block` ReST directives
  - If a variable's value meets certain entropy criteria and matches an environment variable value,
    pdoc will now emit a warning and display the variable's name as a placeholder instead.
    This heuristic is meant to prevent accidental leakage of environment secrets and can be disabled by setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- ✨ You do not need to add a pull request reference or an author, this will be added automatically by CI. ✨ -->
 
  - Add support for `code-block` ReST directives
+   ([#624](https://github.com/mitmproxy/pdoc/pull/624), @JCGoran)
  - If a variable's value meets certain entropy criteria and matches an environment variable value,
    pdoc will now emit a warning and display the variable's name as a placeholder instead.
    This heuristic is meant to prevent accidental leakage of environment secrets and can be disabled by setting

--- a/pdoc/docstrings.py
+++ b/pdoc/docstrings.py
@@ -393,7 +393,9 @@ def _rst_admonitions(contents: str, source_file: Path | None) -> str:
                 f"{indent(contents, ind)}\n"
                 f"{ind}</div>\n"
             )
-        elif type == "versionadded":
+        if type == "code-block":
+            return f"{ind}```{val}\n{contents}\n```\n"
+        if type == "versionadded":
             text = f"New in version {val}"
         elif type == "versionchanged":
             text = f"Changed in version {val}"
@@ -409,7 +411,7 @@ def _rst_admonitions(contents: str, source_file: Path | None) -> str:
 
         return text
 
-    admonition = "note|warning|danger|versionadded|versionchanged|deprecated|seealso|math|include"
+    admonition = "note|warning|danger|versionadded|versionchanged|deprecated|seealso|math|include|code-block"
     return re.sub(
         rf"""
             ^(?P<indent>[ ]*)\.\.[ ]+(?P<type>{admonition})::(?P<val>.*)


### PR DESCRIPTION
Added simple parsing of `code-block` ReST directives, mainly for compatibility purposes with Sphinx. While in Sphinx there seem to be multiple options for writing down blocks of code, the `code-block` one looks like the one which is, structure-wise, the most similar to Markdown's triple backticks.