### PR TITLE
docs: mention that search is only active for 2+ pages

### DIFF
--- a/pdoc/__main__.py
+++ b/pdoc/__main__.py
@@ -112,7 +112,7 @@ renderopts.add_argument(
     "--search",
     action=BooleanOptionalAction,
     default=True,
-    help="Enable search functionality.",
+    help="Enable search functionality if multiple modules are documented.",
 )
 renderopts.add_argument(
     "--show-source",

--- a/pdoc/search.py
+++ b/pdoc/search.py
@@ -5,6 +5,11 @@ and works without any third-party services in a privacy-preserving way. When a u
 search box for the first time, pdoc will fetch the search index (`search.js`) and use that to
 answer all upcoming queries.
 
+##### Single-Page Documentation
+
+If pdoc is documenting a single module only, search functionality will be disabled.
+The browser's built-in search functionality will provide a better user experience in these cases.
+
 ##### Search Coverage
 
 The search functionality covers all documented elements and their docstrings.


### PR DESCRIPTION
closes #629