### PR TITLE
Docs: clarify that include requires extra escapes

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -281,6 +281,7 @@ You can include external Markdown files in your documentation by using reStructu
 ```
 
 Since version 11, pdoc processes such reStructuredText elements by default.
+This will process your Markdown file as a Python string, meaning extra backslashes for escape might be required (e.g. linebreaks \\ -> \\\)
 
 
 ## ...add a title page?


### PR DESCRIPTION
Including a markdown via `.. include::` results in the markdown requiring \\\ instead of \\ in multiline maths. 
This seems to stem from the escape in Markdown being processed as a string. 
I wouldn't call it a bug, but thought the behavior should probably be documented. Confused me for a while, so here is a hopefully well-understood documentation of it.