### PR TITLE
get source_file of wrapped functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased: pdoc next
 
+ - pdoc now correctly extracts the source_file of wrapped functions.
 
 ## 2023-12-22: pdoc 14.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased: pdoc next
 
  - pdoc now correctly extracts the source_file of wrapped functions.
+   ([#657](https://github.com/mitmproxy/pdoc/pull/657), @tmeyier)
 
 ## 2023-12-22: pdoc 14.3.0
 

--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -172,10 +172,7 @@ class Doc(Generic[T]):
     @cached_property
     def source_file(self) -> Path | None:
         """The name of the Python source file in which this object was defined. `None` for built-in objects."""
-        try:
-            return Path(inspect.getsourcefile(self.obj) or inspect.getfile(self.obj))  # type: ignore
-        except TypeError:
-            return None
+        return doc_ast.get_source_file(self.obj)
 
     @cached_property
     def source_lines(self) -> tuple[int, int] | None:

--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -172,7 +172,10 @@ class Doc(Generic[T]):
     @cached_property
     def source_file(self) -> Path | None:
         """The name of the Python source file in which this object was defined. `None` for built-in objects."""
-        return doc_ast.get_source_file(self.obj)
+        try:
+            return Path(inspect.getsourcefile(self.obj) or inspect.getfile(self.obj))  # type: ignore
+        except TypeError:
+            return None
 
     @cached_property
     def source_lines(self) -> tuple[int, int] | None:
@@ -884,6 +887,8 @@ class Function(Doc[types.FunctionType]):
             unwrapped = func.__func__  # type: ignore
         elif isinstance(func, singledispatchmethod):
             unwrapped = func.func  # type: ignore
+        elif hasattr(func, "__wrapped__"):
+            unwrapped = func.__wrapped__
         else:
             unwrapped = func
         super().__init__(modulename, qualname, unwrapped, taken_from)

--- a/pdoc/doc_ast.py
+++ b/pdoc/doc_ast.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 import inspect
 from itertools import tee
 from itertools import zip_longest
-from pathlib import Path
 import types
 from typing import TYPE_CHECKING
 from typing import Any
@@ -50,34 +49,6 @@ def _get_source(obj: Any) -> str:
         return inspect.getsource(obj)
     except Exception:
         return ""
-
-
-def get_source_file(obj: Any) -> Path | None:
-    """
-    Returns the source code of the Python object `obj` as a str.
-    This tries to first unwrap the method if it is wrapped and then calls `inspect.getsource`.
-
-    If this fails, an empty string is returned.
-    """
-    # Some objects may not be hashable, so we fall back to the non-cached version if that is the case.
-    try:
-        return _get_source_file(obj)
-    except TypeError:
-        return _get_source_file.__wrapped__(obj)
-
-
-@cache
-def _get_source_file(obj: Any) -> Path | None:
-    try:
-        return Path(inspect.getsourcefile(obj) or inspect.getfile(obj))  # type: ignore
-    except TypeError:
-        try:
-            return Path(
-                inspect.getsourcefile(obj.__wrapped__)
-                or inspect.getfile(obj.__wrapped__)
-            )  # type: ignore
-        except Exception:
-            return None
 
 
 @overload

--- a/pdoc/doc_ast.py
+++ b/pdoc/doc_ast.py
@@ -10,9 +10,9 @@ from collections.abc import Iterable
 from collections.abc import Iterator
 from dataclasses import dataclass
 import inspect
-from pathlib import Path
 from itertools import tee
 from itertools import zip_longest
+from pathlib import Path
 import types
 from typing import TYPE_CHECKING
 from typing import Any
@@ -72,7 +72,10 @@ def _get_source_file(obj: Any) -> Path | None:
         return Path(inspect.getsourcefile(obj) or inspect.getfile(obj))  # type: ignore
     except TypeError:
         try:
-            return Path(inspect.getsourcefile(obj.__wrapped__) or inspect.getfile(obj.__wrapped__))  # type: ignore
+            return Path(
+                inspect.getsourcefile(obj.__wrapped__)
+                or inspect.getfile(obj.__wrapped__)
+            )  # type: ignore
         except Exception:
             return None
 

--- a/pdoc/doc_ast.py
+++ b/pdoc/doc_ast.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 from collections.abc import Iterator
 from dataclasses import dataclass
 import inspect
+from pathlib import Path
 from itertools import tee
 from itertools import zip_longest
 import types
@@ -49,6 +50,31 @@ def _get_source(obj: Any) -> str:
         return inspect.getsource(obj)
     except Exception:
         return ""
+
+
+def get_source_file(obj: Any) -> Path | None:
+    """
+    Returns the source code of the Python object `obj` as a str.
+    This tries to first unwrap the method if it is wrapped and then calls `inspect.getsource`.
+
+    If this fails, an empty string is returned.
+    """
+    # Some objects may not be hashable, so we fall back to the non-cached version if that is the case.
+    try:
+        return _get_source_file(obj)
+    except TypeError:
+        return _get_source_file.__wrapped__(obj)
+
+
+@cache
+def _get_source_file(obj: Any) -> Path | None:
+    try:
+        return Path(inspect.getsourcefile(obj) or inspect.getfile(obj))  # type: ignore
+    except TypeError:
+        try:
+            return Path(inspect.getsourcefile(obj.__wrapped__) or inspect.getfile(obj.__wrapped__))  # type: ignore
+        except Exception:
+            return None
 
 
 @overload

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -175,3 +175,13 @@ def test_default_value_masks_env_vars(monkeypatch):
         assert v2.default_value_str == "'42.0.1'"
     finally:
         _environ_lookup.cache_clear()
+
+
+def test_source_file_method():
+    mod = extract.load_module(extract.parse_spec(here / "testdata" / "demo_long.py"))
+
+    m = Module(mod)
+
+    assert m.members["Foo"].members["a_cached_function"].source_file == (
+        here / "testdata" / "demo_long.py"
+    )


### PR DESCRIPTION
I added a function get_source_file to doc_ast.py that tries to get the source file from obj.__wrapped__ if inspect.getsourcefile(obj) doesn't succeed.
I used the same cached approach as in doc_ast.get_source.

closes #656 

