### PR TITLE
add overflow-y: hidden to mathjax containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support type-hints from stub-only packages. E.g: `scipy-stubs`
   ([#671](https://github.com/mitmproxy/pdoc/pull/671), @erikdesmedt)
 - Modify css styles for MathJax to remove unnessesary scroll bars
+  ([#675](https://github.com/mitmproxy/pdoc/pull/675), @thehappycheese)
 
 ## 2024-01-18: pdoc 14.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support type-hints from stub-only packages. E.g: `scipy-stubs`
   ([#671](https://github.com/mitmproxy/pdoc/pull/671), @erikdesmedt)
+- Modify css styles for MathJax to remove unnessesary scroll bars
 
 ## 2024-01-18: pdoc 14.4.0
 

--- a/pdoc/templates/math.html.jinja2
+++ b/pdoc/templates/math.html.jinja2
@@ -24,5 +24,6 @@
 <style>
     mjx-container {
         overflow-x: auto;
+        overflow-y: hidden;
     }
 </style>

--- a/test/testdata/math_demo.html
+++ b/test/testdata/math_demo.html
@@ -32,6 +32,7 @@
 <style>
     mjx-container {
         overflow-x: auto;
+        overflow-y: hidden;
     }
 </style></head>
 <body>

--- a/test/testdata/math_misc.html
+++ b/test/testdata/math_misc.html
@@ -32,6 +32,7 @@
 <style>
     mjx-container {
         overflow-x: auto;
+        overflow-y: hidden;
     }
 </style></head>
 <body>


### PR DESCRIPTION

closes #674 

Adds `overflow-y:hidden` to the mathjax container template CSS.

This removes unnesisary vertical scroll bars that show up in Chrome and Edge when `overflow-x` is set to `auto`, particularly for multi-line display mode math blocks.

<details>

<summary>Click Here to expand source code for images below</summary>

`test_module.py`:
```python
r"""
# Inline math tests

this is an $i=n$ line math expression

# Single line display mode

Long (always needs horizontal scroll)

$$
5a^3b^2 - 2b^4c + 7c^2d^3e - 3d^2ef^2 + 6e^3f - 4a^2f^3 + 9a^4bc^2 - 8b^3d^2e^2 + 3c^5de - 7d^3e^4f + 2a^2b^2c^3 - 6b^5df^2 + 4c^3d^4e^2 - 9d^2e^3f^3 + 5a^3cf^4 - 2b^2d^5e + 8c^4d^2f - 6a^5be^3 + 7b^3c^2d^3
$$

Short (never needs scroll)

$$
5a^3b^2 - 2b^4c + 7c^2d^3e - 3d^2ef^2
$$

# Multi line display mode

$$
\\begin{align}
2x^2 + 3y - 7z &= 5 \\\\
11 &= 4x - 6y^3 + 2z^2 + 5a^3b^2 - 2b^4c + 7c^2d^3e - 3d^2ef^2 + 6e^3f - 4a^2f^3 \\\\
9x^3 - 5y^2 + z &= 3
\\end{align}
$$

"""
```

</details>

### Before

![image](https://github.com/mitmproxy/pdoc/assets/2748120/67384bed-7431-4b18-8de4-f12cf9b1aaa2)

### After

![image](https://github.com/mitmproxy/pdoc/assets/2748120/3ca10e95-a29f-4155-9e49-5732f74feabf)
