### PR TITLE
Supply an empty name to `ast.ClassDef` and `ast.FunctionDef`

### DIFF
--- a/pdoc/doc_ast.py
+++ b/pdoc/doc_ast.py
@@ -245,7 +245,7 @@ def _parse_class(source: str) -> ast.ClassDef:
         t = tree.body[0]
         assert isinstance(t, ast.ClassDef)
         return t
-    return ast.ClassDef(body=[], decorator_list=[])  # type: ignore
+    return ast.ClassDef(name="", body=[], decorator_list=[])  # type: ignore
 
 
 @cache
@@ -265,7 +265,7 @@ def _parse_function(source: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
             # we have a lambda function,
             # to simplify the API return the ast.FunctionDef stub.
             pass
-    return ast.FunctionDef(body=[], decorator_list=[])  # type: ignore
+    return ast.FunctionDef(name="", body=[], decorator_list=[])  # type: ignore
 
 
 def _parse(


### PR DESCRIPTION
Python 3.13 appears to be deprecating not providing the name parameter for `ast.ClassDef`, this patch provides an empty string as a name when an empty `ast.ClassDef` or `ast.FunctionDef` is created.

See:
https://github.com/MazinLab/binney/actions/runs/10627764750/job/29462165838#step:5:310

Signed-off-by: Aled Cuda <aled@ucsb.edu>