### PR TITLE
fix(#753): API documentation for `unittest.mock`

### DIFF
--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -445,7 +445,7 @@ class Module(Namespace[types.ModuleType]):
 
         mod = _safe_getattr(obj, "__module__", None)
         qual = _safe_getattr(obj, "__qualname__", None)
-        if mod and hasattr(qual, "__contains__") and "<locals>" not in qual:
+        if mod and isinstance(qual, str) and "<locals>" not in qual:
             return mod, qual
         else:
             # This might be wrong, but it's the best guess we have.

--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -445,7 +445,7 @@ class Module(Namespace[types.ModuleType]):
 
         mod = _safe_getattr(obj, "__module__", None)
         qual = _safe_getattr(obj, "__qualname__", None)
-        if mod and qual and "<locals>" not in qual:
+        if mod and hasattr(qual, "__contains__") and "<locals>" not in qual:
             return mod, qual
         else:
             # This might be wrong, but it's the best guess we have.

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -12,7 +12,7 @@ modules = [
     m.name
     for m in pkgutil.iter_modules()
     if not m.name.startswith("_") and m.name not in ("test", "idlelib", "py")
-]
+] + ["unittest.mock"]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
# Closes #753 

Resolve the `TypeError` by testing for the `__contains__` attribute