### PR TITLE
docs: correct link to Google usage example

### DIFF
--- a/docs/index.html.jinja2
+++ b/docs/index.html.jinja2
@@ -260,7 +260,7 @@
     </a>
 
     <div id="testimonials" class="mt-5">
-        <a href="https://google.github.io/or-tools/">
+        <a href="https://or-tools.github.io/docs/pdoc/">
             <img src="data:image/svg+xml,{% filter urlencode %}{% include "resources/used-by-logos/google.svg" %}{% endfilter %}"
                  alt="Google" width="89" height="30"  style="margin-top: 6px"></a>
         <a href="https://github.com/microsoft/LMChallenge">


### PR DESCRIPTION
This PR updates the URL of the Google usage example at the foot of `https://pdoc.dev/` to new location at `https://or-tools.github.io/docs/pdoc/`.