### PR TITLE
Update CDN location of mermaid from v10 to v11

### DIFF
--- a/pdoc/templates/mermaid.html.jinja2
+++ b/pdoc/templates/mermaid.html.jinja2
@@ -6,7 +6,7 @@
     }
 </style>
 <script type="module" defer>
-    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
 
     /* Re-invoke Mermaid when DOM content changes, for example during search. */
     document.addEventListener("DOMContentLoaded", () => {

--- a/test/testdata/mermaid_demo.html
+++ b/test/testdata/mermaid_demo.html
@@ -18,7 +18,7 @@
     }
 </style>
 <script type="module" defer>
-    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
 
     /* Re-invoke Mermaid when DOM content changes, for example during search. */
     document.addEventListener("DOMContentLoaded", () => {
@@ -140,7 +140,7 @@ mermaid_demo    </h1>
                 <section id="Pet">
                             <input id="Pet-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
 <div class="attr class">
-            
+
     <span class="def">class</span>
     <span class="name">Pet</span>:
 
@@ -161,12 +161,12 @@ mermaid_demo    </h1>
 </span></pre></div>
 
 
-    
+
 
                             <div id="Pet.__init__" class="classattr">
                                         <input id="Pet.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
 <div class="attr function">
-            
+
         <span class="name">Pet</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">name</span><span class="p">:</span> <span class="nb">str</span></span>)</span>
 
                 <label class="view-source-button" for="Pet.__init__-view-source"><span>View Source</span></label>
@@ -189,10 +189,10 @@ mermaid_demo    </h1>
                                 <div class="attr variable">
             <span class="name">name</span><span class="annotation">: str</span>
 
-        
+
     </div>
     <a class="headerlink" href="#Pet.name"></a>
-    
+
             <div class="docstring"><p>The name of our pet.</p>
 </div>
 
@@ -202,10 +202,10 @@ mermaid_demo    </h1>
                                 <div class="attr variable">
             <span class="name">friends</span><span class="annotation">: list[<a href="#Pet">Pet</a>]</span>
 
-        
+
     </div>
     <a class="headerlink" href="#Pet.friends"></a>
-    
+
             <div class="docstring"><p>The friends of our pet.</p>
 </div>
 
@@ -215,7 +215,7 @@ mermaid_demo    </h1>
                 <section id="Dog">
                             <input id="Dog-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
 <div class="attr class">
-            
+
     <span class="def">class</span>
     <span class="name">Dog</span><wbr>(<span class="base"><a href="#Pet">Pet</a></span>):
 
@@ -238,7 +238,7 @@ mermaid_demo    </h1>
                             <div id="Dog.bark" class="classattr">
                                         <input id="Dog.bark-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
 <div class="attr function">
-            
+
         <span class="def">def</span>
         <span class="name">bark</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span>, </span><span class="param"><span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span></span><span class="return-annotation">):</span></span>
 

--- a/test/testdata/mermaid_demo.html
+++ b/test/testdata/mermaid_demo.html
@@ -140,7 +140,7 @@ mermaid_demo    </h1>
                 <section id="Pet">
                             <input id="Pet-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
 <div class="attr class">
-
+            
     <span class="def">class</span>
     <span class="name">Pet</span>:
 
@@ -161,12 +161,12 @@ mermaid_demo    </h1>
 </span></pre></div>
 
 
-
+    
 
                             <div id="Pet.__init__" class="classattr">
                                         <input id="Pet.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
 <div class="attr function">
-
+            
         <span class="name">Pet</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">name</span><span class="p">:</span> <span class="nb">str</span></span>)</span>
 
                 <label class="view-source-button" for="Pet.__init__-view-source"><span>View Source</span></label>
@@ -189,10 +189,10 @@ mermaid_demo    </h1>
                                 <div class="attr variable">
             <span class="name">name</span><span class="annotation">: str</span>
 
-
+        
     </div>
     <a class="headerlink" href="#Pet.name"></a>
-
+    
             <div class="docstring"><p>The name of our pet.</p>
 </div>
 
@@ -202,10 +202,10 @@ mermaid_demo    </h1>
                                 <div class="attr variable">
             <span class="name">friends</span><span class="annotation">: list[<a href="#Pet">Pet</a>]</span>
 
-
+        
     </div>
     <a class="headerlink" href="#Pet.friends"></a>
-
+    
             <div class="docstring"><p>The friends of our pet.</p>
 </div>
 
@@ -215,7 +215,7 @@ mermaid_demo    </h1>
                 <section id="Dog">
                             <input id="Dog-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
 <div class="attr class">
-
+            
     <span class="def">class</span>
     <span class="name">Dog</span><wbr>(<span class="base"><a href="#Pet">Pet</a></span>):
 
@@ -238,7 +238,7 @@ mermaid_demo    </h1>
                             <div id="Dog.bark" class="classattr">
                                         <input id="Dog.bark-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
 <div class="attr function">
-
+            
         <span class="def">def</span>
         <span class="name">bark</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span>, </span><span class="param"><span class="n">loud</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span></span><span class="return-annotation">):</span></span>
 


### PR DESCRIPTION
I discovered your product and it is awesome. However noticed that mermaid (one of the awesome features you provide) is on `v10`. This will bring it up to `v11`. In the tests I ran for rendering mermaid documents it supports the upgraded mermaid syntax / styling.