### PR TITLE
Fix TypeError when cls.__module__ is None

### DIFF
--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -637,7 +637,7 @@ class Class(Namespace[type]):
                 for attr, unresolved_annotation in dynamic_annotations.items():
                     cls_annotations[attr] = unresolved_annotation
             cls_fullname = (
-                _safe_getattr(cls, "__module__", "") + "." + cls.__qualname__
+                _safe_getattr(cls, "__module__", "") or "" + "." + cls.__qualname__
             ).lstrip(".")
 
             new_annotations = {

--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -637,7 +637,7 @@ class Class(Namespace[type]):
                 for attr, unresolved_annotation in dynamic_annotations.items():
                     cls_annotations[attr] = unresolved_annotation
             cls_fullname = (
-                _safe_getattr(cls, "__module__", "") or "" + "." + cls.__qualname__
+                (_safe_getattr(cls, "__module__", "") or "") + "." + cls.__qualname__
             ).lstrip(".")
 
             new_annotations = {


### PR DESCRIPTION
Trying to use `pdoc -o` instead of `pdoc` in my project caused a long stacktrace with this error at the end:

    File "/Users/feuh/.../.venv/lib/python3.12/site-packages/pdoc/doc.py", line 640, in _var_annotations
        _safe_getattr(cls, "__module__", "") + "." + cls.__qualname__
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
    TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

This was caused by one class' `__module__` attribute being `None`.

I could not find the reason why that happens and why it happens only when using `-o`, but this change ensures it won't be a problem again.