### PR TITLE
Prevent infinite recursion in nested derived classes

### DIFF
--- a/pdoc/doc_pyi.py
+++ b/pdoc/doc_pyi.py
@@ -77,7 +77,8 @@ def _prepare_module(ns: doc.Namespace) -> None:
 
     # at the moment, .members is the only lazy property that is accessed.
     for member in ns.members.values():
-        if isinstance(member, doc.Class):
+        # prevent infinite recursion for nested classes derived from the outer class
+        if isinstance(member, doc.Class) and not member.is_inherited:
             _prepare_module(member)
 
 


### PR DESCRIPTION
Python syntax does not allow nesting derived classes into the base class, but compiled extension modules can effectively create class hierarchies like this:

```python
class MyEnum:
    class A(MyEnum):
        a: int
    class B(MyEnum):
        b: int
```

Resolves issue #868