### PR TITLE
Add 'View Source' button to top-level constants

### DIFF
--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -327,6 +327,23 @@ class Namespace(Doc[U], metaclass=ABCMeta):
                     taken_from=taken_from,
                 )
 
+            if isinstance(doc, Variable) and not is_property:
+                _ast_info = doc_ast.walk_tree(self.obj)
+                if name in _ast_info.var_source_lines:
+                    start, end = _ast_info.var_source_lines[name]
+                    parent_source = doc_ast.get_source(self.obj)
+                    if parent_source:
+                        src_lines = parent_source.splitlines(True)
+                        doc.source = "".join(src_lines[start - 1 : end])
+                        parent_start = (
+                            self.source_lines[0] if self.source_lines else 1
+                        )
+                        doc.source_lines = (
+                            parent_start + start - 1,
+                            parent_start + end - 1,
+                        )
+                        doc.source_file = self.source_file
+
             if _doc := _pydantic.get_field_docstring(cast(type, self.obj), name):
                 doc.docstring = _doc
             elif self._var_docstrings.get(name):

--- a/pdoc/doc.py
+++ b/pdoc/doc.py
@@ -335,9 +335,7 @@ class Namespace(Doc[U], metaclass=ABCMeta):
                     if parent_source:
                         src_lines = parent_source.splitlines(True)
                         doc.source = "".join(src_lines[start - 1 : end])
-                        parent_start = (
-                            self.source_lines[0] if self.source_lines else 1
-                        )
+                        parent_start = self.source_lines[0] if self.source_lines else 1
                         doc.source_lines = (
                             parent_start + start - 1,
                             parent_start + end - 1,

--- a/pdoc/doc_ast.py
+++ b/pdoc/doc_ast.py
@@ -93,8 +93,12 @@ class AstInfo:
     """A qualname -> docstring mapping for functions."""
     annotations: dict[str, str | type[pdoc.doc_types.empty]]
     """A qualname -> annotation mapping.
-    
+
     Annotations are not evaluated by this module and only returned as strings."""
+    var_source_lines: dict[str, tuple[int, int]]
+    """A qualname -> (start_line, end_line) mapping for variable assignments.
+
+    Line numbers are 1-based and relative to the parsed source."""
 
 
 def walk_tree(obj: types.ModuleType | type) -> AstInfo:
@@ -111,6 +115,7 @@ def _walk_tree(
     var_docstrings = {}
     func_docstrings = {}
     annotations = {}
+    var_source_lines: dict[str, tuple[int, int]] = {}
     for a, b in _pairwise_longest(_nodes(tree)):
         if isinstance(a, ast_TypeAlias):
             name = a.name.id
@@ -139,6 +144,10 @@ def _walk_tree(
             continue
         else:
             continue
+        # Record source line info for variables (skip synthetic nodes from _init_nodes)
+        lineno = getattr(a, "lineno", None)
+        if lineno is not None:
+            var_source_lines[name] = (lineno, getattr(a, "end_lineno", None) or lineno)
         if (
             isinstance(b, ast.Expr)
             and isinstance(b.value, ast.Constant)
@@ -149,6 +158,7 @@ def _walk_tree(
         var_docstrings,
         func_docstrings,
         annotations,
+        var_source_lines,
     )
 
 

--- a/test/testdata/collections_abc.html
+++ b/test/testdata/collections_abc.html
@@ -131,14 +131,19 @@ Mostly because it's easier, but it also makes a bit more sense here.</p>
 
                 </section>
                 <section id="var">
-                    <div class="attr variable">
+                            <input id="var-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">var</span><span class="annotation">: Container[str]</span>        =
 <span class="default_value">&#39;baz&#39;</span>
 
-        
+                <label class="view-source-button" for="var-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#var"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="var-21"><a href="#var-21"><span class="linenos">21</span></a><span class="n">var</span><span class="p">:</span> <span class="n">Container</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="s2">&quot;baz&quot;</span>
+</span></pre></div>
+
+
     
 
                 </section>

--- a/test/testdata/demo.html
+++ b/test/testdata/demo.html
@@ -141,26 +141,36 @@ demo    </h1>
 
                             </div>
                             <div id="Dog.name" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Dog.name-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">name</span><span class="annotation">: str</span>
 
-        
+                <label class="view-source-button" for="Dog.name-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Dog.name"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.name-8"><a href="#Dog.name-8"><span class="linenos">8</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>The name of our dog.</p>
 </div>
 
 
                             </div>
                             <div id="Dog.friends" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Dog.friends-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">friends</span><span class="annotation">: list[<a href="#Dog">Dog</a>]</span>
 
-        
+                <label class="view-source-button" for="Dog.friends-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Dog.friends"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.friends-10"><a href="#Dog.friends-10"><span class="linenos">10</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>The friends of our dog.</p>
 </div>
 

--- a/test/testdata/demo_long.html
+++ b/test/testdata/demo_long.html
@@ -522,14 +522,19 @@ which will also show up in the navigation.</p>
 
             </section>
                 <section id="FOO_CONSTANT">
-                    <div class="attr variable">
+                            <input id="FOO_CONSTANT-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">FOO_CONSTANT</span><span class="annotation">: int</span>        =
 <span class="default_value">42</span>
 
-        
+                <label class="view-source-button" for="FOO_CONSTANT-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#FOO_CONSTANT"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="FOO_CONSTANT-37"><a href="#FOO_CONSTANT-37"><span class="linenos">37</span></a><span class="n">FOO_CONSTANT</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">42</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A happy constant. ✨
 pdoc documents constants with their type annotation and default value.</p>
 </div>
@@ -537,13 +542,18 @@ pdoc documents constants with their type annotation and default value.</p>
 
                 </section>
                 <section id="FOO_SINGLETON">
-                    <div class="attr variable">
+                            <input id="FOO_SINGLETON-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">FOO_SINGLETON</span><span class="annotation">: <a href="#Foo">Foo</a></span>
 
-        
+                <label class="view-source-button" for="FOO_SINGLETON-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#FOO_SINGLETON"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="FOO_SINGLETON-43"><a href="#FOO_SINGLETON-43"><span class="linenos">43</span></a><span class="n">FOO_SINGLETON</span><span class="p">:</span> <span class="s2">&quot;Foo&quot;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>This variable is annotated with a type only, but not assigned to a value.
 We also haven't defined the associated type (<code><a href="#Foo">Foo</a></code>) yet,
 so the type annotation in the code in the source code is actually a string literal:</p>
@@ -561,13 +571,18 @@ automatically.</p>
 
                 </section>
                 <section id="NO_DOCSTRING">
-                    <div class="attr variable">
+                            <input id="NO_DOCSTRING-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">NO_DOCSTRING</span><span class="annotation">: int</span>
 
-        
+                <label class="view-source-button" for="NO_DOCSTRING-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#NO_DOCSTRING"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="NO_DOCSTRING-58"><a href="#NO_DOCSTRING-58"><span class="linenos">58</span></a><span class="n">NO_DOCSTRING</span><span class="p">:</span> <span class="nb">int</span>
+</span></pre></div>
+
+
     
 
                 </section>
@@ -739,27 +754,37 @@ as well as a keyword-only arguments (*).</p>
 
                             </div>
                             <div id="Foo.an_attribute" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Foo.an_attribute-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">an_attribute</span><span class="annotation">: str | list[int]</span>
 
-        
+                <label class="view-source-button" for="Foo.an_attribute-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Foo.an_attribute"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.an_attribute-98"><a href="#Foo.an_attribute-98"><span class="linenos">98</span></a>    <span class="n">an_attribute</span><span class="p">:</span> <span class="nb">str</span> <span class="o">|</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;int&quot;</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A regular attribute with type annotations</p>
 </div>
 
 
                             </div>
                             <div id="Foo.a_class_attribute" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Foo.a_class_attribute-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">a_class_attribute</span><span class="annotation">: ClassVar[str]</span>        =
 <span class="default_value">&#39;lots of foo!&#39;</span>
 
-        
+                <label class="view-source-button" for="Foo.a_class_attribute-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Foo.a_class_attribute"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.a_class_attribute-101"><a href="#Foo.a_class_attribute-101"><span class="linenos">101</span></a>    <span class="n">a_class_attribute</span><span class="p">:</span> <span class="n">ClassVar</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="s2">&quot;lots of foo!&quot;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>An attribute with a ClassVar annotation.</p>
 </div>
 
@@ -990,13 +1015,18 @@ as well as a keyword-only arguments (*).</p>
 
 
                             <div id="Bar.bar" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Bar.bar-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">bar</span><span class="annotation">: str</span>
 
-        
+                <label class="view-source-button" for="Bar.bar-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Bar.bar"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Bar.bar-150"><a href="#Bar.bar-150"><span class="linenos">150</span></a>    <span class="n">bar</span><span class="p">:</span> <span class="nb">str</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A new attribute defined on this subclass.</p>
 </div>
 
@@ -1223,28 +1253,38 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
                             </div>
                 </section>
                 <section id="CONST_B">
-                    <div class="attr variable">
+                            <input id="CONST_B-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">CONST_B</span>        =
 <span class="default_value">&#39;yes&#39;</span>
 
-        
+                <label class="view-source-button" for="CONST_B-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#CONST_B"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="CONST_B-203"><a href="#CONST_B-203"><span class="linenos">203</span></a><span class="n">CONST_B</span> <span class="o">=</span> <span class="s2">&quot;yes&quot;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A constant without type annotation</p>
 </div>
 
 
                 </section>
                 <section id="CONST_NO_DOC">
-                    <div class="attr variable">
+                            <input id="CONST_NO_DOC-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">CONST_NO_DOC</span>        =
 <span class="default_value">&#39;SHOULD NOT APPEAR&#39;</span>
 
-        
+                <label class="view-source-button" for="CONST_NO_DOC-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#CONST_NO_DOC"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="CONST_NO_DOC-206"><a href="#CONST_NO_DOC-206"><span class="linenos">206</span></a><span class="n">CONST_NO_DOC</span> <span class="o">=</span> <span class="s2">&quot;SHOULD NOT APPEAR&quot;</span>
+</span></pre></div>
+
+
     
 
                 </section>
@@ -1300,62 +1340,87 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
 
                             </div>
                             <div id="DataDemo.a" class="classattr">
-                                <div class="attr variable">
+                                        <input id="DataDemo.a-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">a</span><span class="annotation">: int</span>
 
-        
+                <label class="view-source-button" for="DataDemo.a-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#DataDemo.a"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="DataDemo.a-218"><a href="#DataDemo.a-218"><span class="linenos">218</span></a>    <span class="n">a</span><span class="p">:</span> <span class="nb">int</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>Again, we can document individual properties with docstrings.</p>
 </div>
 
 
                             </div>
                             <div id="DataDemo.a2" class="classattr">
-                                <div class="attr variable">
+                                        <input id="DataDemo.a2-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">a2</span><span class="annotation">: Sequence[str]</span>
 
-        
+                <label class="view-source-button" for="DataDemo.a2-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#DataDemo.a2"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="DataDemo.a2-220"><a href="#DataDemo.a2-220"><span class="linenos">220</span></a>    <span class="n">a2</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span>
+</span></pre></div>
+
+
     
 
                             </div>
                             <div id="DataDemo.a3" class="classattr">
-                                <div class="attr variable">
+                                        <input id="DataDemo.a3-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">a3</span>        =
 <span class="default_value">&#39;a3&#39;</span>
 
-        
+                <label class="view-source-button" for="DataDemo.a3-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#DataDemo.a3"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="DataDemo.a3-222"><a href="#DataDemo.a3-222"><span class="linenos">222</span></a>    <span class="n">a3</span> <span class="o">=</span> <span class="s2">&quot;a3&quot;</span>
+</span></pre></div>
+
+
     
 
                             </div>
                             <div id="DataDemo.a4" class="classattr">
-                                <div class="attr variable">
+                                        <input id="DataDemo.a4-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">a4</span><span class="annotation">: str</span>        =
 <span class="default_value">&#39;a4&#39;</span>
 
-        
+                <label class="view-source-button" for="DataDemo.a4-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#DataDemo.a4"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="DataDemo.a4-224"><a href="#DataDemo.a4-224"><span class="linenos">224</span></a>    <span class="n">a4</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;a4&quot;</span>
+</span></pre></div>
+
+
     
 
                             </div>
                             <div id="DataDemo.b" class="classattr">
-                                <div class="attr variable">
+                                        <input id="DataDemo.b-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">b</span><span class="annotation">: bool</span>        =
 <span class="default_value">True</span>
 
-        
+                <label class="view-source-button" for="DataDemo.b-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#DataDemo.b"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="DataDemo.b-226"><a href="#DataDemo.b-226"><span class="linenos">226</span></a>    <span class="n">b</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="n">field</span><span class="p">(</span><span class="nb">repr</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>This property is assigned to <code>dataclasses.field()</code>, which works just as well.</p>
 </div>
 
@@ -1396,14 +1461,19 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
 
                             </div>
                             <div id="DataDemoExtended.c" class="classattr">
-                                <div class="attr variable">
+                                        <input id="DataDemoExtended.c-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">c</span><span class="annotation">: str</span>        =
 <span class="default_value">&#39;42&#39;</span>
 
-        
+                <label class="view-source-button" for="DataDemoExtended.c-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#DataDemoExtended.c"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="DataDemoExtended.c-232"><a href="#DataDemoExtended.c-232"><span class="linenos">232</span></a>    <span class="n">c</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;42&quot;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A new attribute.</p>
 </div>
 
@@ -1456,42 +1526,57 @@ but some special cases -- like os.environ -- are overridden to avoid leaking sen
 
 
                             <div id="EnumDemo.RED" class="classattr">
-                                <div class="attr variable">
+                                        <input id="EnumDemo.RED-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">RED</span>        =
 <span class="default_value">&lt;<a href="#EnumDemo.RED">EnumDemo.RED</a>: 1&gt;</span>
 
-        
+                <label class="view-source-button" for="EnumDemo.RED-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumDemo.RED"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumDemo.RED-243"><a href="#EnumDemo.RED-243"><span class="linenos">243</span></a>    <span class="n">RED</span> <span class="o">=</span> <span class="mi">1</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>I am the red.</p>
 </div>
 
 
                             </div>
                             <div id="EnumDemo.GREEN" class="classattr">
-                                <div class="attr variable">
+                                        <input id="EnumDemo.GREEN-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">GREEN</span>        =
 <span class="default_value">&lt;<a href="#EnumDemo.GREEN">EnumDemo.GREEN</a>: 2&gt;</span>
 
-        
+                <label class="view-source-button" for="EnumDemo.GREEN-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumDemo.GREEN"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumDemo.GREEN-245"><a href="#EnumDemo.GREEN-245"><span class="linenos">245</span></a>    <span class="n">GREEN</span> <span class="o">=</span> <span class="mi">2</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>I am green.</p>
 </div>
 
 
                             </div>
                             <div id="EnumDemo.BLUE" class="classattr">
-                                <div class="attr variable">
+                                        <input id="EnumDemo.BLUE-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">BLUE</span>        =
 <span class="default_value">&lt;<a href="#EnumDemo.BLUE">EnumDemo.BLUE</a>: 3&gt;</span>
 
-        
+                <label class="view-source-button" for="EnumDemo.BLUE-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumDemo.BLUE"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumDemo.BLUE-247"><a href="#EnumDemo.BLUE-247"><span class="linenos">247</span></a>    <span class="n">BLUE</span> <span class="o">=</span> <span class="n">enum</span><span class="o">.</span><span class="n">auto</span><span class="p">()</span>
+</span></pre></div>
+
+
     
 
                             </div>

--- a/test/testdata/demopackage.html
+++ b/test/testdata/demopackage.html
@@ -212,13 +212,18 @@ demopackage    </h1>
 
 
                             <div id="B.b_type" class="classattr">
-                                <div class="attr variable">
+                                        <input id="B.b_type-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">b_type</span><span class="annotation">: Type[<a href="#B">B</a>]</span>
 
-        
+                <label class="view-source-button" for="B.b_type-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#B.b_type"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="B.b_type-12"><a href="#B.b_type-12"><span class="linenos">12</span></a>    <span class="n">b_type</span><span class="p">:</span> <span class="n">typing</span><span class="o">.</span><span class="n">Type</span><span class="p">[</span><span class="n">B</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>we have a self-referential attribute here</p>
 </div>
 

--- a/test/testdata/demopackage_dir.html
+++ b/test/testdata/demopackage_dir.html
@@ -344,14 +344,19 @@ demopackage2    </h1>
 
             </section>
                 <section id=&quot;x&quot;>
-                    <div class=&quot;attr variable&quot;>
+                            <input id=&quot;x-view-source&quot; class=&quot;view-source-toggle-state&quot; type=&quot;checkbox&quot; aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;>
+<div class=&quot;attr variable&quot;>
             <span class=&quot;name&quot;>x</span>        =
 <span class=&quot;default_value&quot;>42</span>
 
-        
+                <label class=&quot;view-source-button&quot; for=&quot;x-view-source&quot;><span>View Source</span></label>
+
     </div>
     <a class=&quot;headerlink&quot; href=&quot;#x&quot;></a>
-    
+            <div class=&quot;pdoc-code codehilite&quot;><pre><span></span><span id=&quot;x-3&quot;><a href=&quot;#x-3&quot;><span class=&quot;linenos&quot;>3</span></a><span class=&quot;n&quot;>x</span> <span class=&quot;o&quot;>=</span> <span class=&quot;mi&quot;>42</span>
+</span></pre></div>
+
+
     
 
                 </section>
@@ -765,13 +770,18 @@ demopackage    </h1>
 
 
                             <div id=&quot;B.b_type&quot; class=&quot;classattr&quot;>
-                                <div class=&quot;attr variable&quot;>
+                                        <input id=&quot;B.b_type-view-source&quot; class=&quot;view-source-toggle-state&quot; type=&quot;checkbox&quot; aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;>
+<div class=&quot;attr variable&quot;>
             <span class=&quot;name&quot;>b_type</span><span class=&quot;annotation&quot;>: Type[<a href=&quot;#B&quot;>B</a>]</span>
 
-        
+                <label class=&quot;view-source-button&quot; for=&quot;B.b_type-view-source&quot;><span>View Source</span></label>
+
     </div>
     <a class=&quot;headerlink&quot; href=&quot;#B.b_type&quot;></a>
-    
+            <div class=&quot;pdoc-code codehilite&quot;><pre><span></span><span id=&quot;B.b_type-12&quot;><a href=&quot;#B.b_type-12&quot;><span class=&quot;linenos&quot;>12</span></a>    <span class=&quot;n&quot;>b_type</span><span class=&quot;p&quot;>:</span> <span class=&quot;n&quot;>typing</span><span class=&quot;o&quot;>.</span><span class=&quot;n&quot;>Type</span><span class=&quot;p&quot;>[</span><span class=&quot;n&quot;>B</span><span class=&quot;p&quot;>]</span>
+</span></pre></div>
+
+
             <div class=&quot;docstring&quot;><p>we have a self-referential attribute here</p>
 </div>
 
@@ -1300,13 +1310,18 @@ demopackage    </h1>
 
 
                             <div id=&quot;B.b_type&quot; class=&quot;classattr&quot;>
-                                <div class=&quot;attr variable&quot;>
+                                        <input id=&quot;B.b_type-view-source&quot; class=&quot;view-source-toggle-state&quot; type=&quot;checkbox&quot; aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;>
+<div class=&quot;attr variable&quot;>
             <span class=&quot;name&quot;>b_type</span><span class=&quot;annotation&quot;>: Type[<a href=&quot;#B&quot;>B</a>]</span>
 
-        
+                <label class=&quot;view-source-button&quot; for=&quot;B.b_type-view-source&quot;><span>View Source</span></label>
+
     </div>
     <a class=&quot;headerlink&quot; href=&quot;#B.b_type&quot;></a>
-    
+            <div class=&quot;pdoc-code codehilite&quot;><pre><span></span><span id=&quot;B.b_type-12&quot;><a href=&quot;#B.b_type-12&quot;><span class=&quot;linenos&quot;>12</span></a>    <span class=&quot;n&quot;>b_type</span><span class=&quot;p&quot;>:</span> <span class=&quot;n&quot;>typing</span><span class=&quot;o&quot;>.</span><span class=&quot;n&quot;>Type</span><span class=&quot;p&quot;>[</span><span class=&quot;n&quot;>B</span><span class=&quot;p&quot;>]</span>
+</span></pre></div>
+
+
             <div class=&quot;docstring&quot;><p>we have a self-referential attribute here</p>
 </div>
 
@@ -2362,13 +2377,18 @@ demopackage    </h1>
 
 
                             <div id=&quot;B.b_type&quot; class=&quot;classattr&quot;>
-                                <div class=&quot;attr variable&quot;>
+                                        <input id=&quot;B.b_type-view-source&quot; class=&quot;view-source-toggle-state&quot; type=&quot;checkbox&quot; aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;>
+<div class=&quot;attr variable&quot;>
             <span class=&quot;name&quot;>b_type</span><span class=&quot;annotation&quot;>: Type[<a href=&quot;#B&quot;>B</a>]</span>
 
-        
+                <label class=&quot;view-source-button&quot; for=&quot;B.b_type-view-source&quot;><span>View Source</span></label>
+
     </div>
     <a class=&quot;headerlink&quot; href=&quot;#B.b_type&quot;></a>
-    
+            <div class=&quot;pdoc-code codehilite&quot;><pre><span></span><span id=&quot;B.b_type-12&quot;><a href=&quot;#B.b_type-12&quot;><span class=&quot;linenos&quot;>12</span></a>    <span class=&quot;n&quot;>b_type</span><span class=&quot;p&quot;>:</span> <span class=&quot;n&quot;>typing</span><span class=&quot;o&quot;>.</span><span class=&quot;n&quot;>Type</span><span class=&quot;p&quot;>[</span><span class=&quot;n&quot;>B</span><span class=&quot;p&quot;>]</span>
+</span></pre></div>
+
+
             <div class=&quot;docstring&quot;><p>we have a self-referential attribute here</p>
 </div>
 

--- a/test/testdata/enums.html
+++ b/test/testdata/enums.html
@@ -169,42 +169,57 @@ enums    </h1>
 
 
                             <div id="EnumDemo.RED" class="classattr">
-                                <div class="attr variable">
+                                        <input id="EnumDemo.RED-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">RED</span>        =
 <span class="default_value">&lt;<a href="#EnumDemo.RED">EnumDemo.RED</a>: 1&gt;</span>
 
-        
+                <label class="view-source-button" for="EnumDemo.RED-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumDemo.RED"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumDemo.RED-12"><a href="#EnumDemo.RED-12"><span class="linenos">12</span></a>    <span class="n">RED</span> <span class="o">=</span> <span class="mi">1</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>I am the red.</p>
 </div>
 
 
                             </div>
                             <div id="EnumDemo.GREEN" class="classattr">
-                                <div class="attr variable">
+                                        <input id="EnumDemo.GREEN-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">GREEN</span>        =
 <span class="default_value">&lt;<a href="#EnumDemo.GREEN">EnumDemo.GREEN</a>: 2&gt;</span>
 
-        
+                <label class="view-source-button" for="EnumDemo.GREEN-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumDemo.GREEN"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumDemo.GREEN-14"><a href="#EnumDemo.GREEN-14"><span class="linenos">14</span></a>    <span class="n">GREEN</span> <span class="o">=</span> <span class="mi">2</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>I am green.</p>
 </div>
 
 
                             </div>
                             <div id="EnumDemo.BLUE" class="classattr">
-                                <div class="attr variable">
+                                        <input id="EnumDemo.BLUE-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">BLUE</span>        =
 <span class="default_value">&lt;<a href="#EnumDemo.BLUE">EnumDemo.BLUE</a>: 3&gt;</span>
 
-        
+                <label class="view-source-button" for="EnumDemo.BLUE-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumDemo.BLUE"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumDemo.BLUE-16"><a href="#EnumDemo.BLUE-16"><span class="linenos">16</span></a>    <span class="n">BLUE</span> <span class="o">=</span> <span class="n">enum</span><span class="o">.</span><span class="n">auto</span><span class="p">()</span>
+</span></pre></div>
+
+
     
 
                             </div>
@@ -229,26 +244,36 @@ enums    </h1>
     
 
                             <div id="EnumWithoutDocstrings.FOO" class="classattr">
-                                <div class="attr variable">
+                                        <input id="EnumWithoutDocstrings.FOO-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">FOO</span>        =
 <span class="default_value">&lt;<a href="#EnumWithoutDocstrings.FOO">EnumWithoutDocstrings.FOO</a>: 1&gt;</span>
 
-        
+                <label class="view-source-button" for="EnumWithoutDocstrings.FOO-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumWithoutDocstrings.FOO"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumWithoutDocstrings.FOO-20"><a href="#EnumWithoutDocstrings.FOO-20"><span class="linenos">20</span></a>    <span class="n">FOO</span> <span class="o">=</span> <span class="n">enum</span><span class="o">.</span><span class="n">auto</span><span class="p">()</span>
+</span></pre></div>
+
+
     
 
                             </div>
                             <div id="EnumWithoutDocstrings.BAR" class="classattr">
-                                <div class="attr variable">
+                                        <input id="EnumWithoutDocstrings.BAR-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">BAR</span>        =
 <span class="default_value">&lt;<a href="#EnumWithoutDocstrings.BAR">EnumWithoutDocstrings.BAR</a>: 2&gt;</span>
 
-        
+                <label class="view-source-button" for="EnumWithoutDocstrings.BAR-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#EnumWithoutDocstrings.BAR"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="EnumWithoutDocstrings.BAR-21"><a href="#EnumWithoutDocstrings.BAR-21"><span class="linenos">21</span></a>    <span class="n">BAR</span> <span class="o">=</span> <span class="n">enum</span><span class="o">.</span><span class="n">auto</span><span class="p">()</span>
+</span></pre></div>
+
+
     
 
                             </div>
@@ -273,26 +298,36 @@ enums    </h1>
     
 
                             <div id="IntEnum.FOO" class="classattr">
-                                <div class="attr variable">
+                                        <input id="IntEnum.FOO-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">FOO</span>        =
 <span class="default_value">&lt;<a href="#IntEnum.FOO">IntEnum.FOO</a>: 1&gt;</span>
 
-        
+                <label class="view-source-button" for="IntEnum.FOO-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#IntEnum.FOO"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="IntEnum.FOO-25"><a href="#IntEnum.FOO-25"><span class="linenos">25</span></a>    <span class="n">FOO</span> <span class="o">=</span> <span class="n">enum</span><span class="o">.</span><span class="n">auto</span><span class="p">()</span>
+</span></pre></div>
+
+
     
 
                             </div>
                             <div id="IntEnum.BAR" class="classattr">
-                                <div class="attr variable">
+                                        <input id="IntEnum.BAR-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">BAR</span>        =
 <span class="default_value">&lt;<a href="#IntEnum.BAR">IntEnum.BAR</a>: 2&gt;</span>
 
-        
+                <label class="view-source-button" for="IntEnum.BAR-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#IntEnum.BAR"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="IntEnum.BAR-26"><a href="#IntEnum.BAR-26"><span class="linenos">26</span></a>    <span class="n">BAR</span> <span class="o">=</span> <span class="n">enum</span><span class="o">.</span><span class="n">auto</span><span class="p">()</span>
+</span></pre></div>
+
+
     
 
                             </div>
@@ -321,26 +356,36 @@ enums    </h1>
     
 
                             <div id="StrEnum.FOO" class="classattr">
-                                <div class="attr variable">
+                                        <input id="StrEnum.FOO-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">FOO</span>        =
 <span class="default_value">&lt;<a href="#StrEnum.FOO">StrEnum.FOO</a>: &#39;foo&#39;&gt;</span>
 
-        
+                <label class="view-source-button" for="StrEnum.FOO-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#StrEnum.FOO"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="StrEnum.FOO-30"><a href="#StrEnum.FOO-30"><span class="linenos">30</span></a>    <span class="n">FOO</span> <span class="o">=</span> <span class="n">enum</span><span class="o">.</span><span class="n">auto</span><span class="p">()</span>
+</span></pre></div>
+
+
     
 
                             </div>
                             <div id="StrEnum.BAR" class="classattr">
-                                <div class="attr variable">
+                                        <input id="StrEnum.BAR-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">BAR</span>        =
 <span class="default_value">&lt;<a href="#StrEnum.BAR">StrEnum.BAR</a>: &#39;bar&#39;&gt;</span>
 
-        
+                <label class="view-source-button" for="StrEnum.BAR-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#StrEnum.BAR"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="StrEnum.BAR-31"><a href="#StrEnum.BAR-31"><span class="linenos">31</span></a>    <span class="n">BAR</span> <span class="o">=</span> <span class="n">enum</span><span class="o">.</span><span class="n">auto</span><span class="p">()</span>
+</span></pre></div>
+
+
     
 
                             </div>

--- a/test/testdata/example_customtemplate.html
+++ b/test/testdata/example_customtemplate.html
@@ -143,26 +143,36 @@ demo    </h1>
 
                             </div>
                             <div id="Dog.name" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Dog.name-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">name</span><span class="annotation">: str</span>
 
-        
+                <label class="view-source-button" for="Dog.name-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Dog.name"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.name-8"><a href="#Dog.name-8"><span class="linenos">8</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>The name of our dog.</p>
 </div>
 
 
                             </div>
                             <div id="Dog.friends" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Dog.friends-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">friends</span><span class="annotation">: list[<a href="#Dog">Dog</a>]</span>
 
-        
+                <label class="view-source-button" for="Dog.friends-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Dog.friends"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.friends-10"><a href="#Dog.friends-10"><span class="linenos">10</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>The friends of our dog.</p>
 </div>
 

--- a/test/testdata/example_darkmode.html
+++ b/test/testdata/example_darkmode.html
@@ -141,26 +141,36 @@ demo    </h1>
 
                             </div>
                             <div id="Dog.name" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Dog.name-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">name</span><span class="annotation">: str</span>
 
-        
+                <label class="view-source-button" for="Dog.name-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Dog.name"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.name-8"><a href="#Dog.name-8"><span class="linenos">8</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>The name of our dog.</p>
 </div>
 
 
                             </div>
                             <div id="Dog.friends" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Dog.friends-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">friends</span><span class="annotation">: list[<a href="#Dog">Dog</a>]</span>
 
-        
+                <label class="view-source-button" for="Dog.friends-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Dog.friends"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.friends-10"><a href="#Dog.friends-10"><span class="linenos">10</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>The friends of our dog.</p>
 </div>
 

--- a/test/testdata/example_mkdocs.html
+++ b/test/testdata/example_mkdocs.html
@@ -92,26 +92,36 @@ demo    </h1>
 
                             </div>
                             <div id="Dog.name" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Dog.name-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">name</span><span class="annotation">: str</span>
 
-        
+                <label class="view-source-button" for="Dog.name-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Dog.name"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.name-8"><a href="#Dog.name-8"><span class="linenos">8</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>The name of our dog.</p>
 </div>
 
 
                             </div>
                             <div id="Dog.friends" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Dog.friends-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">friends</span><span class="annotation">: list[<a href="#Dog">Dog</a>]</span>
 
-        
+                <label class="view-source-button" for="Dog.friends-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Dog.friends"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Dog.friends-10"><a href="#Dog.friends-10"><span class="linenos">10</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Dog&quot;</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>The friends of our dog.</p>
 </div>
 

--- a/test/testdata/flavors_google.html
+++ b/test/testdata/flavors_google.html
@@ -668,26 +668,36 @@ with it.</p></li>
 
             </section>
                 <section id="module_level_variable1">
-                    <div class="attr variable">
+                            <input id="module_level_variable1-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">module_level_variable1</span>        =
 <span class="default_value">12345</span>
 
-        
+                <label class="view-source-button" for="module_level_variable1-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#module_level_variable1"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="module_level_variable1-48"><a href="#module_level_variable1-48"><span class="linenos">48</span></a><span class="n">module_level_variable1</span> <span class="o">=</span> <span class="mi">12345</span>
+</span></pre></div>
+
+
     
 
                 </section>
                 <section id="module_level_variable2">
-                    <div class="attr variable">
+                            <input id="module_level_variable2-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">module_level_variable2</span>        =
 <span class="default_value">98765</span>
 
-        
+                <label class="view-source-button" for="module_level_variable2-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#module_level_variable2"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="module_level_variable2-50"><a href="#module_level_variable2-50"><span class="linenos">50</span></a><span class="n">module_level_variable2</span> <span class="o">=</span> <span class="mi">98765</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>int: Module level variable documented inline.</p>
 
 <p>The docstring may span multiple lines. The type may optionally be specified

--- a/test/testdata/flavors_numpy.html
+++ b/test/testdata/flavors_numpy.html
@@ -668,26 +668,36 @@ with it.</p></li>
 
             </section>
                 <section id="module_level_variable1">
-                    <div class="attr variable">
+                            <input id="module_level_variable1-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">module_level_variable1</span>        =
 <span class="default_value">12345</span>
 
-        
+                <label class="view-source-button" for="module_level_variable1-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#module_level_variable1"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="module_level_variable1-56"><a href="#module_level_variable1-56"><span class="linenos">56</span></a><span class="n">module_level_variable1</span> <span class="o">=</span> <span class="mi">12345</span>
+</span></pre></div>
+
+
     
 
                 </section>
                 <section id="module_level_variable2">
-                    <div class="attr variable">
+                            <input id="module_level_variable2-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">module_level_variable2</span>        =
 <span class="default_value">98765</span>
 
-        
+                <label class="view-source-button" for="module_level_variable2-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#module_level_variable2"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="module_level_variable2-58"><a href="#module_level_variable2-58"><span class="linenos">58</span></a><span class="n">module_level_variable2</span> <span class="o">=</span> <span class="mi">98765</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>int: Module level variable documented inline.</p>
 
 <p>The docstring may span multiple lines. The type may optionally be specified

--- a/test/testdata/mermaid_demo.html
+++ b/test/testdata/mermaid_demo.html
@@ -186,26 +186,36 @@ mermaid_demo    </h1>
 
                             </div>
                             <div id="Pet.name" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Pet.name-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">name</span><span class="annotation">: str</span>
 
-        
+                <label class="view-source-button" for="Pet.name-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Pet.name"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Pet.name-21"><a href="#Pet.name-21"><span class="linenos">21</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>The name of our pet.</p>
 </div>
 
 
                             </div>
                             <div id="Pet.friends" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Pet.friends-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">friends</span><span class="annotation">: list[<a href="#Pet">Pet</a>]</span>
 
-        
+                <label class="view-source-button" for="Pet.friends-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Pet.friends"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Pet.friends-23"><a href="#Pet.friends-23"><span class="linenos">23</span></a>    <span class="n">friends</span><span class="p">:</span> <span class="nb">list</span><span class="p">[</span><span class="s2">&quot;Pet&quot;</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>The friends of our pet.</p>
 </div>
 

--- a/test/testdata/misc.html
+++ b/test/testdata/misc.html
@@ -908,14 +908,19 @@ misc    </h1>
                             </div>
                 </section>
                 <section id="var_with_default_obj">
-                    <div class="attr variable">
+                            <input id="var_with_default_obj-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">var_with_default_obj</span>        =
 <span class="default_value">&lt;object object&gt;</span>
 
-        
+                <label class="view-source-button" for="var_with_default_obj-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#var_with_default_obj"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="var_with_default_obj-40"><a href="#var_with_default_obj-40"><span class="linenos">40</span></a><span class="n">var_with_default_obj</span> <span class="o">=</span> <span class="n">default_obj</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>this shouldn't render the object address</p>
 </div>
 
@@ -1248,14 +1253,19 @@ misc    </h1>
 
                             </div>
                             <div id="Child.quuux" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Child.quuux-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">quuux</span><span class="annotation">: int</span>        =
 <span class="default_value">42</span>
 
-        
+                <label class="view-source-button" for="Child.quuux-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Child.quuux"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Child.quuux-146"><a href="#Child.quuux-146"><span class="linenos">146</span></a>    <span class="n">quuux</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">42</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>quuux</p>
 </div>
 
@@ -1263,13 +1273,18 @@ misc    </h1>
                             </div>
                 </section>
                 <section id="only_annotated">
-                    <div class="attr variable">
+                            <input id="only_annotated-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">only_annotated</span><span class="annotation">: int</span>
 
-        
+                <label class="view-source-button" for="only_annotated-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#only_annotated"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="only_annotated-150"><a href="#only_annotated-150"><span class="linenos">150</span></a><span class="n">only_annotated</span><span class="p">:</span> <span class="nb">int</span>
+</span></pre></div>
+
+
     
 
                 </section>
@@ -2250,28 +2265,38 @@ indents</p>
     
 
                             <div id="ClassAsAttribute.static_attr_to_class" class="classattr">
-                                <div class="attr variable">
+                                        <input id="ClassAsAttribute.static_attr_to_class-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">static_attr_to_class</span>        =
 <span class="default_value">&lt;class &#39;<a href="#ClassDecorator">ClassDecorator</a>&#39;&gt;</span>
 
-        
+                <label class="view-source-button" for="ClassAsAttribute.static_attr_to_class-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#ClassAsAttribute.static_attr_to_class"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="ClassAsAttribute.static_attr_to_class-392"><a href="#ClassAsAttribute.static_attr_to_class-392"><span class="linenos">392</span></a>    <span class="n">static_attr_to_class</span> <span class="o">=</span> <span class="n">ClassDecorator</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>this is a static attribute that point to a Class (not an instance)</p>
 </div>
 
 
                             </div>
                             <div id="ClassAsAttribute.static_attr_to_instance" class="classattr">
-                                <div class="attr variable">
+                                        <input id="ClassAsAttribute.static_attr_to_instance-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">static_attr_to_instance</span>        =
 <span class="default_value">&lt;<a href="#ClassDecorator">ClassDecorator</a> object&gt;</span>
 
-        
+                <label class="view-source-button" for="ClassAsAttribute.static_attr_to_instance-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#ClassAsAttribute.static_attr_to_instance"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="ClassAsAttribute.static_attr_to_instance-395"><a href="#ClassAsAttribute.static_attr_to_instance-395"><span class="linenos">395</span></a>    <span class="n">static_attr_to_instance</span> <span class="o">=</span> <span class="n">ClassDecorator</span><span class="p">(</span><span class="kc">None</span><span class="p">)</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>this is a static attribute that point to an instance</p>
 </div>
 

--- a/test/testdata/misc_py310.html
+++ b/test/testdata/misc_py310.html
@@ -120,28 +120,38 @@ misc_py310    </h1>
 
                 </section>
                 <section id="NewStyleDict">
-                    <div class="attr variable">
+                            <input id="NewStyleDict-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">NewStyleDict</span>        =
 <span class="default_value">dict[str, str]</span>
 
-        
+                <label class="view-source-button" for="NewStyleDict-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#NewStyleDict"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="NewStyleDict-12"><a href="#NewStyleDict-12"><span class="linenos">12</span></a><span class="n">NewStyleDict</span> <span class="o">=</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>New-style dict.</p>
 </div>
 
 
                 </section>
                 <section id="OldStyleDict">
-                    <div class="attr variable">
+                            <input id="OldStyleDict-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">OldStyleDict</span>        =
 <span class="default_value">typing.Dict[str, str]</span>
 
-        
+                <label class="view-source-button" for="OldStyleDict-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#OldStyleDict"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="OldStyleDict-15"><a href="#OldStyleDict-15"><span class="linenos">15</span></a><span class="n">OldStyleDict</span> <span class="o">=</span> <span class="n">Dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">str</span><span class="p">]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>Old-style dict.</p>
 </div>
 

--- a/test/testdata/misc_py312.html
+++ b/test/testdata/misc_py312.html
@@ -115,53 +115,73 @@ misc_py312    </h1>
 
             </section>
                 <section id="MyType">
-                    <div class="attr variable">
+                            <input id="MyType-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="def">type</span> <span class="name">MyType</span>        =
 <span class="default_value">int</span>
 
-        
+                <label class="view-source-button" for="MyType-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#MyType"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="MyType-13"><a href="#MyType-13"><span class="linenos">13</span></a><span class="nb">type</span> <span class="n">MyType</span> <span class="o">=</span> <span class="nb">int</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A custom Python 3.12 type.</p>
 </div>
 
 
                 </section>
                 <section id="foo">
-                    <div class="attr variable">
+                            <input id="foo-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">foo</span><span class="annotation">: <a href="#MyType">MyType</a></span>
 
-        
+                <label class="view-source-button" for="foo-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#foo"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="foo-16"><a href="#foo-16"><span class="linenos">16</span></a><span class="n">foo</span><span class="p">:</span> <span class="n">MyType</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A custom type instance.</p>
 </div>
 
 
                 </section>
                 <section id="MyTypeWithoutDocstring">
-                    <div class="attr variable">
+                            <input id="MyTypeWithoutDocstring-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="def">type</span> <span class="name">MyTypeWithoutDocstring</span>        =
 <span class="default_value">int</span>
 
-        
+                <label class="view-source-button" for="MyTypeWithoutDocstring-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#MyTypeWithoutDocstring"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="MyTypeWithoutDocstring-20"><a href="#MyTypeWithoutDocstring-20"><span class="linenos">20</span></a><span class="nb">type</span> <span class="n">MyTypeWithoutDocstring</span> <span class="o">=</span> <span class="nb">int</span>
+</span></pre></div>
+
+
     
 
                 </section>
                 <section id="MyTypeClassic">
-                    <div class="attr variable">
+                            <input id="MyTypeClassic-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">MyTypeClassic</span><span class="annotation">: TypeAlias</span>        =
 <span class="default_value">int</span>
 
-        
+                <label class="view-source-button" for="MyTypeClassic-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#MyTypeClassic"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="MyTypeClassic-22"><a href="#MyTypeClassic-22"><span class="linenos">22</span></a><span class="n">MyTypeClassic</span><span class="p">:</span> <span class="n">typing</span><span class="o">.</span><span class="n">TypeAlias</span> <span class="o">=</span> <span class="nb">int</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A "classic" typing.TypeAlias.</p>
 </div>
 
@@ -208,26 +228,36 @@ misc_py312    </h1>
 
                             </div>
                             <div id="NamedTupleExample.name" class="classattr">
-                                <div class="attr variable">
+                                        <input id="NamedTupleExample.name-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">name</span><span class="annotation">: str</span>
 
-        
+                <label class="view-source-button" for="NamedTupleExample.name-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#NamedTupleExample.name"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="NamedTupleExample.name-36"><a href="#NamedTupleExample.name-36"><span class="linenos">36</span></a>    <span class="n">name</span><span class="p">:</span> <span class="nb">str</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>Name of our example tuple.</p>
 </div>
 
 
                             </div>
                             <div id="NamedTupleExample.id" class="classattr">
-                                <div class="attr variable">
+                                        <input id="NamedTupleExample.id-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">id</span><span class="annotation">: int</span>
 
-        
+                <label class="view-source-button" for="NamedTupleExample.id-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#NamedTupleExample.id"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="NamedTupleExample.id-38"><a href="#NamedTupleExample.id-38"><span class="linenos">38</span></a>    <span class="nb">id</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">3</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>Alias for field number 1</p>
 </div>
 

--- a/test/testdata/type_checking_imports.html
+++ b/test/testdata/type_checking_imports.html
@@ -122,28 +122,38 @@ type_checking_imports<wbr>.main    </h1>
 
                 </section>
                 <section id="var">
-                    <div class="attr variable">
+                            <input id="var-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">var</span><span class="annotation">: Sequence[int]</span>        =
 <span class="default_value">(1, 2, 3)</span>
 
-        
+                <label class="view-source-button" for="var-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#var"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="var-24"><a href="#var-24"><span class="linenos">24</span></a><span class="n">var</span><span class="p">:</span> <span class="n">Sequence</span><span class="p">[</span><span class="nb">int</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">3</span><span class="p">)</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A variable with TYPE_CHECKING type annotations.</p>
 </div>
 
 
                 </section>
                 <section id="imported_from_cached_module">
-                    <div class="attr variable">
+                            <input id="imported_from_cached_module-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">imported_from_cached_module</span><span class="annotation">: str | int</span>        =
 <span class="default_value">42</span>
 
-        
+                <label class="view-source-button" for="imported_from_cached_module-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#imported_from_cached_module"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="imported_from_cached_module-28"><a href="#imported_from_cached_module-28"><span class="linenos">28</span></a><span class="n">imported_from_cached_module</span><span class="p">:</span> <span class="n">StrOrInt</span> <span class="o">=</span> <span class="mi">42</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A variable with a type annotation that's imported from another file's TYPE_CHECKING block.</p>
 
 <p><a href="https://github.com/mitmproxy/pdoc/issues/648">https://github.com/mitmproxy/pdoc/issues/648</a></p>
@@ -152,14 +162,19 @@ type_checking_imports<wbr>.main    </h1>
 
                 </section>
                 <section id="imported_from_uncached_module">
-                    <div class="attr variable">
+                            <input id="imported_from_uncached_module-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">imported_from_uncached_module</span><span class="annotation">: str | bool</span>        =
 <span class="default_value">True</span>
 
-        
+                <label class="view-source-button" for="imported_from_uncached_module-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#imported_from_uncached_module"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="imported_from_uncached_module-35"><a href="#imported_from_uncached_module-35"><span class="linenos">35</span></a><span class="n">imported_from_uncached_module</span><span class="p">:</span> <span class="n">StrOrBool</span> <span class="o">=</span> <span class="kc">True</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>A variable with a type annotation that's imported from another file's TYPE_CHECKING block.</p>
 
 <p>In this case, the module is not in sys.modules outside of TYPE_CHECKING.</p>

--- a/test/testdata/type_stubs.html
+++ b/test/testdata/type_stubs.html
@@ -156,14 +156,19 @@ type_stubs    </h1>
 
                 </section>
                 <section id="var">
-                    <div class="attr variable">
+                            <input id="var-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">var</span><span class="annotation">: list[str]</span>        =
 <span class="default_value">[]</span>
 
-        
+                <label class="view-source-button" for="var-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#var"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="var-12"><a href="#var-12"><span class="linenos">12</span></a><span class="n">var</span> <span class="o">=</span> <span class="p">[]</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>Docstring override from the .pyi file.</p>
 </div>
 
@@ -205,14 +210,19 @@ type_stubs    </h1>
     
 
                             <div id="Class.attr" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Class.attr-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">attr</span><span class="annotation">: int</span>        =
 <span class="default_value">42</span>
 
-        
+                <label class="view-source-button" for="Class.attr-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Class.attr"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Class.attr-18"><a href="#Class.attr-18"><span class="linenos">18</span></a>    <span class="n">attr</span> <span class="o">=</span> <span class="mi">42</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>An attribute</p>
 </div>
 
@@ -305,14 +315,19 @@ type_stubs    </h1>
     
 
                             <div id="Class.Subclass.attr" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Class.Subclass.attr-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">attr</span><span class="annotation">: str</span>        =
 <span class="default_value">&#39;42&#39;</span>
 
-        
+                <label class="view-source-button" for="Class.Subclass.attr-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Class.Subclass.attr"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Class.Subclass.attr-25"><a href="#Class.Subclass.attr-25"><span class="linenos">25</span></a>        <span class="n">attr</span> <span class="o">=</span> <span class="s2">&quot;42&quot;</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>An attribute</p>
 </div>
 

--- a/test/testdata/typed_dict.html
+++ b/test/testdata/typed_dict.html
@@ -120,13 +120,18 @@ typed_dict    </h1>
     
 
                             <div id="Foo.a" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Foo.a-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">a</span><span class="annotation">: int | None</span>
 
-        
+                <label class="view-source-button" for="Foo.a-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Foo.a"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.a-6"><a href="#Foo.a-6"><span class="linenos">6</span></a>    <span class="n">a</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="kc">None</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>First attribute.</p>
 </div>
 
@@ -159,26 +164,36 @@ typed_dict    </h1>
 
 
                             <div id="Bar.b" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Bar.b-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">b</span><span class="annotation">: int</span>
 
-        
+                <label class="view-source-button" for="Bar.b-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Bar.b"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Bar.b-13"><a href="#Bar.b-13"><span class="linenos">13</span></a>    <span class="n">b</span><span class="p">:</span> <span class="nb">int</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>Second attribute.</p>
 </div>
 
 
                             </div>
                             <div id="Bar.c" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Bar.c-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">c</span><span class="annotation">: str</span>
 
-        
+                <label class="view-source-button" for="Bar.c-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Bar.c"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Bar.c-15"><a href="#Bar.c-15"><span class="linenos">15</span></a>    <span class="n">c</span><span class="p">:</span> <span class="nb">str</span>
+</span></pre></div>
+
+
     
 
                             </div>
@@ -216,13 +231,18 @@ typed_dict    </h1>
 
 
                             <div id="Baz.d" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Baz.d-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">d</span><span class="annotation">: bool</span>
 
-        
+                <label class="view-source-button" for="Baz.d-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Baz.d"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Baz.d-22"><a href="#Baz.d-22"><span class="linenos">22</span></a>    <span class="n">d</span><span class="p">:</span> <span class="nb">bool</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>new attribute</p>
 </div>
 

--- a/test/testdata/with_pydantic.html
+++ b/test/testdata/with_pydantic.html
@@ -110,28 +110,38 @@ with_pydantic    </h1>
 
 
                             <div id="Foo.a" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Foo.a-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">a</span><span class="annotation">: int</span>        =
 <span class="default_value">1</span>
 
-        
+                <label class="view-source-button" for="Foo.a-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Foo.a"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.a-16"><a href="#Foo.a-16"><span class="linenos">16</span></a>    <span class="n">a</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="n">pydantic</span><span class="o">.</span><span class="n">Field</span><span class="p">(</span><span class="n">default</span><span class="o">=</span><span class="mi">1</span><span class="p">,</span> <span class="n">description</span><span class="o">=</span><span class="s2">&quot;Docstring for a&quot;</span><span class="p">)</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>Docstring for a</p>
 </div>
 
 
                             </div>
                             <div id="Foo.b" class="classattr">
-                                <div class="attr variable">
+                                        <input id="Foo.b-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr variable">
             <span class="name">b</span><span class="annotation">: int</span>        =
 <span class="default_value">2</span>
 
-        
+                <label class="view-source-button" for="Foo.b-view-source"><span>View Source</span></label>
+
     </div>
     <a class="headerlink" href="#Foo.b"></a>
-    
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Foo.b-18"><a href="#Foo.b-18"><span class="linenos">18</span></a>    <span class="n">b</span><span class="p">:</span> <span class="nb">int</span> <span class="o">=</span> <span class="mi">2</span>
+</span></pre></div>
+
+
             <div class="docstring"><p>Docstring for b.</p>
 </div>
 


### PR DESCRIPTION
Current behaviour only shows the content of the constants, but when they're multiline strings, it's difficult to read because the newlines are displayed as `\n`. I'm not proposing changing that behaviour. However, it's still useful to see how they're defined in the code, so adding a `View Source` button to them seems like a reasonable thing to do.