### PR TITLE
Add max-width to pdoc img to avoid overflow of images in Markdown

### DIFF
--- a/pdoc/templates/content.css
+++ b/pdoc/templates/content.css
@@ -468,3 +468,8 @@ This makes sure that the pdoc styling doesn't leak to the rest of the page when 
     padding: 6px 13px;
     border: 1px solid var(--accent2);
 }
+
+.pdoc img {
+    height: auto;
+    max-width: 100%;
+}


### PR DESCRIPTION
This is a very simple fix. If you include a Markdown file that contains an image that is wider than the container, it will overflow.

For example, if this is `__init__.py`

```python
"""
.. include:: README.md
"""
```

and this is `README.md`

```markdown
This is from my README

A very large image

![Test](https://upload.wikimedia.org/wikipedia/commons/thumb/d/db/Pacific_Ocean_as_viewed_from_GOES-18_on_September_23%2C_2023.jpg/3840px-Pacific_Ocean_as_viewed_from_GOES-18_on_September_23%2C_2023.jpg)
```

This image will just be rendered at its native resolution. I believe it should rather be scaled to the width of the container, so I propose to add `max-width: 100%` to `.pdoc img`.
