### PR TITLE
fix: prevent infinite recursion when evaluating TYPE_CHECKING sections (closes #868)

### DIFF
--- a/pdoc/doc_types.py
+++ b/pdoc/doc_types.py
@@ -115,7 +115,7 @@ def safe_eval_type(
     if module:
         assert module.__dict__ is globalns
         # Guard against re-entering this block for the same module (prevents infinite recursion)
-        if getattr(module, '_pdoc_evaluating_type_checking', False):
+        if getattr(module, "_pdoc_evaluating_type_checking", False):
             warnings.warn(
                 f"Circular dependency detected while resolving type annotation {t} for {fullname} in module {module.__name__}. Returning unevaluated."
             )

--- a/pdoc/doc_types.py
+++ b/pdoc/doc_types.py
@@ -114,12 +114,21 @@ def safe_eval_type(
     # Simple _eval_type has failed. We now execute all TYPE_CHECKING sections in the module and try again.
     if module:
         assert module.__dict__ is globalns
+        # Guard against re-entering this block for the same module (prevents infinite recursion)
+        if getattr(module, '_pdoc_evaluating_type_checking', False):
+            warnings.warn(
+                f"Circular dependency detected while resolving type annotation {t} for {fullname} in module {module.__name__}. Returning unevaluated."
+            )
+            return t
+        module._pdoc_evaluating_type_checking = True
         try:
             _eval_type_checking_sections(module, set())
         except Exception as e:
             warnings.warn(
                 f"Failed to run TYPE_CHECKING code while parsing {t} type annotation for {fullname}: {e}"
             )
+        finally:
+            del module._pdoc_evaluating_type_checking
         try:
             return _eval_type(t, globalns, None)
         except (AttributeError, NameError):


### PR DESCRIPTION
## What
When pdoc documents PyO3 complex enums (v0.28+) that have `.pyi` stub files, infinite recursion occurs. This happens because the type annotation resolution in `safe_eval_type` attempts to run all `TYPE_CHECKING` sections of the module to resolve forward references. PyO3's complex enums create nested class hierarchies that reference themselves, causing these `TYPE_CHECKING` sections to trigger re-evaluation of the same types, leading to infinite recursion.

## Fix
Added a guard flag on the module object (`_pdoc_evaluating_type_checking`) to detect when we are already in the process of evaluating `TYPE_CHECKING` sections for that module. If a recursive call is detected, we issue a warning and return the unevaluated type annotation instead of recursing infinitely. This breaks the cycle while still attempting to resolve annotations normally in the non-recursive case.

Closes #868