### PR TITLE
fix(web): Try xdg-open before hardcoded browsers

### DIFF
--- a/pdoc/web.py
+++ b/pdoc/web.py
@@ -176,6 +176,7 @@ def open_browser(url: str) -> bool:  # pragma: no cover
         "wslview %s",
         "x-www-browser %s",
         "gnome-open %s",
+        "xdg-open",
         "google-chrome",
         "chrome",
         "chromium",


### PR DESCRIPTION
Currently, `web.open_browser()` doesn't always honor the user's browser preference on Linux.  It tries `x-www-browser`, which is Debian (and derivatives)-specific, and it tries `gnome-open`, which was a GNOME 2 mechanism.

This adds `xdg-open` to the list of "browsers", used by `web.open_browser()`, right before it starts trying specific browsers - Chrome, Chromium, Firefox, etc.  Thus, users who are currently using the Debian alternatives system (or GNOME 2 settings) won't be affected by this change.